### PR TITLE
Remove Application Task from install generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ TODO: You can generate tasks using:
 $ rails generate maintenance_task
 ```
 
-Or subclass your ApplicationTask and implement:
+Or subclass `MaintenanceTasks::Task` and implement:
 
 * `collection`: return an Active Record Relation or an Array to be iterated
   over.
@@ -38,7 +38,7 @@ Or subclass your ApplicationTask and implement:
 ```ruby
 # app/tasks/maintenance/update_posts_task.rb
 module Maintenance
-  class UpdatePostsTask < ApplicationTask
+  class UpdatePostsTask < MaintenanceTasks::Task
     def collection
       Post.all
     end
@@ -69,14 +69,14 @@ If no value is specified, it will default to `Maintenance`.
 
 `MaintenanceTasks.job` can be configured to define a Job class for your tasks
 to use. This is a global configuration, so this Job class will be used across
-all maintenance tasks in your application. 
+all maintenance tasks in your application.
 ```ruby
 # config/initializers/maintenance_tasks.rb
 MaintenanceTasks.job = 'CustomTaskJob'
 
 # app/jobs/custom_task_job.rb
 class CustomTaskJob < MaintenanceTasks::TaskJob
-  queue_as :low_priority 
+  queue_as :low_priority
 end
 ```
 The Job class **must inherit** from `MaintenanceTasks::TaskJob`.

--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -6,18 +6,6 @@ module MaintenanceTasks
     extend ActiveSupport::DescendantsTracker
 
     class << self
-      # Controls the value of abstract_class, which indicates whether the class
-      # is abstract or not. Abstract classes are excluded from the list of
-      # available_tasks.
-      #
-      # @return [Boolean] the value of abstract_class
-      attr_accessor :abstract_class
-
-      # @return [Boolean] whether or not the class is abstract
-      def abstract_class?
-        defined?(@abstract_class) && @abstract_class == true
-      end
-
       # Given the name of a Task, returns the Task subclass. Returns nil if
       # there's no task with that name.
       def named(name)
@@ -26,13 +14,13 @@ module MaintenanceTasks
         nil
       end
 
-      # Returns a list of concrete classes that inherit from
-      # the Task superclass.
+      # Returns a list of concrete classes that inherit from the Task
+      # superclass.
       #
       # @return [Array<Class>] the list of classes.
       def available_tasks
         load_constants
-        descendants.reject(&:abstract_class?)
+        descendants
       end
 
       # Returns the set of Run records associated with the Task.

--- a/lib/generators/maintenance_tasks/install_generator.rb
+++ b/lib/generators/maintenance_tasks/install_generator.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 module MaintenanceTasks
-  # Generator used to set up the engine in the host application.
-  # It handles mounting the engine, installing migrations
-  # and creating some required files.
+  # Generator used to set up the engine in the host application. It handles
+  # mounting the engine and installing migrations.
   #
   # @api private
   class InstallGenerator < Rails::Generators::Base
@@ -17,14 +16,6 @@ module MaintenanceTasks
     def install_migrations
       rake('maintenance_tasks:install:migrations')
       rake('db:migrate')
-    end
-
-    # Creates ApplicationTask class for task classes to subclass
-    def create_application_task
-      template(
-        'application_task.rb',
-        'app/tasks/maintenance/application_task.rb'
-      )
     end
   end
   private_constant :InstallGenerator

--- a/lib/generators/maintenance_tasks/templates/application_task.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/application_task.rb.tt
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-module Maintenance
-  class ApplicationTask < MaintenanceTasks::Task
-    self.abstract_class = true
-  end
-end

--- a/test/dummy/app/tasks/maintenance/application_task.rb
+++ b/test/dummy/app/tasks/maintenance/application_task.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-module Maintenance
-  class ApplicationTask < MaintenanceTasks::Task
-    self.abstract_class = true
-  end
-end

--- a/test/lib/generators/maintenance_tasks/install_generator_test.rb
+++ b/test/lib/generators/maintenance_tasks/install_generator_test.rb
@@ -18,7 +18,7 @@ module MaintenanceTasks
       FileUtils.rm_rf(SAMPLE_APP_PATH)
     end
 
-    test 'generator mounts engine, runs migrations, and creates required files' do
+    test 'generator mounts engine and runs migrations' do
       Dir.chdir(SAMPLE_APP_PATH) do
         run_generator
 
@@ -34,8 +34,6 @@ module MaintenanceTasks
         assert_file('db/schema.rb') do |contents|
           assert_match(/create_table "maintenance_tasks_runs"/, contents)
         end
-
-        assert_file('app/tasks/maintenance/application_task.rb')
       end
     end
 
@@ -46,7 +44,6 @@ module MaintenanceTasks
 
       Dir.chdir(SAMPLE_APP_PATH) do
         FileUtils.rm_r('db')
-        FileUtils.rm('app/tasks/maintenance/application_task.rb')
       end
     end
   end

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -19,11 +19,6 @@ module MaintenanceTasks
       refute run.valid?
     end
 
-    test 'invalid if the task is abstract' do
-      run = Run.new(task_name: 'Maintenance::ApplicationTask')
-      refute run.valid?
-    end
-
     test '#increment_ticks persists an increment to the tick count' do
       run = Run.create!(
         task_name: 'Maintenance::UpdatePostsTask',


### PR DESCRIPTION
This superclass is just polluting the main app. We don't have a concrete usage for such extra layer of inheritance. We can revisit this later once real user needs exist.