### PR TITLE
Remove system test flakiness by freezing time

### DIFF
--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -22,6 +22,7 @@ module MaintenanceTasks
     end
 
     test 'lists active runs' do
+      freeze_time
       visit maintenance_tasks_path
 
       click_on 'Maintenance::UpdatePostsTask'


### PR DESCRIPTION
The row was sometimes not found because it had a different timestamp.