### PR TITLE
Rename Task#task_iteration as Task#process

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Or subclass your ApplicationTask and implement:
 
 * `collection`: return an Active Record Relation or an Array to be iterated
   over.
-* `task_iteration`: do the work of your maintenance task on a single record
+* `process`: do the work of your maintenance task on a single record
 * `count`: return the number of rows that will be iterated over (optional,
   to be able to show progress)
 
@@ -47,7 +47,7 @@ module Maintenance
       collection.count
     end
 
-    def task_iteration(post)
+    def process(post)
       post.update!(content: 'New content!')
     end
   end

--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -40,7 +40,7 @@ module MaintenanceTasks
     # @param _run [Run] the current Run, passed as an argument by Job Iteration.
     def each_iteration(input, _run)
       throw(:abort, :skip_complete_callbacks) if task_stopped?
-      @task.task_iteration(input)
+      @task.process(input)
       @ticker.tick
     end
 

--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -85,9 +85,9 @@ module MaintenanceTasks
     #
     # @raise [NotImplementedError] with a message advising subclasses to
     #   implement an override for this method.
-    def task_iteration(_item)
+    def process(_item)
       raise NotImplementedError,
-        "#{self.class.name} must implement `task_iteration`."
+        "#{self.class.name} must implement `process`."
     end
 
     # Total count of iterations to be performed.

--- a/test/dummy/app/tasks/maintenance/error_task.rb
+++ b/test/dummy/app/tasks/maintenance/error_task.rb
@@ -5,7 +5,7 @@ module Maintenance
       [1, 2]
     end
 
-    def task_iteration(*)
+    def process(*)
       raise ArgumentError, 'Something went wrong'
     end
   end

--- a/test/dummy/app/tasks/maintenance/update_posts_task.rb
+++ b/test/dummy/app/tasks/maintenance/update_posts_task.rb
@@ -15,7 +15,7 @@ module Maintenance
       collection.count
     end
 
-    def task_iteration(post)
+    def process(post)
       sleep(1) unless self.class.fast_task
 
       post.update!(content: "New content added on #{Time.now.utc}")

--- a/test/helpers/maintenance_tasks/task_helper_test.rb
+++ b/test/helpers/maintenance_tasks/task_helper_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'test_helper'
 
 module MaintenanceTasks
@@ -6,11 +7,11 @@ module MaintenanceTasks
     test '#format_backtrace converts the backtrace to a formatted string' do
       backtrace = [
         "app/jobs/maintenance/error_task.rb:13:in `foo'",
-        "app/jobs/maintenance/error_task.rb:9:in `task_iteration'",
+        "app/jobs/maintenance/error_task.rb:9:in `process'",
       ]
 
       expected_trace = 'app/jobs/maintenance/error_task.rb:13:in `foo&#39;' \
-        '<br>app/jobs/maintenance/error_task.rb:9:in `task_iteration&#39;'
+        '<br>app/jobs/maintenance/error_task.rb:9:in `process&#39;'
 
       assert_equal expected_trace, format_backtrace(backtrace)
     end

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -76,7 +76,7 @@ module MaintenanceTasks
           'errored',
           'ArgumentError',
           'Something went wrong',
-          "app/tasks/maintenance/error_task.rb:9:in `task_iteration'",
+          "app/tasks/maintenance/error_task.rb:9:in `process'",
         ],
       ]
     end

--- a/test/tasks/maintenance_tasks/task_test.rb
+++ b/test/tasks/maintenance_tasks/task_test.rb
@@ -55,11 +55,11 @@ module MaintenanceTasks
       assert_equal message, error.message
     end
 
-    test '#task_iteration raises NotImplementedError' do
+    test '#process raises NotImplementedError' do
       error = assert_raises(NotImplementedError) do
-        Task.new.task_iteration('an item')
+        Task.new.process('an item')
       end
-      message = 'MaintenanceTasks::Task must implement `task_iteration`.'
+      message = 'MaintenanceTasks::Task must implement `process`.'
       assert_equal message, error.message
     end
 


### PR DESCRIPTION
Since we are about to ship V1 I would like to make sure that our API is getting its final form, and that includes revisiting the names we are using.

This is a proposal to rename the `task_iteration` method that every Task should implement as `process`. I think it's a simpler and easier to understand name for such important part of our API.