### PR TITLE
Use the test queue adapter in system tests

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,6 +3,8 @@
 require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  include ActiveJob::TestHelper
+
   driven_by :rack_test
 
   setup { Maintenance::UpdatePostsTask.fast_task = false }

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -41,9 +41,7 @@ module MaintenanceTasks
 
       click_on 'Pause'
 
-      with_queue_adapter(:test) do
-        click_on 'Resume'
-      end
+      click_on 'Resume'
 
       assert_table with_rows: [[I18n.l(Time.now.utc), 'enqueued']]
     end
@@ -66,7 +64,7 @@ module MaintenanceTasks
 
       click_on 'Maintenance::ErrorTask'
 
-      with_queue_adapter(:inline) do
+      perform_enqueued_jobs do
         click_on 'Run'
       end
 
@@ -81,16 +79,6 @@ module MaintenanceTasks
           "app/tasks/maintenance/error_task.rb:9:in `task_iteration'",
         ],
       ]
-    end
-
-    private
-
-    def with_queue_adapter(adapter)
-      original_adapter = TaskJob.queue_adapter
-      TaskJob.queue_adapter = adapter
-      yield
-    ensure
-      TaskJob.queue_adapter = original_adapter
     end
   end
 end


### PR DESCRIPTION
We've seen some flakiness when running the tests:
* the tick counter being 12 instead of 2 (in task_job_test):
```
Failure:
MaintenanceTasks::TaskJobTest#test_.perform_now_updates_tick_count [/Users/etienne/src/github.com/Shopify/maintenance_tasks/test/jobs/maintenance_tasks/task_job_test.rb:70]:
Expected: 2
  Actual: 12
```
* another wrong tick count:
```
Failure:
MaintenanceTasks::TaskJobTest#test_.perform_now_updates_tick_count [/Users/etienne/src/github.com/Shopify/maintenance_tasks/test/jobs/maintenance_tasks/task_job_test.rb:70]:
Expected: 2
  Actual: 3
```

* wrong tick count when interrupted:
```
Failure:
MaintenanceTasks::TaskJobTest#test_.perform_now_updates_tick_count_when_job_is_interrupted [/Users/etienne/src/github.com/Shopify/maintenance_tasks/test/jobs/maintenance_tasks/task_job_test.rb:79]:
Expected: 1
  Actual: 2
```

* the DB being locked (in task_job_test)

This is all related to the system tests enqueuing task jobs and not waiting for them to finish.