### PR TITLE
Fix dependency on ActiveRecord by loading the railtie

### DIFF
--- a/lib/maintenance_tasks/engine.rb
+++ b/lib/maintenance_tasks/engine.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'active_record/railtie'
+
 module MaintenanceTasks
   # The engine's main class, which defines its namespace. The engine is mounted
   # by the host application.


### PR DESCRIPTION
So in #114 I only loaded the gems, but not the railtie, but as mentioned in https://github.com/Shopify/maintenance_tasks/pull/114#discussion_r515259086 we actually need it, at least ActiveRecord.

It fails like this:
```
$ rails new --skip-javascript --skip-spring --skip-git --skip-active-record maintenance_tasks_example
$ cd maintenance_tasks_example
$ echo 'gem "maintenance_tasks", path: "../maintenance_tasks"' >> Gemfile
$ rails generate maintenance_tasks:install
       route  mount MaintenanceTasks::Engine => '/maintenance_tasks'
        rake  maintenance_tasks:install:migrations
rake aborted!
Don't know how to build task 'app:railties:install:migrations' (See the list of available tasks with `rake --tasks`)
/Users/etienne/.gem/ruby/2.7.1/gems/railties-6.0.3.4/lib/rails/engine.rb:646:in `block (4 levels) in <class:Engine>'
Tasks: TOP => maintenance_tasks:install:migrations
(See full trace by running task with --trace)
        rake  db:migrate
rake aborted!
Don't know how to build task 'db:migrate' (See the list of available tasks with `rake --tasks`)

(See full trace by running task with --trace)
```

@rafaelfranca I'm not sure how to test whether we need to load the other railties, it's not obvious if they're needed, how would I know?