### PR TITLE
Use custom validator to ensure valid run status transitions

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -31,6 +31,8 @@ module MaintenanceTasks
 
     scope :active, -> { where(status: ACTIVE_STATUSES) }
 
+    validates_with RunStatusValidator, on: :update
+
     # Enqueues the job after validating and persisting the run.
     def enqueue
       if save

--- a/app/validators/maintenance_tasks/run_status_validator.rb
+++ b/app/validators/maintenance_tasks/run_status_validator.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+module MaintenanceTasks
+  # Custom validator class responsible for ensuring that transitions between
+  # Run statuses are valid.
+  class RunStatusValidator < ActiveModel::Validator
+    # Valid status transitions a Run can make.
+    VALID_STATUS_TRANSITIONS = {
+      'enqueued' => ['running', 'paused', 'cancelled'],
+      'running' => [
+        'succeeded',
+        'paused',
+        'cancelled',
+        'interrupted',
+        'errored',
+      ],
+      'paused' => ['enqueued'],
+      'interrupted' => ['running', 'succeeded'],
+    }
+
+    # Validate whether a transition from one Run status
+    # to another is acceptable.
+    #
+    #  @param record [MaintenanceTasks::Run] the Run object being validated.
+    def validate(record)
+      previous_status = record.status_was
+      new_status = record.status
+
+      return if previous_status == new_status
+
+      valid_new_statuses = VALID_STATUS_TRANSITIONS.fetch(previous_status, [])
+
+      unless valid_new_statuses.include?(new_status)
+        add_invalid_status_error(record, previous_status, new_status)
+      end
+    end
+
+    private
+
+    def add_invalid_status_error(record, previous_status, new_status)
+      record.errors.add(
+        :status,
+        "Cannot transition run from status #{previous_status} to #{new_status}"
+      )
+    end
+  end
+end

--- a/test/tasks/maintenance_tasks/task_test.rb
+++ b/test/tasks/maintenance_tasks/task_test.rb
@@ -31,13 +31,13 @@ module MaintenanceTasks
 
     test '.active_run returns the only enqueued, running, or paused run associated with a Task' do
       run = Run.create!(task_name: 'Maintenance::UpdatePostsTask')
-
-      assert_equal run, Maintenance::UpdatePostsTask.active_run
-
-      run.running!
       assert_equal run, Maintenance::UpdatePostsTask.active_run
 
       run.paused!
+      assert_equal run, Maintenance::UpdatePostsTask.active_run
+
+      run.enqueued!
+      run.running!
       assert_equal run, Maintenance::UpdatePostsTask.active_run
 
       run.succeeded!

--- a/test/validators/maintenance_tasks/run_status_validator_test.rb
+++ b/test/validators/maintenance_tasks/run_status_validator_test.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module MaintenanceTasks
+  class RunStatusValidatorTest < ActiveSupport::TestCase
+    test 'run can go from enqueued or interrupted to running' do
+      enqueued_run = Run.create!(task_name: 'Maintenance::UpdatePostsTask')
+      enqueued_run.status = :running
+
+      assert enqueued_run.valid?
+
+      interrupted_run = Run.create!(
+        task_name: 'Maintenance::UpdatePostsTask',
+        status: :interrupted
+      )
+      interrupted_run.status = :running
+
+      assert interrupted_run.valid?
+
+      assert_no_invalid_transitions([:enqueued, :interrupted], :running)
+    end
+
+    test 'run can go from paused to enqueued' do
+      paused_run = Run.create!(
+        task_name: 'Maintenance::UpdatePostsTask',
+        status: :paused
+      )
+      paused_run.status = :enqueued
+
+      assert paused_run.valid?
+
+      assert_no_invalid_transitions([:paused], :enqueued)
+    end
+
+    test 'run can go from running or interrupted to succeeded' do
+      running_run = Run.create!(
+        task_name: 'Maintenance::UpdatePostsTask',
+        status: :running
+      )
+      running_run.status = :succeeded
+
+      assert running_run.valid?
+
+      interrupted_run = Run.create!(
+        task_name: 'Maintenance::UpdatePostsTask',
+        status: :interrupted
+      )
+      interrupted_run.status = :succeeded
+
+      assert interrupted_run.valid?
+
+      assert_no_invalid_transitions([:running, :interrupted], :succeeded)
+    end
+
+    test 'run can go from enqueued or running to cancelled' do
+      enqueued_run = Run.create!(task_name: 'Maintenance::UpdatePostsTask')
+      enqueued_run.status = :cancelled
+
+      assert enqueued_run.valid?
+
+      running_run = Run.create!(
+        task_name: 'Maintenance::UpdatePostsTask',
+        status: :running
+      )
+      running_run.status = :cancelled
+
+      assert running_run.valid?
+
+      assert_no_invalid_transitions([:enqueued, :running], :cancelled)
+    end
+
+    test 'run can go from enqueued or running to paused' do
+      enqueued_run = Run.create!(task_name: 'Maintenance::UpdatePostsTask')
+      enqueued_run.status = :paused
+
+      assert enqueued_run.valid?
+
+      running_run = Run.create!(
+        task_name: 'Maintenance::UpdatePostsTask',
+        status: :running
+      )
+      running_run.status = :paused
+
+      assert running_run.valid?
+
+      assert_no_invalid_transitions([:enqueued, :running], :paused)
+    end
+
+    test 'run can go from running to interrupted' do
+      running_run = Run.create!(
+        task_name: 'Maintenance::UpdatePostsTask',
+        status: :running
+      )
+      running_run.status = :interrupted
+
+      assert running_run.valid?
+
+      assert_no_invalid_transitions([:running], :interrupted)
+    end
+
+    test 'run can go from running to errored' do
+      running_run = Run.create!(
+        task_name: 'Maintenance::UpdatePostsTask',
+        status: :running
+      )
+      running_run.status = :errored
+
+      assert running_run.valid?
+
+      assert_no_invalid_transitions([:running], :errored)
+    end
+
+    private
+
+    def assert_no_invalid_transitions(valid_starting_statuses, end_status)
+      invalid_statuses = Run::STATUSES - valid_starting_statuses - [end_status]
+      invalid_statuses.each do |status|
+        run = Run.create!(
+          task_name: 'Maintenance::UpdatePostsTask',
+          status: status
+        )
+
+        run.status = end_status
+
+        refute(run.valid?,
+          "Expected transition from #{status} to #{end_status} to be invalid")
+        expected_status_error = [
+          "Cannot transition run from status #{status} to #{end_status}",
+        ]
+        assert_equal(expected_status_error, run.errors[:status])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Alternate proposal to solve https://github.com/Shopify/maintenance_tasks/issues/64

Instead of having a PORO to act as a state machine, we implement a custom `ActiveModel::Validator` which checks the previous `status` and the new `status` and ensures that the state transition is valid. If not, we add an error to the status attribute.