### PR TITLE
Use configured tasks_module in Task generator

### DIFF
--- a/lib/generators/maintenance_tasks/task_generator.rb
+++ b/lib/generators/maintenance_tasks/task_generator.rb
@@ -6,14 +6,14 @@ module MaintenanceTasks
   # @api private
   class TaskGenerator < Rails::Generators::NamedBase
     source_root File.expand_path('templates', __dir__)
-    desc 'This generator creates a task file at app/tasks/maintenance'
+    desc 'This generator creates a task file at app/tasks.'
 
     check_class_collision suffix: 'Task'
 
     # Creates the Task file.
     def create_task_file
       template_file = File.join(
-        'app/tasks/maintenance',
+        "app/tasks/#{tasks_module_file_path}",
         class_path,
         "#{file_name}_task.rb"
       )
@@ -23,7 +23,7 @@ module MaintenanceTasks
     # Create the Task test file.
     def create_task_test_file
       template_file = File.join(
-        'test/tasks/maintenance',
+        "test/tasks/#{tasks_module_file_path}",
         class_path,
         "#{file_name}_task_test.rb"
       )
@@ -34,6 +34,14 @@ module MaintenanceTasks
 
     def file_name
       super.sub(/_task\z/i, '')
+    end
+
+    def tasks_module
+      MaintenanceTasks.tasks_module
+    end
+
+    def tasks_module_file_path
+      tasks_module.to_s.underscore
     end
   end
   private_constant :TaskGenerator

--- a/lib/generators/maintenance_tasks/templates/task.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/task.rb.tt
@@ -1,4 +1,6 @@
-module Maintenance
+# frozen_string_literal: true
+
+module <%= tasks_module %>
 <% module_namespacing do -%>
   class <%= class_name %>Task < MaintenanceTasks::Task
     def collection

--- a/lib/generators/maintenance_tasks/templates/task_test.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/task_test.rb.tt
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
 require 'test_helper'
-module Maintenance
+
+module <%= tasks_module %>
 <% module_namespacing do -%>
   class <%= class_name %>TaskTest < ActiveSupport::TestCase
     # test "the truth" do

--- a/test/lib/generators/maintenance_tasks/task_generator_test.rb
+++ b/test/lib/generators/maintenance_tasks/task_generator_test.rb
@@ -31,6 +31,20 @@ module MaintenanceTasks
       end
     end
 
+    test 'generator uses configured tasks module' do
+      previous_task_module = MaintenanceTasks.tasks_module.name
+      Object.const_set('Foo', Module.new {})
+      MaintenanceTasks.tasks_module = 'Foo'
+
+      run_generator(['sleepy'])
+      assert_file('app/tasks/foo/sleepy_task.rb') do |task|
+        assert_match(/module Foo/, task)
+      end
+    ensure
+      MaintenanceTasks.tasks_module = previous_task_module
+      Object.send(:remove_const, :Foo)
+    end
+
     test 'generator namespaces task properly' do
       run_generator ['admin/sleepy']
       assert_file 'app/tasks/maintenance/admin/sleepy_task.rb' do |task|


### PR DESCRIPTION
I _think_ last time we chatted about this we decided the generators could just use the default configs, but we might as well use the configured `tasks_module` in the Task generator. 