### PR TITLE
Order Runs by most recently created

### DIFF
--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -8,14 +8,14 @@ module MaintenanceTasks
     # available tasks to users.
     def index
       @tasks = Task.available_tasks
-      @pagy, @active_runs = pagy(Run.active)
+      @pagy, @active_runs = pagy(Run.active.order(created_at: :desc))
     end
 
     # Renders the page responsible for providing Task actions to users.
     # Shows running and completed instances of the Task.
     def show
       @task = Task.named(params.fetch(:id))
-      @pagy, @runs = pagy(@task.runs)
+      @pagy, @runs = pagy(@task.runs.order(created_at: :desc))
       @active_run = @task.active_run
     end
   end

--- a/db/migrate/20201022142907_add_index_to_maintenance_tasks_runs_created_at.rb
+++ b/db/migrate/20201022142907_add_index_to_maintenance_tasks_runs_created_at.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddIndexToMaintenanceTasksRunsCreatedAt < ActiveRecord::Migration[6.0]
+  def change
+    add_index(:maintenance_tasks_runs, :created_at)
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_13_130804) do
+ActiveRecord::Schema.define(version: 2020_10_22_142907) do
 
   create_table "maintenance_tasks_runs", force: :cascade do |t|
     t.string "task_name", null: false
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2020_10_13_130804) do
     t.string "error_class"
     t.string "error_message"
     t.text "backtrace"
+    t.index ["created_at"], name: "index_maintenance_tasks_runs_on_created_at"
   end
 
   create_table "posts", force: :cascade do |t|


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/86

Orders runs by `CREATED_AT DESC` so that we show the latest runs first in the UI.
I've also added an index to the `created_at` column in our table.