### PR TITLE
No run argument

### DIFF
--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -15,12 +15,13 @@ module MaintenanceTasks
     #
     # Creates a new Run with the given parameters.
     def create
-      run = Run.new(run_params)
-      if run.save
-        run.task_class.perform_later(run: run)
-        redirect_to(root_path, notice: "Task #{run.task_name} enqueued.")
+      task_name = run_params[:task_name]
+      task = Task.named(task_name)
+      if task
+        task.perform_later
+        redirect_to(root_path, notice: "Task #{task_name} enqueued.")
       else
-        redirect_to(root_path, notice: run.errors.full_messages.join(' '))
+        redirect_to(root_path, notice: "Task #{task_name} does not exist.")
       end
     end
 

--- a/app/jobs/maintenance_tasks/task.rb
+++ b/app/jobs/maintenance_tasks/task.rb
@@ -46,20 +46,13 @@ module MaintenanceTasks
     end
 
     delegate :name, to: :class
-    attr_accessor :run
-    before_enqueue :set_job_id
 
-    def initialize(*arguments, run: nil)
-      super(*arguments)
-
-      @run = run
-    end
+    before_enqueue :create_run
 
     private
 
-    def set_job_id
-      return unless run
-      run.update!(job_id: job_id)
+    def create_run
+      Run.create!(task_name: name, job_id: job_id)
     end
   end
 end

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -23,12 +23,11 @@ module MaintenanceTasks
 
     validate :task_exists?
 
-    # The class of the task for this run.
+    private
+
     def task_class
       Task.named(task_name)
     end
-
-    private
 
     def task_exists?
       unless task_class

--- a/test/jobs/maintenance_tasks/task_test.rb
+++ b/test/jobs/maintenance_tasks/task_test.rb
@@ -23,21 +23,16 @@ module MaintenanceTasks
       end
     end
 
-    test 'can be enqueued with a Run' do
-      run = Run.create(task_name: Maintenance::UpdatePostsTask)
-
-      assert_enqueued_with job: Maintenance::UpdatePostsTask do
-        Maintenance::UpdatePostsTask.perform_later(run: run)
+    test 'creates a Run if it has been enqueued without one' do
+      assert_difference -> { Run.count } do
+        Maintenance::UpdatePostsTask.perform_later
       end
     end
 
-    test 'updates job_id on Run when performed with a run' do
-      run = Run.create(task_name: Maintenance::UpdatePostsTask)
-      job = Maintenance::UpdatePostsTask.perform_later(run: run)
-
-      perform_enqueued_jobs
-
-      assert_equal job.job_id, run.reload.job_id
+    test 'does not re-enqueue itself if it has been enqueued without a Run' do
+      assert_enqueued_jobs 1 do
+        Maintenance::UpdatePostsTask.perform_later
+      end
     end
   end
 end


### PR DESCRIPTION
As mentioned in #29, we need to handle the `run` argument for the job.

1. We can simply enqueue the Task from the controller, and let the job handle persisting the run: 90eb9a6175692edc335caf08661d23555c2cd5f7
  https://github.com/Shopify/maintenance_tasks/blob/90eb9a6175692edc335caf08661d23555c2cd5f7/app/controllers/maintenance_tasks/runs_controller.rb#L17-L21 https://github.com/Shopify/maintenance_tasks/blob/90eb9a6175692edc335caf08661d23555c2cd5f7/app/jobs/maintenance_tasks/task.rb#L50-L56
2. We can tell the run to enqueue itself, but then it turns around and lets the job handle the work: f5cb9cc0da33935a968090afc24677e381e579f1
  https://github.com/Shopify/maintenance_tasks/blob/f5cb9cc0da33935a968090afc24677e381e579f1/app/controllers/maintenance_tasks/runs_controller.rb#L17-L19 https://github.com/Shopify/maintenance_tasks/blob/f5cb9cc0da33935a968090afc24677e381e579f1/app/models/maintenance_tasks/run.rb#L27-L29 https://github.com/Shopify/maintenance_tasks/blob/f5cb9cc0da33935a968090afc24677e381e579f1/app/jobs/maintenance_tasks/task.rb#L13-L18
3. We can tell the run to enqueue itself, and it does most of the work, and enqueues the job: ca4842c33dc9048ca351abd2ee1feed297ee4405 (same code but in the model)
4. We can do everything from the controller: 9fa4e7d5f878f5d4d44cd51cf5c2c4bd77c0ee7f
   * supposedly it helps with single responsibility of the model, but now the controller does too much
5. We can wrap the job iteration API, and we can pass `run` as an argument, just hide it from the API we provide.

We moved away from 1 in because of https://github.com/Shopify/maintenance_tasks/pull/20#pullrequestreview-501402943 in order to have a more direct creation of the Run in `runs#create` even though we found out during pairing https://github.com/Shopify/maintenance_tasks/pull/20#issuecomment-702889591 that it made the code simpler (the task was entirely in charge of the run, no need to also support the controller).