### PR TITLE
Allow users to pause a running task

### DIFF
--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -24,6 +24,13 @@ module MaintenanceTasks
       end
     end
 
+    # Updates a Run status to paused.
+    def pause
+      run = Run.find(params.fetch(:id))
+      run.paused!
+      redirect_to(root_path)
+    end
+
     private
 
     def run_params

--- a/app/views/maintenance_tasks/runs/index.html.erb
+++ b/app/views/maintenance_tasks/runs/index.html.erb
@@ -32,6 +32,7 @@
       <th>Task Name</th>
       <th>Created at</th>
       <th>Status</th>
+      <th></th>
     </tr>
   </thead>
 
@@ -41,6 +42,9 @@
         <td><%= run.task_name %></td>
         <td><%= l run.created_at %></td>
         <td><%= run.status %></td>
+        <td>
+          <%= button_to 'Pause', pause_run_path(run), method: :put if run.enqueued? || run.running? %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 MaintenanceTasks::Engine.routes.draw do
-  resources :runs, only: [:index, :create], format: false
+  resources :runs, only: [:index, :create], format: false do
+    put 'pause', on: :member
+  end
+
   root to: 'runs#index'
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -4,4 +4,7 @@ require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :rack_test
+
+  setup { Maintenance::UpdatePostsTask.fast_task = false }
+  teardown { Maintenance::UpdatePostsTask.fast_task = true }
 end

--- a/test/dummy/app/jobs/maintenance/update_posts_task.rb
+++ b/test/dummy/app/jobs/maintenance/update_posts_task.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 module Maintenance
   class UpdatePostsTask < MaintenanceTasks::Task
+    class << self
+      attr_accessor :fast_task
+    end
+
     def task_enumerator(cursor:)
       enumerator_builder.active_record_on_records(
         Post.all,
@@ -9,7 +13,7 @@ module Maintenance
     end
 
     def task_iteration(post)
-      sleep(Rails.env.test? ? 0 : 1)
+      sleep(1) unless self.class.fast_task
 
       post.update!(content: "New content added on #{Time.now.utc}")
     end

--- a/test/system/tasks_test.rb
+++ b/test/system/tasks_test.rb
@@ -3,19 +3,19 @@
 require 'application_system_test_case'
 
 class TasksTest < ApplicationSystemTestCase
+  setup { freeze_time }
+
   test 'list all tasks' do
     visit maintenance_tasks_path
 
     assert_title 'Maintenance Tasks'
 
     assert_table 'Enqueue Task', with_rows: [
-      ['Maintenance::UpdatePostsTask', ''],
+      ['Maintenance::UpdatePostsTask'],
     ]
   end
 
   test 'run a task' do
-    freeze_time
-
     visit maintenance_tasks_path
 
     within 'tr', text: 'Maintenance::UpdatePostsTask' do
@@ -28,6 +28,22 @@ class TasksTest < ApplicationSystemTestCase
 
     assert_table 'Maintenance Task Runs', with_rows: [
       ['Maintenance::UpdatePostsTask', I18n.l(Time.now.utc)],
+    ]
+  end
+
+  test 'pause a Run' do
+    visit maintenance_tasks_path
+
+    within 'tr', text: 'Maintenance::UpdatePostsTask' do
+      click_on 'Run'
+    end
+
+    within 'table', text: 'Maintenance Task Runs' do
+      within('tr', text: 'Maintenance::UpdatePostsTask') { click_on 'Pause' }
+    end
+
+    assert_table 'Maintenance Task Runs', with_rows: [
+      ['Maintenance::UpdatePostsTask', I18n.l(Time.now.utc), 'paused'],
     ]
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,3 +22,5 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
     ActiveSupport::TestCase.fixture_path + '/files'
   ActiveSupport::TestCase.fixtures(:all)
 end
+
+Maintenance::UpdatePostsTask.fast_task = true


### PR DESCRIPTION
Quite straightforward: we render a "pause" button for running tasks that allows users to pause the task. The job signals to Job Iterator that the job should exit without a retry. I'll submit another PR for a "resume" button after this one.

Note that in order to test this behaviour I need the async adapter with a slow running job, so I can interact with the page in a "running" state. Hopefully this won't be flaky!