### PR TITLE
Create version.rb

### DIFF
--- a/lib/maintenance_tasks/version.rb
+++ b/lib/maintenance_tasks/version.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+module MaintenanceTasks
+  VERSION = '0.1.0'
+end

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
+require_relative 'lib/maintenance_tasks/version'
 
 Gem::Specification.new do |spec|
   spec.name = 'maintenance_tasks'
-  spec.version = '0.1.0'
+  spec.version = MaintenanceTasks::VERSION
   spec.author = 'Shopify Engineering'
   spec.email = 'gems@shopify.com'
   spec.homepage = 'https://github.com/Shopify/maintenance_tasks'

--- a/test/lib/maintenance_tasks_test.rb
+++ b/test/lib/maintenance_tasks_test.rb
@@ -30,6 +30,7 @@ class MaintenanceTasksTest < ActiveSupport::TestCase
       :Engine,  # to mount
       :Task,    # to define tasks
       :TaskJob, # to customize the job
+      :VERSION, # to specify the gem version in gemspec
     ]
     public_constants = MaintenanceTasks.constants.select do |constant|
       constant =


### PR DESCRIPTION
Move the version specification to its own `version.rb` file. I think it makes sense to have version changes limited to a single file, rather than having to change the gemspec each time.