### PR TITLE
Provide button to main app root from maintenance_tasks page

### DIFF
--- a/app/views/maintenance_tasks/tasks/index.html.erb
+++ b/app/views/maintenance_tasks/tasks/index.html.erb
@@ -57,3 +57,4 @@
     </tr>
   </tfoot>
 </table>
+<%= button_to 'Back to main application', main_app.root_path, method: :get, class: 'button is-link' %>


### PR DESCRIPTION
We should provide a link to return to the main app's root from the Maintenance Tasks page.

![Screen Shot 2020-11-02 at 8 46 34 AM](https://user-images.githubusercontent.com/22918438/97875301-2f827000-1ce8-11eb-95c7-023b527a30f8.png)
