### PR TITLE
Task generator for generating new maintenance tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ $ rails generate maintenance_tasks:install
 
 ## Usage
 
-TODO: You can generate tasks using:
+A generator is provided to create tasks. Generate a new task by running:
 
 ```bash
-$ rails generate maintenance_task
-```
+$ rails generate maintenance_task update_posts
 
-Or subclass `MaintenanceTasks::Task` and implement:
+This creates the task file `app/tasks/maintenance/update_posts_task.rb`.
+
+The generated task is a subclass of `MaintenanceTasks::Task` that implements:
 
 * `collection`: return an Active Record Relation or an Array to be iterated
   over.

--- a/lib/generators/maintenance_task_generator.rb
+++ b/lib/generators/maintenance_task_generator.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Generator used for creating maintenance tasks in the host application.
+#
+# @api private
+class MaintenanceTaskGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path('templates', __dir__)
+  desc 'This generator creates a task file at app/tasks/maintenance'
+
+  check_class_collision suffix: 'Task'
+
+  # Creates the Task file.
+  def create_task_file
+    template_file = File.join(
+      'app/tasks/maintenance',
+      class_path,
+      "#{file_name}_task.rb"
+    )
+    template('task.rb', template_file)
+  end
+
+  # Create the Task test file.
+  def create_task_test_file
+    template_file = File.join(
+      'test/tasks/maintenance',
+      class_path,
+      "#{file_name}_task_test.rb"
+    )
+    template('task_test.rb', template_file)
+  end
+
+  private
+
+  def file_name
+    super.sub(/_task\z/i, '')
+  end
+end

--- a/lib/generators/templates/task.rb.tt
+++ b/lib/generators/templates/task.rb.tt
@@ -1,0 +1,19 @@
+module Maintenance
+<% module_namespacing do -%>
+  class <%= class_name %>Task < MaintenanceTasks::Task
+    def collection
+      # Collection to be iterated over
+      # Must be Active Record Relation or Array
+    end
+
+    def process(element)
+      # The work to be done in a single iteration of the task
+    end
+
+    def count
+      # Optionally, define the number of rows that will be iterated over
+      # This is used to track the task's progress
+    end
+  end
+<% end -%>
+end

--- a/lib/generators/templates/task_test.rb.tt
+++ b/lib/generators/templates/task_test.rb.tt
@@ -1,0 +1,10 @@
+require 'test_helper'
+module Maintenance
+<% module_namespacing do -%>
+  class <%= class_name %>TaskTest < ActiveSupport::TestCase
+    # test "the truth" do
+    #   assert true
+    # end
+  end
+<% end -%>
+end

--- a/test/lib/generators/maintenance_task_generator_test.rb
+++ b/test/lib/generators/maintenance_task_generator_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'generators/maintenance_task_generator'
+
+class MaintenanceTaskGeneratorTest < Rails::Generators::TestCase
+  tests MaintenanceTaskGenerator
+  SAMPLE_APP_PATH = MaintenanceTasks::Engine.root.join('tmp/sample_app')
+  destination SAMPLE_APP_PATH
+  setup :prepare_destination
+
+  def teardown
+    FileUtils.rm_rf(SAMPLE_APP_PATH)
+  end
+
+  test 'generator creates task skeleton and task test' do
+    run_generator ['sleepy']
+    assert_file 'app/tasks/maintenance/sleepy_task.rb' do |task|
+      assert_match(/module Maintenance/, task)
+      assert_match(/class SleepyTask < MaintenanceTasks::Task/, task)
+      assert_match(/def collection/, task)
+      assert_match(/def process\(element\)/, task)
+      assert_match(/def count/, task)
+    end
+    assert_file 'test/tasks/maintenance/sleepy_task_test.rb' do |task_test|
+      assert_match(/module Maintenance/, task_test)
+      assert_match(
+        /class SleepyTaskTest < ActiveSupport::TestCase/,
+        task_test
+      )
+    end
+  end
+
+  test 'generator namespaces task properly' do
+    run_generator ['admin/sleepy']
+    assert_file 'app/tasks/maintenance/admin/sleepy_task.rb' do |task|
+      assert_match(/class Admin::SleepyTask < MaintenanceTasks::Task/, task)
+    end
+  end
+
+  test 'generator does not duplicate task suffix' do
+    run_generator ['sleepy_task']
+
+    assert_no_file 'app/tasks/maintenance/sleepy_task_task.rb'
+    assert_file 'app/tasks/maintenance/sleepy_task.rb'
+  end
+end


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/105

Creates a `MaintenanceTaskGenerator` that can be invoked using `rails generate maintenance_tasks foo`, which will create `foo_task.rb` in `app/tasks/maintenance`, as well as `test/tasks/maintenance/foo_task_test.rb`.

Generated tasks have a template that follows the API we've outlined in the README.