### PR TITLE
Resume a paused task

### DIFF
--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -31,6 +31,14 @@ module MaintenanceTasks
       redirect_to(root_path)
     end
 
+    # Updates a Run status from paused to running.
+    def resume
+      run = Run.find(params.fetch(:id))
+      run.enqueued!
+      run.enqueue
+      redirect_to(root_path)
+    end
+
     private
 
     def run_params

--- a/app/views/maintenance_tasks/runs/index.html.erb
+++ b/app/views/maintenance_tasks/runs/index.html.erb
@@ -34,6 +34,7 @@
       <th>Error Class</th>
       <th>Error Message</th>
       <th>Backtrace</th>
+      <th></th>
     </tr>
   </thead>
 
@@ -48,6 +49,7 @@
         <td><%= format_backtrace(run.backtrace) %></td>
         <td>
           <%= button_to 'Pause', pause_run_path(run), method: :put if run.enqueued? || run.running? %>
+          <%= button_to 'Resume', resume_run_path(run), method: :put if run.paused? %>
         </td>
       </tr>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 MaintenanceTasks::Engine.routes.draw do
   resources :runs, only: [:index, :create], format: false do
-    put 'pause', on: :member
+    member do
+      put 'pause'
+      put 'resume'
+    end
   end
 
   root to: 'runs#index'


### PR DESCRIPTION
Closes #22 

This PR finishes the work with pause/resume by adding the Resume button to paused runs. A few things to note:

* I added yet another custom route for this. If this becomes a trend I would like to replace all these with an `update` route to set the status we want.
* I'm reusing the `enqueue` method to resume the task. I think that's fine for now, but I still think that should not be the model's responsibility. I'm planning on refactoring this later as well. For now I want to have the feature working so I can improve the code later without changing the UX behaviour. Stay tuned!