### PR TITLE
Remove warnings on boot

### DIFF
--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 require_relative 'boot'
 
+verbose = $VERBOSE
+$VERBOSE = false
+require 'action_mailbox/engine'
+$VERBOSE = verbose
+
 require 'rails/all'
 
 Bundler.require(*Rails.groups)


### PR DESCRIPTION
Require the framework causing the warnings with verbose mode off before loading the rest of Rails.

---

I wondered if we should list only the ones we actually use, but in the interest of making the smallest change possible, and testing with the full Rails, this just loads the offending framework without warnings first.