### PR TITLE
Enforce warnings as errors

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,4 +24,11 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.fixtures(:all)
 end
 
+module Warning
+  def self.warn(message)
+    raise message.to_s
+  end
+end
+$VERBOSE = true
+
 Maintenance::UpdatePostsTask.fast_task = true


### PR DESCRIPTION
This prevents us from introducing warnings by turning on verbose mode (which adds the warnings) and raising when a warning happens, both of these in tests.