### PR TITLE
Decouple Task from Job Iteration Enumerator Builder

### DIFF
--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -20,7 +20,17 @@ module MaintenanceTasks
 
     def build_enumerator(_run, cursor:)
       cursor ||= @run.cursor
-      @task.task_enumerator(cursor: cursor)
+      collection = @task.collection
+
+      case collection
+      when ActiveRecord::Relation
+        enumerator_builder.active_record_on_records(collection, cursor: cursor)
+      when Array
+        enumerator_builder.build_array_enumerator(collection, cursor: cursor)
+      else
+        raise ArgumentError, "#{@task.class.name}#collection must be either "\
+          'an Active Record Relation or an Array.'
+      end
     end
 
     # Performs task iteration logic for the current input returned by the

--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -73,9 +73,9 @@ module MaintenanceTasks
     #
     # @raise [NotImplementedError] with a message advising subclasses to
     #   implement an override for this method.
-    def task_enumerator(*)
+    def collection
       raise NotImplementedError,
-        "#{self.class.name} must implement `task_enumerator`."
+        "#{self.class.name} must implement `collection`."
     end
 
     # Placeholder method to raise in case a subclass fails to implement the

--- a/test/dummy/app/tasks/maintenance/error_task.rb
+++ b/test/dummy/app/tasks/maintenance/error_task.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 module Maintenance
   class ErrorTask < MaintenanceTasks::Task
-    def task_enumerator(*)
-      [1, 2].to_enum
+    def collection
+      [1, 2]
     end
 
     def task_iteration(*)

--- a/test/dummy/app/tasks/maintenance/update_posts_task.rb
+++ b/test/dummy/app/tasks/maintenance/update_posts_task.rb
@@ -7,15 +7,12 @@ module Maintenance
       attr_accessor :fast_task
     end
 
-    def task_enumerator(cursor:)
-      enumerator_builder.active_record_on_records(
-        Post.all,
-        cursor: cursor,
-      )
+    def collection
+      Post.all
     end
 
     def task_count
-      Post.count
+      collection.count
     end
 
     def task_iteration(post)

--- a/test/tasks/maintenance_tasks/task_test.rb
+++ b/test/tasks/maintenance_tasks/task_test.rb
@@ -49,11 +49,9 @@ module MaintenanceTasks
       assert_nil task.task_count
     end
 
-    test '#task_enumerator raises NotImplementedError' do
-      error = assert_raises(NotImplementedError) do
-        Task.new.task_enumerator(cursor: 1)
-      end
-      message = 'MaintenanceTasks::Task must implement `task_enumerator`.'
+    test '#collection raises NotImplementedError' do
+      error = assert_raises(NotImplementedError) { Task.new.collection }
+      message = 'MaintenanceTasks::Task must implement `collection`.'
       assert_equal message, error.message
     end
 


### PR DESCRIPTION
After decoupling tasks from jobs I had to re-couple the new Task class with Job Iteration's Enumerator Builder in order to keep the current API unchanged. This PR addresses this coupling by moving the dependency back to Task Job, which now uses Task's new `collection` instance method. That's a much simpler API that requires tasks to just declare a "collection" of items to be iterated over; no need to know anything about enumerators or cursors. I think this easy-to-use API will please our users very much.

Fixes #85