### PR TITLE
Use the test task from the Rails engine

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up database
       run: bundle exec rails db:setup
     - name: Ruby Tests
-      run: bundle exec rails test
+      run: bundle exec rails app:test
     - name: System Tests
       run: bundle exec rails app:test:system
     - name: RuboCop

--- a/Rakefile
+++ b/Rakefile
@@ -21,14 +21,7 @@ load('rails/tasks/statistics.rake')
 
 require 'bundler/gem_tasks'
 
-require 'rake/testtask'
-Rake::TestTask.new(:test) do |t|
-  t.libs << 'test'
-  t.pattern = 'test/**/*_test.rb'
-  t.verbose = false
-end
-
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
-task(default: ['db:setup', :test, 'rubocop'])
+task(default: ['db:setup', 'app:test', 'app:test:system', 'rubocop'])

--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -62,4 +62,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Whitelist host used in integration tests.
+  config.hosts << 'www.example.com'
 end


### PR DESCRIPTION
We are currently loading a `test` Rake task to run our tests. However the engine already has a task for that: `app:test`. It runs all tests except the system tests. Those are run with `app:test:system`.

This PR removes the custom `test` task in favour of `app:test`. It also updates the default Rake test to run all the tests, including system test, so we can always run `bundle exec rake` to run the entire suite and RuboCop.