### PR TITLE
Rename Task#task_count to Task#count

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Or subclass your ApplicationTask and implement:
 * `collection`: return an Active Record Relation or an Array to be iterated
   over.
 * `task_iteration`: do the work of your maintenance task on a single record
-* `task_count`: return the number of rows that will be iterated over (optional,
+* `count`: return the number of rows that will be iterated over (optional,
   to be able to show progress)
 
 ### Example
@@ -43,7 +43,7 @@ module Maintenance
       Post.all
     end
 
-    def task_count
+    def count
       collection.count
     end
 

--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -53,7 +53,7 @@ module MaintenanceTasks
     end
 
     def job_started
-      @run.update!(tick_total: @task.task_count)
+      @run.update!(tick_total: @task.count)
     end
 
     def job_completed

--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -97,7 +97,7 @@ module MaintenanceTasks
     # undefined, or counting would be prohibitive for your database.
     #
     # @return [Integer, nil]
-    def task_count
+    def count
     end
 
     # Convenience method to allow tasks define enumerators with cursors for

--- a/test/dummy/app/tasks/maintenance/update_posts_task.rb
+++ b/test/dummy/app/tasks/maintenance/update_posts_task.rb
@@ -11,7 +11,7 @@ module Maintenance
       Post.all
     end
 
-    def task_count
+    def count
       collection.count
     end
 

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -9,7 +9,7 @@ module MaintenanceTasks
         [1, 2]
       end
 
-      def task_count
+      def count
         collection.count
       end
     end

--- a/test/tasks/maintenance_tasks/task_test.rb
+++ b/test/tasks/maintenance_tasks/task_test.rb
@@ -44,9 +44,9 @@ module MaintenanceTasks
       assert_nil Maintenance::UpdatePostsTask.active_run
     end
 
-    test '#task_count is nil by default' do
+    test '#count is nil by default' do
       task = Task.new
-      assert_nil task.task_count
+      assert_nil task.count
     end
 
     test '#collection raises NotImplementedError' do


### PR DESCRIPTION
Since we are about to ship V1 I would like to make sure that our API is getting its final form, and that includes revisiting the names we are using.

This is a proposal to rename the `task_count` method that every Task should implement as `count`. The `task_` prefix is redundant and unnecessary (and yeah, this was redundant also).