### PR TITLE
Show only ticks if tick_total is 0

### DIFF
--- a/app/helpers/maintenance_tasks/task_helper.rb
+++ b/app/helpers/maintenance_tasks/task_helper.rb
@@ -20,7 +20,7 @@ module MaintenanceTasks
     # @param run [Run] the run for which the ticks are formatted.
     # @return [String] the progress information properly formatted.
     def format_ticks(run)
-      if run.tick_total
+      if run.tick_total.to_i > 0
         safe_join([
           tag.progress(value: run.tick_count, max: run.tick_total,
             class: 'progress is-small'),

--- a/test/helpers/maintenance_tasks/task_helper_test.rb
+++ b/test/helpers/maintenance_tasks/task_helper_test.rb
@@ -15,9 +15,14 @@ module MaintenanceTasks
       assert_equal expected_trace, format_backtrace(backtrace)
     end
 
-    test '#format_ticks only shows the ticks if tick_total is not set' do
+    test '#format_ticks shows only the ticks if tick_total is not set' do
       run = Run.new(tick_count: 42)
       assert_equal '42', format_ticks(run)
+    end
+
+    test '#format_ticks shows only the ticks if tick_total is 0' do
+      run = Run.new(tick_count: 0, tick_total: 0)
+      assert_equal '0', format_ticks(run)
     end
 
     test '#format_ticks renders a <progress> element' do


### PR DESCRIPTION
Recently encountered a situation where I reset my db, so `Post.count` was equal to `0`.
This resulted in a NaN error in `format_ticks` when I tried to run `Maintenance::UpdatePostsTask`, because it tried to divide by 0.

We should ensure the `tick_total` is not 0 before computing the progress value.