### PR TITLE
Pagination with Pagy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     maintenance_tasks (0.1.0)
       job-iteration (~> 1.1.8)
+      pagy (~> 3.8.3)
       rails (~> 6.0.3)
 
 GEM
@@ -103,6 +104,7 @@ GEM
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    pagy (3.8.3)
     parallel (1.19.2)
     parser (2.7.2.0)
       ast (~> 2.4.1)

--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -3,6 +3,8 @@
 module MaintenanceTasks
   # Base class for all controllers used by this engine.
   class ApplicationController < ActionController::Base
+    include Pagy::Backend
+
     protect_from_forgery with: :exception
   end
 end

--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -8,14 +8,14 @@ module MaintenanceTasks
     # available tasks to users.
     def index
       @tasks = Task.available_tasks
-      @active_runs = Run.active
+      @pagy, @active_runs = pagy(Run.active)
     end
 
     # Renders the page responsible for providing Task actions to users.
     # Shows running and completed instances of the Task.
     def show
       @task = Task.named(params.fetch(:id))
-      @runs = @task.runs
+      @pagy, @runs = pagy(@task.runs)
       @active_run = @task.active_run
     end
   end

--- a/app/helpers/maintenance_tasks/application_helper.rb
+++ b/app/helpers/maintenance_tasks/application_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module MaintenanceTasks
+  # Module for common view helpers.
+  module ApplicationHelper
+    include Pagy::Frontend
+
+    # Renders pagination for the page, if there is more than one page present.
+    #
+    # @param pagy [Pagy] the pagy instance containing pagination details,
+    #   including the number of pages the results are spread across.
+    # @return [String] the HTML to render for pagination.
+    def pagination(pagy)
+      raw(pagy_bulma_nav(pagy)) if pagy.pages > 1
+    end
+  end
+end

--- a/app/views/maintenance_tasks/tasks/index.html.erb
+++ b/app/views/maintenance_tasks/tasks/index.html.erb
@@ -28,3 +28,5 @@
     <% end %>
   </tbody>
 </table>
+
+<%= pagination(@pagy) %>

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -44,3 +44,5 @@
     <% end %>
   </tbody>
 </table>
+
+<%= pagination(@pagy) %>

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 require 'maintenance_tasks/engine'
+require 'pagy'
+require 'pagy/extras/bulma'
 
 # The engine's namespace module. It provides isolation between the host
 # application's code and the engine-specific code. Top-level engine constants

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -17,5 +17,6 @@ Gem::Specification.new do |spec|
   spec.files = Dir['{app,config,db,lib}/**/*', 'Rakefile', 'README.md']
 
   spec.add_dependency('job-iteration', '~> 1.1.8')
+  spec.add_dependency('pagy', '~> 3.8.3')
   spec.add_dependency('rails', '~> 6.0.3')
 end

--- a/test/helpers/maintenance_tasks/application_helper_test.rb
+++ b/test/helpers/maintenance_tasks/application_helper_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module MaintenanceTasks
+  class ApplicationHelperTest < ActionView::TestCase
+    setup { @pagy = mock }
+
+    test '#pagination returns nil if pages is less than or equal to 1' do
+      @pagy.expects(pages: 1)
+      expects(:pagy_bulma_nav).never
+      assert_nil pagination(@pagy)
+    end
+
+    test '#pagination returns pagination element if pages is greater than 1' do
+      @pagy.expects(pages: 2)
+      expects(:pagy_bulma_nav).with(@pagy).returns('pagination')
+      assert_equal 'pagination', pagination(@pagy)
+    end
+  end
+end


### PR DESCRIPTION
For: https://github.com/Shopify/maintenance_tasks/issues/70

Opted to use [Pagy](https://github.com/ddnexus/pagy) to handle pagination in our gem, for a number of reasons:
- Faster, more memory efficient, and simpler than a lot of other pagination gems
- Integrates really nicely with Bulma
- Modular, so we only need to include the bare minimum (comes with very basic pagination, and other than that I've just included the Bulma helper)
- Agnostic, so doesn't need to know anything about Rails / our models / etc.

Pagy on [the Ruby Toolbox](https://www.ruby-toolbox.com/projects/pagy)

## 🎩 
![Screen Shot 2020-10-19 at 3 51 00 PM](https://user-images.githubusercontent.com/22918438/96508488-ab7cb280-1228-11eb-95f8-a6453aaccb9a.png)
