### PR TITLE
Update the maintenance_tasks_runs table with some new columns

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -2,5 +2,23 @@
 module MaintenanceTasks
   # Model that persists information related to a task being run from the UI.
   class Run < ApplicationRecord
+    # Various statuses a run can be in:
+    #
+    # enqueued      The task has been enqueued by the user.
+    # running       The task is being performed by a job worker.
+    # succeeded     The task finished without error.
+    # aborted       The user explicitly halted the task's execution.
+    # interrupted   The task was paused in the middle of the run by the user.
+    # errored       The task code produced an unhandled exception.
+    STATUSES = [
+      :enqueued,
+      :running,
+      :succeeded,
+      :aborted,
+      :interrupted,
+      :errored,
+    ]
+
+    enum status: STATUSES.to_h { |status| [status, status.to_s] }
   end
 end

--- a/db/migrate/20201005191107_update_maintenance_tasks_runs_table.rb
+++ b/db/migrate/20201005191107_update_maintenance_tasks_runs_table.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class UpdateMaintenanceTasksRunsTable < ActiveRecord::Migration[6.0]
+  def change
+    change_table(:maintenance_tasks_runs) do |t|
+      t.remove(:executions)
+
+      t.string(:job_id)
+      t.bigint(:cursor)
+      t.string(:status, default: :enqueued, null: false)
+      t.string(:error_class)
+      t.string(:error_message)
+      t.text(:stack_trace)
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,20 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_23_173403) do
+ActiveRecord::Schema.define(version: 2020_10_05_191107) do
+
   create_table "maintenance_tasks_runs", force: :cascade do |t|
-    t.string("task_name", null: false)
-    t.text("executions")
-    t.integer("tick_count", default: 0, null: false)
-    t.integer("tick_total")
-    t.datetime("created_at", precision: 6, null: false)
-    t.datetime("updated_at", precision: 6, null: false)
+    t.string "task_name", null: false
+    t.integer "tick_count", default: 0, null: false
+    t.integer "tick_total"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "job_id"
+    t.bigint "cursor"
+    t.string "status", default: "enqueued", null: false
+    t.string "error_class"
+    t.string "error_message"
+    t.text "stack_trace"
   end
 
   create_table "posts", force: :cascade do |t|
-    t.string("title")
-    t.string("content")
-    t.datetime("created_at", precision: 6, null: false)
-    t.datetime("updated_at", precision: 6, null: false)
+    t.string "title"
+    t.string "content"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
+
 end

--- a/test/fixtures/maintenance_tasks/runs.yml
+++ b/test/fixtures/maintenance_tasks/runs.yml
@@ -2,12 +2,14 @@
 
 one:
   task_name: MyString
-  executions: MyText
   tick_count: 1
   tick_total: 1
+  job_id: '123abc'
+  status: 'enqueued'
 
 two:
   task_name: MyString
-  executions: MyText
   tick_count: 1
   tick_total: 1
+  job_id: '456xyz'
+  status: 'enqueued'


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/25

Updates our `maintenance_tasks_runs` table to include the columns we described in the latest version of the [technical design document](https://docs.google.com/document/d/1uChhOh6ZUIDoFTkmJwtQUMn74E0EdUaWdzs19IWGsDE/edit?usp=sharing), and added an `enum` to the model with descriptions of the various states a `Run` can occupy.