### PR TITLE
Persist Task Exceptions

### DIFF
--- a/app/helpers/maintenance_tasks/task_helper.rb
+++ b/app/helpers/maintenance_tasks/task_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module MaintenanceTasks
+  # Helpers for formatting data in the maintenance_tasks views.
+  module TaskHelper
+    # Formats a run backtrace.
+    #
+    # @param backtrace [Array<String>] the backtrace associated with an
+    #   exception on a Task that ran and raised.
+    # @return [String] the parsed, HTML formatted version of the backtrace.
+    def format_backtrace(backtrace)
+      return unless backtrace.present?
+
+      safe_join(backtrace, tag.br)
+    end
+  end
+end

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -25,6 +25,8 @@ module MaintenanceTasks
 
     validate :task_exists?, :task_non_abstract?
 
+    serialize :backtrace
+
     # Enqueues the job after validating and persisting the run.
     def enqueue
       if save

--- a/app/views/maintenance_tasks/runs/index.html.erb
+++ b/app/views/maintenance_tasks/runs/index.html.erb
@@ -23,7 +23,6 @@
     <% end %>
   </tbody>
 </table>
-
 <table>
   <caption>Maintenance Task Runs</caption>
 
@@ -32,7 +31,9 @@
       <th>Task Name</th>
       <th>Created at</th>
       <th>Status</th>
-      <th></th>
+      <th>Error Class</th>
+      <th>Error Message</th>
+      <th>Backtrace</th>
     </tr>
   </thead>
 
@@ -42,6 +43,9 @@
         <td><%= run.task_name %></td>
         <td><%= l run.created_at %></td>
         <td><%= run.status %></td>
+        <td><%= run.error_class %></td>
+        <td><%= run.error_message %></td>
+        <td><%= format_backtrace(run.backtrace) %></td>
         <td>
           <%= button_to 'Pause', pause_run_path(run), method: :put if run.enqueued? || run.running? %>
         </td>

--- a/db/migrate/20201013130804_rename_stack_trace_to_backtrace.rb
+++ b/db/migrate/20201013130804_rename_stack_trace_to_backtrace.rb
@@ -1,0 +1,7 @@
+
+# frozen_string_literal: true
+class RenameStackTraceToBacktrace < ActiveRecord::Migration[6.0]
+  def change
+    rename_column(:maintenance_tasks_runs, :stack_trace, :backtrace)
+  end
+end

--- a/test/dummy/app/jobs/maintenance/error_task.rb
+++ b/test/dummy/app/jobs/maintenance/error_task.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module Maintenance
+  class ErrorTask < MaintenanceTasks::Task
+    def task_enumerator(*)
+      [1, 2].to_enum
+    end
+
+    def task_iteration(*)
+      raise ArgumentError, 'Something went wrong'
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_05_191107) do
+ActiveRecord::Schema.define(version: 2020_10_13_130804) do
 
   create_table "maintenance_tasks_runs", force: :cascade do |t|
     t.string "task_name", null: false
@@ -19,11 +19,11 @@ ActiveRecord::Schema.define(version: 2020_10_05_191107) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "job_id"
-    t.bigint "cursor"
+    t.integer "cursor"
     t.string "status", default: "enqueued", null: false
     t.string "error_class"
     t.string "error_message"
-    t.text "stack_trace"
+    t.text "backtrace"
   end
 
   create_table "posts", force: :cascade do |t|

--- a/test/helpers/maintenance_tasks/task_helper_test.rb
+++ b/test/helpers/maintenance_tasks/task_helper_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module MaintenanceTasks
+  class TaskHelperTest < ActionView::TestCase
+    test '#format_backtrace converts the backtrace to a formatted string' do
+      backtrace = [
+        "app/jobs/maintenance/error_task.rb:13:in `foo'",
+        "app/jobs/maintenance/error_task.rb:9:in `task_iteration'",
+      ]
+
+      expected_trace = 'app/jobs/maintenance/error_task.rb:13:in `foo&#39;' \
+        '<br>app/jobs/maintenance/error_task.rb:9:in `task_iteration&#39;'
+
+      assert_equal expected_trace, format_backtrace(backtrace)
+    end
+  end
+end

--- a/test/system/tasks_test.rb
+++ b/test/system/tasks_test.rb
@@ -11,7 +11,8 @@ class TasksTest < ApplicationSystemTestCase
     assert_title 'Maintenance Tasks'
 
     assert_table 'Enqueue Task', with_rows: [
-      ['Maintenance::UpdatePostsTask'],
+      ['Maintenance::UpdatePostsTask', ''],
+      ['Maintenance::ErrorTask', ''],
     ]
   end
 
@@ -44,6 +45,32 @@ class TasksTest < ApplicationSystemTestCase
 
     assert_table 'Maintenance Task Runs', with_rows: [
       ['Maintenance::UpdatePostsTask', I18n.l(Time.now.utc), 'paused'],
+    ]
+  end
+
+  test 'run a task that errors' do
+    freeze_time
+
+    visit maintenance_tasks_path
+
+    within 'tr', text: 'Maintenance::ErrorTask' do
+      click_on 'Run'
+    end
+
+    # To remove after rewriting this test properly
+    sleep(1)
+
+    assert_text 'Task Maintenance::ErrorTask enqueued.'
+
+    assert_table 'Maintenance Task Runs', with_rows: [
+      [
+        'Maintenance::ErrorTask',
+        I18n.l(Time.now.utc),
+        'errored',
+        'ArgumentError',
+        'Something went wrong',
+        "app/jobs/maintenance/error_task.rb:9:in `task_iteration'",
+      ],
     ]
   end
 end


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/27

## Context

We want to persist job errors to the associated `Run` in the case where a task raises an exception.
Note that we persist error info even if the job does not enter a status of `errored` and terminate (ie. the situation where the job has a handler set up to catch the error and continue).

## Changes in this PR
- As the job performs, we rescue exceptions, and persist the relevant info to the `Run` object
- We update the `Run` to `errored` if the task does not have graceful exception handling in place for that exception
- Added a dummy task that errors for our system tests / tophatting
- Changed all of the tests in `task_test.rb` to use `Task` language instead of `Job`, since we're trying to move away from the idea of a "job" and I shouldn't have named things that way 😛  Also changed the tests to assert status on the run object when possible, only relying on the `run_status_snapshots` if it was an intermediary state (which simplifies things).

## 🎩 
<img width="1641" alt="Screen Shot 2020-10-08 at 3 16 57 PM" src="https://user-images.githubusercontent.com/22918438/95510232-9af44e80-0983-11eb-99ee-41738e6ea8aa.png">
