### PR TITLE
Prevent running tasks from being shown in the UI as enqueuable

### DIFF
--- a/app/jobs/maintenance_tasks/task.rb
+++ b/app/jobs/maintenance_tasks/task.rb
@@ -40,7 +40,8 @@ module MaintenanceTasks
       # @return [Array<Class>] the list of classes.
       def available_tasks
         load_constants
-        descendants.reject(&:abstract_class?)
+        running = Run.select(&:running?).pluck(:task_name).map(&:constantize)
+        descendants.reject(&:abstract_class?) - running
       end
 
       private

--- a/test/jobs/maintenance_tasks/task_test.rb
+++ b/test/jobs/maintenance_tasks/task_test.rb
@@ -77,6 +77,12 @@ module MaintenanceTasks
         MaintenanceTasks::Task.available_tasks.map(&:name).sort
     end
 
+    test '.available_tasks excludes running tasks' do
+      Run.create!(task_name: 'Maintenance::UpdatePostsTask', status: :running)
+      running_task = Maintenance::UpdatePostsTask
+      refute_includes MaintenanceTasks::Task.available_tasks, running_task
+    end
+
     test '.named returns the task based on its name' do
       expected_task = Maintenance::UpdatePostsTask
       assert_equal expected_task, Task.named('Maintenance::UpdatePostsTask')

--- a/test/system/tasks_test.rb
+++ b/test/system/tasks_test.rb
@@ -27,6 +27,10 @@ class TasksTest < ApplicationSystemTestCase
 
     assert_text 'Task Maintenance::UpdatePostsTask enqueued.'
 
+    assert_no_table 'Enqueue Task', with_rows: [
+      ['Maintenance::UpdatePostsTask', ''],
+    ]
+
     assert_table 'Maintenance Task Runs', with_rows: [
       ['Maintenance::UpdatePostsTask', I18n.l(Time.now.utc)],
     ]


### PR DESCRIPTION
Since we only allow one instance of a task to be performed at a time, we shouldn't show a task as enqueuable if it is currently performing.

Closes: https://github.com/Shopify/maintenance_tasks/issues/53