### PR TITLE
Show UTC time on hover over datetime table cells

### DIFF
--- a/app/helpers/maintenance_tasks/application_helper.rb
+++ b/app/helpers/maintenance_tasks/application_helper.rb
@@ -12,5 +12,15 @@ module MaintenanceTasks
     def pagination(pagy)
       raw(pagy_bulma_nav(pagy)) if pagy.pages > 1
     end
+
+    # Renders a time element with the localized version of the datetime.
+    # The ISO 8601 version of the datetime is shown on hover
+    # via a title attribute.
+    #
+    # @param datetime [ActiveSupport::TimeWithZone] the time to be formatted.
+    # @return [String] the HTML to render with the formatted datetime.
+    def formatted_datetime(datetime)
+      time_tag(datetime, title: datetime.utc.iso8601)
+    end
   end
 end

--- a/app/views/maintenance_tasks/tasks/index.html.erb
+++ b/app/views/maintenance_tasks/tasks/index.html.erb
@@ -23,7 +23,7 @@
     <% @active_runs.each do |run| %>
       <tr>
         <td><%= link_to run.task_name, task_path(run.task_name) %></td>
-        <td><%= l run.created_at %></td>
+        <td><%= formatted_datetime(run.created_at) %></td>
         <td><%= status_tag(run.status) %></td>
         <td><%= format_ticks(run) %></td>
       </tr>

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -34,7 +34,7 @@
   <tbody>
     <% @runs.each do |run| %>
       <tr>
-        <td><%= l run.created_at %></td>
+        <td><%= formatted_datetime(run.created_at) %></td>
         <td><%= status_tag(run.status) %></td>
         <td><%= format_ticks(run) %></td>
         <td><%= run.error_class %></td>

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -5,6 +5,9 @@ require 'test_helper'
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :rack_test
 
-  setup { Maintenance::UpdatePostsTask.fast_task = false }
+  setup do
+    travel_to Time.zone.local(2020, 01, 01, 01, 00, 00)
+    Maintenance::UpdatePostsTask.fast_task = false
+  end
   teardown { Maintenance::UpdatePostsTask.fast_task = true }
 end

--- a/test/helpers/maintenance_tasks/application_helper_test.rb
+++ b/test/helpers/maintenance_tasks/application_helper_test.rb
@@ -16,5 +16,15 @@ module MaintenanceTasks
       expects(:pagy_bulma_nav).with(@pagy).returns('pagination')
       assert_equal 'pagination', pagination(@pagy)
     end
+
+    test '#formatted_datetime returns time element with local datetime and ISO 8601 UTC time in title attribute' do
+      time = Time.zone.local(2020, 01, 01, 01, 00, 00)
+
+      datetime = '2020-01-01T01:00:00Z'
+      title = '2020-01-01T01:00:00Z'
+      text = 'January 01, 2020 01:00'
+      exp = "<time datetime=\"#{datetime}\" title=\"#{title}\">#{text}</time>"
+      assert_equal exp, formatted_datetime(time)
+    end
   end
 end

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -4,8 +4,6 @@ require 'application_system_test_case'
 
 module MaintenanceTasks
   class RunsTest < ApplicationSystemTestCase
-    setup { freeze_time }
-
     test 'run a task' do
       visit maintenance_tasks_path
 
@@ -14,7 +12,7 @@ module MaintenanceTasks
 
       assert_title 'Maintenance::UpdatePostsTask'
       assert_text 'Task Maintenance::UpdatePostsTask enqueued.'
-      assert_table with_rows: [[I18n.l(Time.now.utc)]]
+      assert_table with_rows: [['January 01, 2020 01:00']]
       assert_no_button 'Run'
     end
 
@@ -28,7 +26,7 @@ module MaintenanceTasks
 
       click_on 'Pause'
 
-      assert_table with_rows: [[I18n.l(Time.now.utc), 'paused']]
+      assert_table with_rows: [['January 01, 2020 01:00', 'paused']]
     end
 
     test 'resume a Run' do
@@ -45,7 +43,7 @@ module MaintenanceTasks
         click_on 'Resume'
       end
 
-      assert_table with_rows: [[I18n.l(Time.now.utc), 'enqueued']]
+      assert_table with_rows: [['January 01, 2020 01:00', 'enqueued']]
     end
 
     test 'cancel a Run' do
@@ -58,7 +56,7 @@ module MaintenanceTasks
 
       click_on 'Cancel'
 
-      assert_table with_rows: [[I18n.l(Time.now.utc), 'cancelled']]
+      assert_table with_rows: [['January 01, 2020 01:00', 'cancelled']]
     end
 
     test 'run a task that errors' do
@@ -74,7 +72,7 @@ module MaintenanceTasks
 
       assert_table with_rows: [
         [
-          I18n.l(Time.now.utc),
+          'January 01, 2020 01:00',
           'errored',
           'ArgumentError',
           'Something went wrong',

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -22,7 +22,6 @@ module MaintenanceTasks
     end
 
     test 'lists active runs' do
-      freeze_time
       visit maintenance_tasks_path
 
       click_on 'Maintenance::UpdatePostsTask'
@@ -31,7 +30,7 @@ module MaintenanceTasks
       visit maintenance_tasks_path
 
       assert_table with_rows: [
-        ['Maintenance::UpdatePostsTask', I18n.l(Time.now.utc)],
+        ['Maintenance::UpdatePostsTask', 'January 01, 2020 01:00'],
       ]
     end
 


### PR DESCRIPTION
Closes https://github.com/Shopify/maintenance_tasks/issues/89

- Adds a `title` attribute to our `datetime` table cells so that we show the UTC time on hover
- Adds `Last updated at` column to our views
- Configures a timezone for our dummy app
- Changes `Time.now` -> `Time.current`, so we ensure our tests use the Rails application configured time instead of the system time

## 🎩 
<img width="1680" alt="Screen Shot 2020-10-26 at 12 15 20 PM" src="https://user-images.githubusercontent.com/22918438/97206714-77a50e00-178f-11eb-8356-7589e688efcd.png">

