### PR TITLE
Use tags for Run statuses

### DIFF
--- a/app/helpers/maintenance_tasks/task_helper.rb
+++ b/app/helpers/maintenance_tasks/task_helper.rb
@@ -31,6 +31,26 @@ module MaintenanceTasks
       end
     end
 
+    # Renders a span with a Run's status, with the corresponding tag class
+    # attached.
+    #
+    # @param status [String] the status for the Run.
+    # @return [String] the span element containing the status, with the
+    #   appropriate tag class attached.
+    def status_tag(status)
+      tag_labels = {
+        'enqueued' => 'primary',
+        'running' => 'info',
+        'interrupted' => 'warning',
+        'paused' => 'warning',
+        'succeeded' => 'success',
+        'cancelled' => 'dark',
+        'errored' => 'danger',
+      }
+
+      tag.span(status, class: "tag is-#{tag_labels.fetch(status)}")
+    end
+
     private
 
     def progress_text(run)

--- a/app/views/maintenance_tasks/tasks/index.html.erb
+++ b/app/views/maintenance_tasks/tasks/index.html.erb
@@ -24,7 +24,7 @@
       <tr>
         <td><%= link_to run.task_name, task_path(run.task_name) %></td>
         <td><%= l run.created_at %></td>
-        <td><%= run.status %></td>
+        <td><%= status_tag(run.status) %></td>
         <td><%= format_ticks(run) %></td>
       </tr>
     <% end %>

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -35,7 +35,7 @@
     <% @runs.each do |run| %>
       <tr>
         <td><%= l run.created_at %></td>
-        <td><%= run.status %></td>
+        <td><%= status_tag(run.status) %></td>
         <td><%= format_ticks(run) %></td>
         <td><%= run.error_class %></td>
         <td><%= run.error_message %></td>

--- a/test/helpers/maintenance_tasks/task_helper_test.rb
+++ b/test/helpers/maintenance_tasks/task_helper_test.rb
@@ -35,5 +35,22 @@ module MaintenanceTasks
       run = Run.new(tick_count: 999, tick_total: 1000)
       assert_equal '999 / 1000 (99%)', progress_text(run)
     end
+
+    test '#status_tag renders a span with the appropriate tag based on status' do
+      tag_classes = {
+        'enqueued' => 'tag is-primary',
+        'running' => 'tag is-info',
+        'interrupted' => 'tag is-warning',
+        'paused' => 'tag is-warning',
+        'succeeded' => 'tag is-success',
+        'cancelled' => 'tag is-dark',
+        'errored' => 'tag is-danger',
+      }
+
+      tag_classes.each do |status, tag_class|
+        expected_result = "<span class=\"#{tag_class}\">#{status}</span>"
+        assert_equal expected_result, status_tag(status)
+      end
+    end
   end
 end


### PR DESCRIPTION
Our Run tables could use a little extra colour! I've made use of Bulma's [tag](https://bulma.io/documentation/elements/tag/) element to highlight Run statuses with a different coloured tag, depending on the status.

Maybe `cancelled` could be red as well to match the `Cancel` button 🤔 

Let me know what you think!

## 🎩 
![Screen Shot 2020-10-26 at 4 56 16 PM](https://user-images.githubusercontent.com/22918438/97228035-b8f7e680-17ac-11eb-9779-7228755aa03f.png)
![Screen Shot 2020-10-26 at 4 58 41 PM](https://user-images.githubusercontent.com/22918438/97228039-b9907d00-17ac-11eb-8baf-606f5d4f461f.png)
![Screen Shot 2020-10-26 at 4 59 54 PM](https://user-images.githubusercontent.com/22918438/97228042-ba291380-17ac-11eb-8086-845b8a92fd97.png)
