### PR TITLE
Replace custom validation with inclusion validator

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -25,7 +25,9 @@ module MaintenanceTasks
 
     enum status: STATUSES.to_h { |status| [status, status.to_s] }
 
-    validate :task_exists?, :task_non_abstract?
+    validates :task_name, inclusion: { in: ->(_) {
+      Task.available_tasks.map(&:to_s)
+    } }
 
     serialize :backtrace
 
@@ -45,24 +47,6 @@ module MaintenanceTasks
     # @param number_of_ticks [Integer] number of ticks to add to tick_count.
     def increment_ticks(number_of_ticks)
       self.class.update_counters(id, tick_count: number_of_ticks, touch: true)
-    end
-
-    private
-
-    def task_class
-      Task.named(task_name)
-    end
-
-    def task_exists?
-      unless task_class
-        errors.add(:base, "Task #{task_name} does not exist.")
-      end
-    end
-
-    def task_non_abstract?
-      if task_class&.abstract_class?
-        errors.add(:base, "Task #{task_name} is abstract.")
-      end
     end
   end
 end

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -17,15 +17,11 @@ module MaintenanceTasks
     test "invalid if the task doesn't exist" do
       run = Run.new(task_name: 'Maintenance::DoesNotExist')
       refute run.valid?
-      expected_error = 'Task Maintenance::DoesNotExist does not exist.'
-      assert_includes run.errors.full_messages, expected_error
     end
 
     test 'invalid if the task is abstract' do
       run = Run.new(task_name: 'Maintenance::ApplicationTask')
       refute run.valid?
-      expected_error = 'Task Maintenance::ApplicationTask is abstract.'
-      assert_includes run.errors.full_messages, expected_error
     end
 
     test '#increment_ticks persists an increment to the tick count' do


### PR DESCRIPTION
Since we already have a list of allowed Tasks we can use that with the inclusion validator. Also we don't care about the actual message since failing this validation would be an internal bug, so I'll leave it with the default message from Rails.