### PR TITLE
Enqueue task fixes

### DIFF
--- a/app/jobs/maintenance_tasks/task.rb
+++ b/app/jobs/maintenance_tasks/task.rb
@@ -49,11 +49,15 @@ module MaintenanceTasks
 
     before_enqueue :create_run
 
+    def initialize(*arguments, run: nil)
+      @run = run
+      super(*arguments)
+    end
+
     private
 
     def create_run
-      run = arguments.dig(-1, :run)
-      Run.create!(task_name: name) unless run
+      Run.create!(task_name: name) unless @run
     end
   end
 end


### PR DESCRIPTION
Follow-up to #17, makes it actually possible to enqueue and perform a task.

1. ~~The change from button to link caused a GET rather than a POST request. Using a link would require us rails-ujs or some code to handle `a[data-method]`, since we don't want to have coupling to the main app asset pipeline, I think it makes sense to use what the browsers give us that work out of the box.~~
2. Inverting the dependency from the Run to the Task meant passing the Run when enqueuing. I forgot to handle the argument which caused an API change and required the task to define `def build_enumerator(_hash_including_run, cursor:)` (job-iteration doesn't handle keyword arguments, just splats the arguments as an array possibly ending with a hash).

Edit: 1. was fixed in #30, for 2. I took the idea from @adrianna-chang-shopify in #32 to remove the argument in `initialize`.