### PR TITLE
Allow to smoke test production for the dummy app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ test/dummy/db/*.sqlite3
 test/dummy/db/*.sqlite3-journal
 test/dummy/db/*.sqlite3-*
 test/dummy/log/*.log
+test/dummy/public/assets
 test/dummy/storage/
 test/dummy/tmp/

--- a/bin/production
+++ b/bin/production
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -ex
+
+export RAILS_ENV=production
+SECRET_KEY_BASE="$(rails app:secret)"
+export SECRET_KEY_BASE
+
+rails app:assets:precompile
+DISABLE_DATABASE_ENVIRONMENT_CHECK=true rails db:setup
+
+RAILS_SERVE_STATIC_FILES=true rails server


### PR DESCRIPTION
Sometimes I want to test whether the loading of constants, with regards to autoloading/eager loading can be an issue. I could use the different options in development like cache_classes, eager_load but I figured the closer we get to a production environment the better, so this does what's needed to get the dummy app running with all the Rails defaults set for production.