### PR TITLE
Allow apps to define custom Task Jobs

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -38,7 +38,7 @@ module MaintenanceTasks
     # Enqueues the job after validating and persisting the run.
     def enqueue
       if save
-        TaskJob.perform_later(self)
+        MaintenanceTasks.job.perform_later(self)
       end
     end
 

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -9,14 +9,26 @@ require 'pagy/extras/bulma'
 module MaintenanceTasks
   # Sets the value of tasks_module, the intended module to namespace Tasks in.
   # Defaults to 'Maintenance'.
-  #
-  # @attr_writer [String] the tasks_module value.
   mattr_writer :tasks_module, default: 'Maintenance'
+
+  # Defines the job to be used to perform Tasks. This job must be either
+  # `MaintenanceTasks::TaskJob` or a class that inherits from it.
+  #
+  # @param [String] the name of the job class.
+  mattr_writer :job, default: 'MaintenanceTasks::TaskJob'
 
   # Retrieves the module that Tasks are namespaced in.
   #
   # @return [Module] the constantized tasks_module value.
   def self.tasks_module
     @@tasks_module.constantize
+  end
+
+  # Retrieves the class that is configured as the Task Job to be used to
+  # perform Tasks.
+  #
+  # @return [TaskJob] the job class.
+  def self.job
+    @@job.constantize
   end
 end

--- a/test/dummy/app/jobs/custom_task_job.rb
+++ b/test/dummy/app/jobs/custom_task_job.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class CustomTaskJob < MaintenanceTasks::TaskJob
+end

--- a/test/lib/maintenance_tasks_test.rb
+++ b/test/lib/maintenance_tasks_test.rb
@@ -16,4 +16,12 @@ class MaintenanceTasksTest < ActiveSupport::TestCase
     MaintenanceTasks.tasks_module = previous_task_module
     Object.send(:remove_const, :Task)
   end
+
+  test '.job can be set' do
+    original_job = MaintenanceTasks.job.name
+    MaintenanceTasks.job = 'CustomTaskJob'
+    assert_equal(CustomTaskJob, MaintenanceTasks.job)
+  ensure
+    MaintenanceTasks.job = original_job
+  end
 end

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -8,7 +8,7 @@ module MaintenanceTasks
     test '#enqueue enqueues the Task Job for the current Run' do
       run = Run.new(task_name: 'Maintenance::UpdatePostsTask')
 
-      assert_enqueued_with job: TaskJob, args: [run] do
+      assert_enqueued_with job: MaintenanceTasks.job, args: [run] do
         run.enqueue
         assert_predicate run, :persisted?
       end


### PR DESCRIPTION
Hosting apps might be special constraints in their background queues that require additional setup in the job that performs maintenance tasks. This change allows apps to optionally define their own job that inherit from our Task Job, in which they can customize further.

Fixes #97 