### PR TITLE
Remove the maintenance_tasks initializer

### DIFF
--- a/lib/generators/maintenance_tasks/install_generator.rb
+++ b/lib/generators/maintenance_tasks/install_generator.rb
@@ -17,14 +17,6 @@ module MaintenanceTasks
       rake('db:migrate')
     end
 
-    # Creates an initializer file for the engine in the host application
-    def create_initializer
-      template(
-        'maintenance_tasks.rb',
-        'config/initializers/maintenance_tasks.rb'
-      )
-    end
-
     # Creates ApplicationTask class for task classes to subclass
     def create_application_task
       template(

--- a/lib/generators/maintenance_tasks/templates/maintenance_tasks.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/maintenance_tasks.rb.tt
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-# Custom configuration for the tasks namespace can be defined here, ie.
-# MaintenanceTasks.tasks_module = 'Maintenance'

--- a/test/dummy/config/initializers/maintenance_tasks.rb
+++ b/test/dummy/config/initializers/maintenance_tasks.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-# Custom configuration for the tasks namespace can be defined here, ie.
-# MaintenanceTasks.tasks_module = 'Maintenance'

--- a/test/lib/generators/maintenance_tasks/install_generator_test.rb
+++ b/test/lib/generators/maintenance_tasks/install_generator_test.rb
@@ -36,7 +36,6 @@ module MaintenanceTasks
         end
 
         assert_file('app/tasks/maintenance/application_task.rb')
-        assert_file('config/initializers/maintenance_tasks.rb')
       end
     end
 
@@ -47,7 +46,6 @@ module MaintenanceTasks
 
       Dir.chdir(SAMPLE_APP_PATH) do
         FileUtils.rm_r('db')
-        FileUtils.rm('config/initializers/maintenance_tasks.rb')
         FileUtils.rm('app/tasks/maintenance/application_task.rb')
       end
     end


### PR DESCRIPTION
Let's assume our default works for most cases. If we have an app that needs to configure `MaintenanceTasks.tasks_module` we can create the initializer by hand. That way we won't introduce unnecessary code into apps using this gem. We can opt to document the config option in the `README` instead.