### PR TITLE
Another potential solution

### DIFF
--- a/app/jobs/maintenance_tasks/task.rb
+++ b/app/jobs/maintenance_tasks/task.rb
@@ -46,14 +46,21 @@ module MaintenanceTasks
     end
 
     delegate :name, to: :class
+    before_enqueue :set_job_id
 
-    before_enqueue :create_run
+    attr_accessor :run
+
+    def initialize(*arguments, run: nil)
+      super(*arguments)
+
+      @run = run
+    end
 
     private
 
-    def create_run
-      run = arguments.dig(-1, :run)
-      Run.create!(task_name: name) unless run
+    def set_job_id
+      return unless run
+      run.update!(job_id: job_id)
     end
   end
 end

--- a/test/jobs/maintenance_tasks/task_test.rb
+++ b/test/jobs/maintenance_tasks/task_test.rb
@@ -23,16 +23,21 @@ module MaintenanceTasks
       end
     end
 
-    test 'creates a Run if it has been enqueued without one' do
-      assert_difference -> { Run.count } do
-        Maintenance::UpdatePostsTask.perform_later
+    test 'can be enqueued with a Run' do
+      run = Run.create(task_name: Maintenance::UpdatePostsTask)
+
+      assert_enqueued_with job: Maintenance::UpdatePostsTask do
+        Maintenance::UpdatePostsTask.perform_later(run: run)
       end
     end
 
-    test 'does not re-enqueue itself if it has been enqueued without a Run' do
-      assert_enqueued_jobs 1 do
-        Maintenance::UpdatePostsTask.perform_later
-      end
+    test 'updates job_id on Run when performed with a run' do
+      run = Run.create(task_name: Maintenance::UpdatePostsTask)
+      job = Maintenance::UpdatePostsTask.perform_later(run: run)
+
+      perform_enqueued_jobs
+
+      assert_equal job.job_id, run.reload.job_id
     end
   end
 end


### PR DESCRIPTION
Model handles saving itself and enqueuing the job, but most logic is delegated to `Task` to happen when job is enqueued / performed

Pretty similar to what we already had, except that we drop the creation of a `Run` from the `Task` class, and rely on `initialize` to set our run argument.