### PR TITLE
Declare constants as private

### DIFF
--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -2,9 +2,12 @@
 
 module MaintenanceTasks
   # Base class for all controllers used by this engine.
+  #
+  # @api private
   class ApplicationController < ActionController::Base
     include Pagy::Backend
 
     protect_from_forgery with: :exception
   end
+  private_constant :ApplicationController
 end

--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -3,6 +3,8 @@
 module MaintenanceTasks
   # Class communicates with the Run model to persist info related to task runs.
   # It defines actions for creating and pausing runs.
+  #
+  # @api private
   class RunsController < ApplicationController
     before_action :set_run, only: [:pause, :cancel, :resume]
     before_action :set_task
@@ -49,4 +51,5 @@ module MaintenanceTasks
       @task = Task.named(params.fetch(:task_id))
     end
   end
+  private_constant :RunsController
 end

--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -3,6 +3,8 @@ module MaintenanceTasks
   # Class handles rendering the maintenance_tasks page in the host application.
   # It makes data about available, enqueued, performing, and completed
   # tasks accessible to the views so it can be displayed in the UI.
+  #
+  # @api private
   class TasksController < ApplicationController
     # Renders the maintenance_tasks/tasks page, displaying
     # available tasks to users.
@@ -28,4 +30,5 @@ module MaintenanceTasks
       @refresh = 5
     end
   end
+  private_constant :TasksController
 end

--- a/app/helpers/maintenance_tasks/application_helper.rb
+++ b/app/helpers/maintenance_tasks/application_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module MaintenanceTasks
   # Module for common view helpers.
+  #
+  # @api private
   module ApplicationHelper
     include Pagy::Frontend
 
@@ -23,4 +25,5 @@ module MaintenanceTasks
       time_tag(datetime, title: datetime.utc.iso8601)
     end
   end
+  private_constant :ApplicationHelper
 end

--- a/app/helpers/maintenance_tasks/task_helper.rb
+++ b/app/helpers/maintenance_tasks/task_helper.rb
@@ -2,6 +2,8 @@
 
 module MaintenanceTasks
   # Helpers for formatting data in the maintenance_tasks views.
+  #
+  # @api private
   module TaskHelper
     # Formats a run backtrace.
     #
@@ -59,4 +61,5 @@ module MaintenanceTasks
         "(#{number_to_percentage(percentage.floor, precision: 0)})"
     end
   end
+  private_constant :TaskHelper
 end

--- a/app/models/maintenance_tasks/application_record.rb
+++ b/app/models/maintenance_tasks/application_record.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 module MaintenanceTasks
   # Base class for all records used by this engine.
+  #
+  # @api private
   class ApplicationRecord < ActiveRecord::Base
     self.abstract_class = true
   end
+  private_constant :ApplicationRecord
 end

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module MaintenanceTasks
   # Model that persists information related to a task being run from the UI.
+  #
+  # @api private
   class Run < ApplicationRecord
     # Various statuses a run can be in:
     #
@@ -58,4 +60,5 @@ module MaintenanceTasks
       self.class.update_counters(id, tick_count: number_of_ticks, touch: true)
     end
   end
+  private_constant :Run
 end

--- a/app/models/maintenance_tasks/ticker.rb
+++ b/app/models/maintenance_tasks/ticker.rb
@@ -52,4 +52,5 @@ module MaintenanceTasks
       Time.now - @last_persisted >= @throttle_duration
     end
   end
+  private_constant :Ticker
 end

--- a/app/validators/maintenance_tasks/run_status_validator.rb
+++ b/app/validators/maintenance_tasks/run_status_validator.rb
@@ -2,6 +2,8 @@
 module MaintenanceTasks
   # Custom validator class responsible for ensuring that transitions between
   # Run statuses are valid.
+  #
+  # @api private
   class RunStatusValidator < ActiveModel::Validator
     # Valid status transitions a Run can make.
     VALID_STATUS_TRANSITIONS = {
@@ -43,4 +45,5 @@ module MaintenanceTasks
       )
     end
   end
+  private_constant :RunStatusValidator
 end

--- a/lib/generators/maintenance_tasks/install_generator.rb
+++ b/lib/generators/maintenance_tasks/install_generator.rb
@@ -3,6 +3,8 @@ module MaintenanceTasks
   # Generator used to set up the engine in the host application.
   # It handles mounting the engine, installing migrations
   # and creating some required files.
+  #
+  # @api private
   class InstallGenerator < Rails::Generators::Base
     source_root File.expand_path('templates', __dir__)
 
@@ -33,4 +35,5 @@ module MaintenanceTasks
       )
     end
   end
+  private_constant :InstallGenerator
 end

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -3,11 +3,13 @@
   Post.create!(title: "Post ##{i}", content: "Content ##{i}")
 end
 
-10.times do
-  MaintenanceTasks::Run.create!(
-    task_name: 'Maintenance::UpdatePostsTask',
-    tick_count: 10,
-    tick_total: 10,
-    status: :succeeded
-  )
+module MaintenanceTasks
+  10.times do
+    Run.create!(
+      task_name: 'Maintenance::UpdatePostsTask',
+      tick_count: 10,
+      tick_total: 10,
+      status: :succeeded
+    )
+  end
 end

--- a/test/lib/maintenance_tasks_test.rb
+++ b/test/lib/maintenance_tasks_test.rb
@@ -24,4 +24,21 @@ class MaintenanceTasksTest < ActiveSupport::TestCase
   ensure
     MaintenanceTasks.job = original_job
   end
+
+  test "doesn't leak its internals" do
+    expected_public_constants = [
+      :Engine,  # to mount
+      :Task,    # to define tasks
+      :TaskJob, # to customize the job
+    ]
+    public_constants = MaintenanceTasks.constants.select do |constant|
+      constant =
+        eval("MaintenanceTasks::#{constant}") # rubocop:disable Security/Eval
+      next if constant.is_a?(Class) && constant < Minitest::Test
+      true
+    rescue NameError
+      false
+    end
+    assert_equal expected_public_constants.sort, public_constants.sort
+  end
 end


### PR DESCRIPTION
This PR declares the classes as private API with the `@api private` YARD tag which shows a big warning.

<img width="764" alt="image" src="https://user-images.githubusercontent.com/3535/97750388-0fc03180-1ac7-11eb-9814-7a9105857b6a.png">

Also the constants themselves are private so that users have to jump through hoops to get to them.