### PR TITLE
Disable query cache when loading Run status in #task_stopped?

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -67,7 +67,9 @@ module MaintenanceTasks
     #
     # @return [MaintenanceTasks::Run] the Run record with its updated status.
     def reload_status
-      updated_status = Run.where(id: id).pluck(:status).first
+      updated_status = Run.uncached do
+        Run.where(id: id).pluck(:status).first
+      end
       self.status = updated_status
       clear_attribute_changes([:status])
       self


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/127

We need to disable query cache when loading the run status in `task_job` so that we don't delay in pausing / cancelling a task until a tick count has been persisted. More details in the issue.