### PR TITLE
Change abort to cancel

### DIFF
--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -4,7 +4,7 @@ module MaintenanceTasks
   # Class communicates with the Run model to persist info related to task runs.
   # It defines actions for creating and pausing runs.
   class RunsController < ApplicationController
-    before_action :set_run, only: [:pause, :abort, :resume]
+    before_action :set_run, only: [:pause, :cancel, :resume]
     before_action :set_task
 
     # POST /maintenance_tasks/runs
@@ -26,9 +26,9 @@ module MaintenanceTasks
       redirect_to(task_path(@task))
     end
 
-    # Updates a Run status to aborted.
-    def abort
-      @run.aborted!
+    # Updates a Run status to cancelled.
+    def cancel
+      @run.cancelled!
       redirect_to(task_path(@task))
     end
 

--- a/app/jobs/maintenance_tasks/task.rb
+++ b/app/jobs/maintenance_tasks/task.rb
@@ -143,10 +143,10 @@ module MaintenanceTasks
       # Note that as long as @task_stopped is false, this block will run.
       # It is still preferable to memoize here because it prevents us from
       #  having to perform more reloads after the task has entered
-      # a paused or aborted status
+      # a paused or cancelled status
       @task_stopped ||= begin
         run = Run.select(:status).find(@run.id)
-        run.paused? || run.aborted?
+        run.paused? || run.cancelled?
       end
     end
 

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -7,7 +7,7 @@ module MaintenanceTasks
     # enqueued      The task has been enqueued by the user.
     # running       The task is being performed by a job worker.
     # succeeded     The task finished without error.
-    # aborted       The user explicitly halted the task's execution.
+    # cancelled     The user explicitly halted the task's execution.
     # interrupted   The task was interrupted by the job infrastructure.
     # paused        The task was paused in the middle of the run by the user.
     # errored       The task code produced an unhandled exception.
@@ -15,7 +15,7 @@ module MaintenanceTasks
       :enqueued,
       :running,
       :succeeded,
-      :aborted,
+      :cancelled,
       :interrupted,
       :paused,
       :errored,

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -13,7 +13,7 @@
     <%= button_to 'Resume', resume_task_run_path(@task, @active_run), method: :put, class: 'button is-primary' %>
   <% else %>
     <%= button_to 'Pause', pause_task_run_path(@task, @active_run), method: :put, class: 'button is-warning' %>
-    <%= button_to 'Abort', abort_task_run_path(@task, @active_run), method: :put, class: 'button is-danger' %>
+    <%= button_to 'Cancel', cancel_task_run_path(@task, @active_run), method: :put, class: 'button is-danger' %>
   <% end %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ MaintenanceTasks::Engine.routes.draw do
       member do
         put 'pause'
         put 'resume'
-        put 'abort'
+        put 'cancel'
       end
     end
   end

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -53,7 +53,7 @@ module MaintenanceTasks
       running_run = Run.create!(task_name: task_name, status: :running)
 
       succeeded_run = Run.create!(task_name: task_name, status: :succeeded)
-      aborted_run = Run.create!(task_name: task_name, status: :aborted)
+      cancelled_run = Run.create!(task_name: task_name, status: :cancelled)
       interrupted_run = Run.create!(task_name: task_name, status: :interrupted)
       errored_run = Run.create!(task_name: task_name, status: :errored)
 
@@ -64,7 +64,7 @@ module MaintenanceTasks
       assert_includes active_runs, running_run
 
       assert_not_includes active_runs, succeeded_run
-      assert_not_includes active_runs, aborted_run
+      assert_not_includes active_runs, cancelled_run
       assert_not_includes active_runs, interrupted_run
       assert_not_includes active_runs, errored_run
     end

--- a/test/system/runs_test.rb
+++ b/test/system/runs_test.rb
@@ -47,7 +47,7 @@ class RunsTest < ApplicationSystemTestCase
     assert_table with_rows: [[I18n.l(Time.now.utc), 'enqueued']]
   end
 
-  test 'abort a Run' do
+  test 'cancel a Run' do
     visit maintenance_tasks_path
 
     click_on 'Maintenance::UpdatePostsTask'
@@ -55,9 +55,9 @@ class RunsTest < ApplicationSystemTestCase
 
     assert_title 'Maintenance::UpdatePostsTask'
 
-    click_on 'Abort'
+    click_on 'Cancel'
 
-    assert_table with_rows: [[I18n.l(Time.now.utc), 'aborted']]
+    assert_table with_rows: [[I18n.l(Time.now.utc), 'cancelled']]
   end
 
   test 'run a task that errors' do


### PR DESCRIPTION
`abort` arguably carries some contentious connotations, so let's use `cancel` instead 😄 

Closes https://github.com/Shopify/maintenance_tasks/issues/73