### PR TITLE
Refactor run status reloading in TaskJob

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -72,6 +72,14 @@ module MaintenanceTasks
       clear_attribute_changes([:status])
       self
     end
+
+    # Returns whether the Run is stopped, which is defined as
+    # having a status of paused or cancelled.
+    #
+    # @return [Boolean] whether the Run is stopped.
+    def stopped?
+      paused? || cancelled?
+    end
   end
   private_constant :Run
 end

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -38,5 +38,20 @@ module MaintenanceTasks
       assert_predicate run, :running?
       refute run.changed?
     end
+
+    test '#stopped? returns true if status is paused or cancelled' do
+      run = Run.new(task_name: 'Maintenance::UpdatePostsTask')
+
+      (Run.statuses.keys - ['paused', 'cancelled']).each do |status|
+        run.status = status
+        refute_predicate run, :stopped?
+      end
+
+      run.status = :paused
+      assert_predicate run, :stopped?
+
+      run.status = :cancelled
+      assert_predicate run, :stopped?
+    end
   end
 end


### PR DESCRIPTION
Currently, our solution for "refreshing" `@run`'s status in `task_job.rb` is brittle and overly convoluted.
We rely on `task_stopped?` to reload the run status and check if it's one we care about here:
```
    def task_stopped?
      @task_stopped ||= begin
        run = Run.select(:status).find(@run.id)
        run.paused? || run.cancelled?
      end
```
And then we _also_ memoize to save ourselves an extra query in `shutdown_job`.

This approach complicates things if we want to persist additional data, such as a `completed_at` timestamp in `each_iteration` when a job is cancelled.
```
    def each_iteration(input, _run)
      @run.reload_status
      if task_stopped?
         # I want to persist `completed_at` but now i need a way to check the up-to-date status 
         # again to see if it's cancelled not paused
         ...
      end
```

A more favourable approach that @etiennebarrie and I settled on was having the `@run` be responsible for reloading its own status when necessary. This allows us to drop the unnecessary complexity of the memoziation, and keeps the number of reads to the db the same. It is a lot easier to see what's going on in `task_job` this way.

To accomplish this, the run grabs its status from the db using `updated_status = Run.where(id: id).pluck(:status).first`, sets it's status to that value, and then uses `clear_attribute_changes([:status])` to mark itself as unchanged.