### PR TITLE
Allow tasks to be aborted

### DIFF
--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -6,6 +6,8 @@ module MaintenanceTasks
   # It makes data about available, enqueued, performing, and completed
   # tasks accessible to the views so it can be displayed in the UI.
   class RunsController < ApplicationController
+    before_action :set_run, only: [:pause, :abort]
+
     # Renders the /maintenance_tasks page, displaying available tasks to users.
     def index
       @runs = Run.all
@@ -26,8 +28,13 @@ module MaintenanceTasks
 
     # Updates a Run status to paused.
     def pause
-      run = Run.find(params.fetch(:id))
-      run.paused!
+      @run.paused!
+      redirect_to(root_path)
+    end
+
+    # Updates a Run status to aborted.
+    def abort
+      @run.aborted!
       redirect_to(root_path)
     end
 
@@ -40,6 +47,10 @@ module MaintenanceTasks
     end
 
     private
+
+    def set_run
+      @run = Run.find(params.fetch(:id))
+    end
 
     def run_params
       params.require(:run).permit(:task_name)

--- a/app/views/maintenance_tasks/runs/index.html.erb
+++ b/app/views/maintenance_tasks/runs/index.html.erb
@@ -48,8 +48,12 @@
         <td><%= run.error_message %></td>
         <td><%= format_backtrace(run.backtrace) %></td>
         <td>
-          <%= button_to 'Pause', pause_run_path(run), method: :put if run.enqueued? || run.running? %>
-          <%= button_to 'Resume', resume_run_path(run), method: :put if run.paused? %>
+          <% if run.enqueued? || run.running? %>
+             <%= button_to 'Pause', pause_run_path(run), method: :put %>
+             <%= button_to 'Abort', abort_run_path(run), method: :put %>
+          <% elsif run.paused? %>
+            <%= button_to 'Resume', resume_run_path(run), method: :put %>
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ MaintenanceTasks::Engine.routes.draw do
     member do
       put 'pause'
       put 'resume'
+      put 'abort'
     end
   end
 

--- a/test/system/tasks_test.rb
+++ b/test/system/tasks_test.rb
@@ -48,6 +48,22 @@ class TasksTest < ApplicationSystemTestCase
     ]
   end
 
+  test 'abort a Run' do
+    visit maintenance_tasks_path
+
+    within 'tr', text: 'Maintenance::UpdatePostsTask' do
+      click_on 'Run'
+    end
+
+    within 'table', text: 'Maintenance Task Runs' do
+      within('tr', text: 'Maintenance::UpdatePostsTask') { click_on 'Abort' }
+    end
+
+    assert_table 'Maintenance Task Runs', with_rows: [
+      ['Maintenance::UpdatePostsTask', I18n.l(Time.now.utc), 'aborted'],
+    ]
+  end
+
   test 'run a task that errors' do
     with_queue_adapter(:inline, Maintenance::ErrorTask) do
       visit maintenance_tasks_path


### PR DESCRIPTION
Right now, aborting a task is similar to pausing a task. However, aborted tasks will not be resumable (unlike paused tasks).

This PR introduces the functionality of aborting a task, which is a button click similar to `Pause`.

This PR also updates the logic in `jobs/task.rb` to check the run status prior to running an iteration, and ensures we only update status on the run in `job_running` if the run is not already paused or aborted.