### PR TITLE
Refresh UI when runs are active

### DIFF
--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -24,7 +24,7 @@ module MaintenanceTasks
     private
 
     def set_refresh
-      response.headers['Refresh'] = '5'
+      @refresh = 5
     end
   end
 end

--- a/app/views/layouts/maintenance_tasks/application.html.erb
+++ b/app/views/layouts/maintenance_tasks/application.html.erb
@@ -18,6 +18,10 @@
         integrity: 'sha256-67AR2JVjhMZCLVxapLuBSMap5RrXbksv4vlllenHBSE=',
         crossorigin: 'anonymous'
     %>
+
+    <% if defined?(@refresh) %>
+      <meta http-equiv="refresh" content="<%= @refresh %>">
+    <% end %>
   </head>
 
   <body>

--- a/test/controllers/maintenance_tasks/tasks_controller_test.rb
+++ b/test/controllers/maintenance_tasks/tasks_controller_test.rb
@@ -7,24 +7,28 @@ module MaintenanceTasks
 
     test "#index has no Refresh header if there's no active run" do
       get tasks_url
-      assert_nil response.header['Refresh']
+      assert_nil meta_http_equiv_refresh
     end
 
     test "#index returns a Refresh header if there's an active run" do
       Run.new(task_name: 'Maintenance::UpdatePostsTask').enqueue
       get tasks_url
-      refute_nil response.header['Refresh']
+      refute_nil meta_http_equiv_refresh
     end
 
     test "#show has no Refresh header if there's no active run" do
       get task_url('Maintenance::UpdatePostsTask')
-      assert_nil response.header['Refresh']
+      assert_nil meta_http_equiv_refresh
     end
 
     test "#show returns a Refresh header if there's an active run" do
       Run.new(task_name: 'Maintenance::UpdatePostsTask').enqueue
       get task_url('Maintenance::UpdatePostsTask')
-      refute_nil response.header['Refresh']
+      refute_nil meta_http_equiv_refresh
+    end
+
+    def meta_http_equiv_refresh
+      body[/<meta http-equiv="refresh" content="\d+">/]
     end
   end
 end


### PR DESCRIPTION
This is the simplest thing to have the page refresh itself after some time, to have recent information on the runs.
The refresh rate is not configurable, the whole page is refreshed, happens on both the index and the task view.

Close #91 