### PR TITLE
Documentation with Yard

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,15 +9,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.7
+    - name: Set up Ruby
       uses: actions/setup-ruby@v1.1.1
       with:
         ruby-version: 2.7
     - name: Install dependencies
       run: gem install bundler && bundle install --jobs 4 --retry 3
-    - name: Set up db schema
-      run: RAILS_ENV=test bundle exec rake db:create db:schema:load
+    - name: Set up database
+      run: bundle exec rails db:setup
     - name: Ruby Tests
-      run: bundle exec rake test
-    - name: Ruby Lint
+      run: bundle exec rails test
+    - name: RuboCop
       run: bundle exec rubocop

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .bundle/
+.yardoc/
+doc/
 log/*.log
 pkg/
 test/dummy/db/*.sqlite3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,16 @@ Bundler/OrderedGems:
 Layout/LineLength:
   Max: 80
 
+Style/Documentation:
+  Include:
+    - app/**/*.rb
+    - lib/**/*.rb
+
+Style/DocumentationMethod:
+  Include:
+    - app/**/*.rb
+    - lib/**/*.rb
+
 Style/StringLiterals:
   EnforcedStyle: single_quotes
 

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,4 @@
+--no-cache
+--fail-on-warning
+app/**/*.rb
+lib/**/*.rb

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gemspec
 
 gem 'rubocop-shopify'
 gem 'sqlite3'
+gem 'yard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,7 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    yard (0.9.25)
     zeitwerk (2.4.0)
 
 PLATFORMS
@@ -164,6 +165,7 @@ DEPENDENCIES
   maintenance_tasks!
   rubocop-shopify
   sqlite3
+  yard
 
 BUNDLED WITH
    2.1.4

--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
+
 module MaintenanceTasks
+  # Base class for all controllers used by this engine.
   class ApplicationController < ActionController::Base
     protect_from_forgery with: :exception
   end

--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-require_dependency 'maintenance_tasks/application_controller'
-
-module MaintenanceTasks
-  class RunsController < ApplicationController
-  end
-end

--- a/app/helpers/maintenance_tasks/application_helper.rb
+++ b/app/helpers/maintenance_tasks/application_helper.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-module MaintenanceTasks
-  module ApplicationHelper
-  end
-end

--- a/app/helpers/maintenance_tasks/runs_helper.rb
+++ b/app/helpers/maintenance_tasks/runs_helper.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-module MaintenanceTasks
-  module RunsHelper
-  end
-end

--- a/app/jobs/maintenance_tasks/task.rb
+++ b/app/jobs/maintenance_tasks/task.rb
@@ -2,6 +2,7 @@
 require 'job-iteration'
 
 module MaintenanceTasks
+  # Base class that is inherited by the host application's task classes.
   class Task < ActiveJob::Base
     include JobIteration::Iteration
   end

--- a/app/mailers/maintenance_tasks/application_mailer.rb
+++ b/app/mailers/maintenance_tasks/application_mailer.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-module MaintenanceTasks
-  class ApplicationMailer < ActionMailer::Base
-    default from: 'from@example.com'
-    layout 'mailer'
-  end
-end

--- a/app/models/maintenance_tasks/application_record.rb
+++ b/app/models/maintenance_tasks/application_record.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 module MaintenanceTasks
+  # Base class for all records used by this engine.
   class ApplicationRecord < ActiveRecord::Base
     self.abstract_class = true
   end

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 require 'maintenance_tasks/engine'
 
+# The engine's namespace module. It provides isolation between the host
+# application's code and the engine-specific code. Top-level engine constants
+# and variables are defined under this module.
 module MaintenanceTasks
 end

--- a/lib/maintenance_tasks/engine.rb
+++ b/lib/maintenance_tasks/engine.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 module MaintenanceTasks
+  # The engine's main class, which defines its namespace. The engine is mounted
+  # by the host application.
   class Engine < ::Rails::Engine
     isolate_namespace MaintenanceTasks
   end

--- a/test/documentation_test.rb
+++ b/test/documentation_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'yard'
+
+class DocumentationTest < ActiveSupport::TestCase
+  test 'documentation is correctly written' do
+    assert_empty %x(bundle exec yard --no-save --no-output --no-stats)
+  end
+end


### PR DESCRIPTION
Setting up documentation with Yard, which will be enforced for all code under `app` and `lib` via RuboCop. You can generate the docs website using `bundle exec yard`. I'm also adding a test to make sure that Yard is able to generate the docs without warnings all the time.

Fixes #18 