### PR TITLE
Make job_id not nullable

### DIFF
--- a/db/migrate/20201006195701_make_job_id_not_nullable.rb
+++ b/db/migrate/20201006195701_make_job_id_not_nullable.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class MakeJobIdNotNullable < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null(:maintenance_tasks_runs, :job_id, false)
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_05_191107) do
+ActiveRecord::Schema.define(version: 2020_10_06_195701) do
 
   create_table "maintenance_tasks_runs", force: :cascade do |t|
     t.string "task_name", null: false
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2020_10_05_191107) do
     t.integer "tick_total"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "job_id"
+    t.string "job_id", null: false
     t.bigint "cursor"
     t.string "status", default: "enqueued", null: false
     t.string "error_class"


### PR DESCRIPTION
We have the Task instance and its job id when we create the Run, so we can make the `job_id NOT NULL`. 