### PR TITLE
Set job_id on a Run before the job is enqueued

### DIFF
--- a/test/jobs/maintenance_tasks/task_test.rb
+++ b/test/jobs/maintenance_tasks/task_test.rb
@@ -6,8 +6,6 @@ module MaintenanceTasks
     class SnapshotTask < Task
       self.abstract_class = true
 
-      attr_reader :run
-
       class << self
         attr_reader :run_status_snapshots
 
@@ -100,14 +98,19 @@ module MaintenanceTasks
       assert_no_enqueued_jobs
     end
 
-    test 'updates associated Run to running and persists job_id when job starts performing' do
+    test 'persists job_id to associated Run when job is enqueued' do
       run = Run.create!(task_name: 'MaintenanceTasks::TaskTest::SuccessfulJob')
       job = SuccessfulJob.perform_later(run)
 
-      perform_enqueued_jobs
-
       run.reload
       assert_equal job.job_id, run.job_id
+    end
+
+    test 'updates associated Run to running when job starts performing' do
+      run = Run.create!(task_name: 'MaintenanceTasks::TaskTest::SuccessfulJob')
+      SuccessfulJob.perform_later(run)
+
+      perform_enqueued_jobs
 
       assert_includes SuccessfulJob.run_status_snapshots, 'running'
     end


### PR DESCRIPTION
- Right now, we can't abort / pause a job before it starts performing because the `@run` hasn't yet been set (as that happens in a `before_perform` hook)
- We should allow tasks to be paused / aborted prior to the job actually starting to perform by setting the `job_id` as soon as it's enqueued, and moving `task_iteration` to happen after we check if the run is aborted or not
- I've also defined a `run` getter because the `Task` object is actually not the same object between enqueue / perform, so we need to set it based on the args twice