### PR TITLE
Replace per-Task ticker delay config with a global config

### DIFF
--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -91,7 +91,7 @@ module MaintenanceTasks
     end
 
     def setup_ticker
-      @ticker = Ticker.new(@task.minimum_duration_for_tick_update) do |ticks|
+      @ticker = Ticker.new(MaintenanceTasks.ticker_delay) do |ticks|
         @run.increment_ticks(ticks)
       end
     end

--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -5,15 +5,6 @@ module MaintenanceTasks
   class Task
     extend ActiveSupport::DescendantsTracker
 
-    # After each iteration, the progress of the task may be updated.
-    # This duration in seconds limits these updates, skipping if the duration
-    # since the last update is lower than this value, except if the job is
-    # interrupted, in which case the progress will always be recorded.
-    #
-    # @api private
-    class_attribute :minimum_duration_for_tick_update, default: 1.0,
-      instance_accessor: false, instance_predicate: false, instance_reader: true
-
     class << self
       # Controls the value of abstract_class, which indicates whether the class
       # is abstract or not. Abstract classes are excluded from the list of

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -17,6 +17,15 @@ module MaintenanceTasks
   # @param [String] the name of the job class.
   mattr_writer :job, default: 'MaintenanceTasks::TaskJob'
 
+  # After each iteration, the progress of the task may be updated. This duration
+  # in seconds limits these updates, skipping if the duration since the last
+  # update is lower than this value, except if the job is interrupted, in which
+  # case the progress will always be recorded.
+  #
+  # @param [ActiveSupport::Duration, Numeric] Duration of the delay to update
+  #   the ticker during Task iterations.
+  mattr_accessor :ticker_delay, default: 1.second
+
   # Retrieves the module that Tasks are namespaced in.
   #
   # @return [Module] the constantized tasks_module value.

--- a/test/dummy/app/tasks/maintenance/update_posts_task.rb
+++ b/test/dummy/app/tasks/maintenance/update_posts_task.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 module Maintenance
   class UpdatePostsTask < MaintenanceTasks::Task
-    self.minimum_duration_for_tick_update = 2.seconds
-
     class << self
       attr_accessor :fast_task
     end


### PR DESCRIPTION
In the spirit of simplifying our configs prior to our release, as well as avoiding dead code, this PR replaces the ticker delay config, currently per-Task, with a global config in the Maintenance Task module.

I think everything that is configurable should be done in a uniform way. Right now we are adding config in that module with no individual setting per-Task. Also we don't know if there is even a need for specific config per Task. Let's ship global configs only and see if the need arises for specific configs in Tasks, which can be added in subsequent releases.