### PR TITLE
Extra RuboCop rules and organize Gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,8 +3,17 @@ inherit_gem:
 
 AllCops:
   TargetRubyVersion: 2.7
-
-Style/FrozenStringLiteralComment:
-  Enabled: true
   Exclude:
     - test/dummy/db/schema.rb
+
+Bundler/OrderedGems:
+  Enabled: true
+
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+
+Style/SymbolArray:
+  EnforcedStyle: brackets
+
+Style/WordArray:
+  EnforcedStyle: brackets

--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,8 @@
 # frozen_string_literal: true
-source 'https://rubygems.org'
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-# Declare your gem's dependencies in maintenance_tasks.gemspec.
-# Bundler will treat runtime dependencies like base dependencies, and
-# development dependencies will be added by default to the :development group.
+source 'https://rubygems.org'
+
 gemspec
 
-# Declare any dependencies that are still in development here instead of in
-# your gemspec. These might include edge Rails or gems from your path or
-# Git. Remember to move these dependencies to your gemspec before releasing
-# your gem to rubygems.org.
-
-# To use a debugger
-# gem 'byebug', group: [:development, :test]
-
-gem 'rubocop-shopify', require: false
+gem 'rubocop-shopify'
+gem 'sqlite3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     maintenance_tasks (0.1.0)
-      job-iteration
+      job-iteration (~> 1.1.8)
       rails (~> 6.0.3)
 
 GEM

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 
-APP_RAKEFILE = File.expand_path("test/dummy/Rakefile", __dir__)
+APP_RAKEFILE = File.expand_path('test/dummy/Rakefile', __dir__)
 load('rails/tasks/engine.rake')
 
 load('rails/tasks/statistics.rake')

--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_dependency "maintenance_tasks/application_controller"
+require_dependency 'maintenance_tasks/application_controller'
 
 module MaintenanceTasks
   class RunsController < ApplicationController

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require "maintenance_tasks/engine"
+require 'maintenance_tasks/engine'
 
 module MaintenanceTasks
 end

--- a/lib/maintenance_tasks/version.rb
+++ b/lib/maintenance_tasks/version.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-module MaintenanceTasks
-  VERSION = '0.1.0'
-end

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -1,31 +1,21 @@
 # frozen_string_literal: true
-$LOAD_PATH.push(File.expand_path("lib", __dir__))
 
-# Maintain your gem's version:
-require "maintenance_tasks/version"
-
-# Describe your gem and declare its dependencies:
 Gem::Specification.new do |spec|
-  spec.name        = "maintenance_tasks"
-  spec.version     = MaintenanceTasks::VERSION
-  spec.authors     = ["Shopify"]
-  spec.email       = ["gems@shopify.com"]
-  spec.homepage    = "https://github.com/Shopify/maintenance_tasks"
-  spec.summary     = "A Rails engine for queuing and managing maintenance tasks"
+  spec.name = 'maintenance_tasks'
+  spec.version = '0.1.0'
+  spec.author = 'Shopify Engineering'
+  spec.email = 'gems@shopify.com'
+  spec.homepage = 'https://github.com/Shopify/maintenance_tasks'
+  spec.summary = 'A Rails engine for queuing and managing maintenance tasks'
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "https://packages.shopify.io"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
+  spec.metadata = {
+    'source_code_uri' =>
+      "https://github.com/Shopify/maintenance_tasks/tree/v#{spec.version}",
+    'allowed_push_host' => 'https://packages.shopify.io',
+  }
 
-  spec.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  spec.files = Dir['{app,config,db,lib}/**/*', 'Rakefile', 'README.md']
 
-  spec.add_dependency("rails", "~> 6.0.3")
-  spec.add_dependency("job-iteration")
-
-  spec.add_development_dependency("sqlite3")
+  spec.add_dependency('job-iteration', '~> 1.1.8')
+  spec.add_dependency('rails', '~> 6.0.3')
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -4,7 +4,7 @@ require_relative 'boot'
 require 'rails/all'
 
 Bundler.require(*Rails.groups)
-require "maintenance_tasks"
+require 'maintenance_tasks'
 
 module Dummy
   class Application < Rails::Application

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -81,7 +81,7 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)

--- a/test/dummy/config/puma.rb
+++ b/test/dummy/config/puma.rb
@@ -5,20 +5,20 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
+min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
 threads(min_threads_count, max_threads_count)
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port(ENV.fetch("PORT") { 3000 })
+port(ENV.fetch('PORT') { 3000 })
 
 # Specifies the `environment` that Puma will run in.
 #
-environment(ENV.fetch("RAILS_ENV") { "development" })
+environment(ENV.fetch('RAILS_ENV') { 'development' })
 
 # Specifies the `pidfile` that Puma will use.
-pidfile(ENV.fetch("PIDFILE") { "tmp/pids/server.pid" })
+pidfile(ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' })
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 Rails.application.routes.draw do
-  mount MaintenanceTasks::Engine => "/maintenance_tasks"
+  mount MaintenanceTasks::Engine => '/maintenance_tasks'
 end

--- a/test/dummy/config/spring.rb
+++ b/test/dummy/config/spring.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 Spring.watch(
-  ".ruby-version",
-  ".rbenv-vars",
-  "tmp/restart.txt",
-  "tmp/caching-dev.txt"
+  '.ruby-version',
+  '.rbenv-vars',
+  'tmp/restart.txt',
+  'tmp/caching-dev.txt'
 )

--- a/test/maintenance_tasks_test.rb
+++ b/test/maintenance_tasks_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 class MaintenanceTasksTest < ActiveSupport::TestCase
-  test "truth" do
+  test 'truth' do
     assert_kind_of Module, MaintenanceTasks
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 # Configure Rails Environment
-ENV["RAILS_ENV"] = "test"
+ENV['RAILS_ENV'] = 'test'
 
-require_relative "../test/dummy/config/environment"
-ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
+require_relative '../test/dummy/config/environment'
+ActiveRecord::Migrator.migrations_paths = [File.expand_path('../test/dummy/db/migrate', __dir__)]
 ActiveRecord::Migrator.migrations_paths << File.expand_path('../db/migrate', __dir__)
-require "rails/test_help"
+require 'rails/test_help'
 
 # Filter out the backtrace from minitest while preserving the one from other libraries.
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_path=)
-  ActiveSupport::TestCase.fixture_path = File.expand_path("fixtures", __dir__)
+  ActiveSupport::TestCase.fixture_path = File.expand_path('fixtures', __dir__)
   ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
-  ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + "/files"
+  ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + '/files'
   ActiveSupport::TestCase.fixtures(:all)
 end


### PR DESCRIPTION
With this change I'm adding some RuboCop checks to keep the Gemfile ordered, enforce single-quotes for consistency as well as a consistent array syntax.

I also removed the clutter from the Gemfile and the Gemspec.