### PR TITLE
Use cursor in pause / resume functionality

### DIFF
--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -19,6 +19,7 @@ module MaintenanceTasks
     private
 
     def build_enumerator(_run, cursor:)
+      cursor ||= @run.cursor
       @task.task_enumerator(cursor: cursor)
     end
 
@@ -50,7 +51,9 @@ module MaintenanceTasks
     end
 
     def shutdown_job
-      @run.interrupted! unless task_stopped?
+      @run.cursor = cursor_position
+      @run.status = :interrupted unless task_stopped?
+      @run.save!
     end
 
     def job_errored(exception)


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/72

Pause / resume functionality on main is currently broken - if a run is paused and then resumed, it starts from the beginning.
We need to persist the cursor to the run object if the job shuts down, and then check for the cursor on the run object when the enumerator is built.

Note that cursor can come in from Job Iteration (the scenario where the job has been interrupted and re-enqueued with a cursor), or that the cursor can come from a Run object (the scenario where a user has paused the task). The latter of the two is the scenario we're fixing here.