### PR TITLE
Hide tick progress if task is still enqueued

### DIFF
--- a/app/helpers/maintenance_tasks/task_helper.rb
+++ b/app/helpers/maintenance_tasks/task_helper.rb
@@ -17,11 +17,14 @@ module MaintenanceTasks
     # Formats the ticks.
     #
     # Only shows the ticks or if the total is available, shows the ticks,
-    # total and percentage.
+    # total and percentage. Does not show ticks if run has not started.
     #
     # @param run [Run] the run for which the ticks are formatted.
-    # @return [String] the progress information properly formatted.
+    # @return [String, nil] the progress information properly formatted, or
+    #   nil if the run has not started yet.
     def format_ticks(run)
+      return unless run.started?
+
       if run.tick_total.to_i > 0
         safe_join([
           tag.progress(value: run.tick_count, max: run.tick_total,

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -82,6 +82,14 @@ module MaintenanceTasks
     def stopped?
       paused? || cancelled?
     end
+
+    # Returns whether the Run has been started, which is indicated by the
+    # started_at timestamp being present.
+    #
+    # @return [Boolean] whether the Run was started.
+    def started?
+      started_at.present?
+    end
   end
   private_constant :Run
 end

--- a/test/helpers/maintenance_tasks/task_helper_test.rb
+++ b/test/helpers/maintenance_tasks/task_helper_test.rb
@@ -17,17 +17,22 @@ module MaintenanceTasks
     end
 
     test '#format_ticks shows only the ticks if tick_total is not set' do
-      run = Run.new(tick_count: 42)
+      run = Run.new(tick_count: 42, started_at: Time.now)
       assert_equal '42', format_ticks(run)
     end
 
     test '#format_ticks shows only the ticks if tick_total is 0' do
-      run = Run.new(tick_count: 0, tick_total: 0)
+      run = Run.new(tick_count: 0, tick_total: 0, started_at: Time.now)
       assert_equal '0', format_ticks(run)
     end
 
+    test '#format_ticks returns nil if the run has not started' do
+      run = Run.new(tick_count: 0, tick_total: 10)
+      assert_nil format_ticks(run)
+    end
+
     test '#format_ticks renders a <progress> element' do
-      run = Run.new(tick_count: 42, tick_total: 84)
+      run = Run.new(tick_count: 42, tick_total: 84, started_at: Time.now)
       render(inline: '<%= format_ticks(run) %>', locals: { run: run })
       assert_select 'progress[value=42][max=84]'
     end

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -65,6 +65,19 @@ module MaintenanceTasks
       assert_predicate run, :stopped?
     end
 
+    test '#started? returns false if the Run has no started_at timestamp' do
+      run = Run.new(task_name: 'Maintenance::UpdatePostsTask')
+      refute_predicate run, :started?
+    end
+
+    test '#started? returns true if the Run has a started_at timestamp' do
+      run = Run.new(
+        task_name: 'Maintenance::UpdatePostsTask',
+        started_at: Time.now
+      )
+      assert_predicate run, :started?
+    end
+
     private
 
     def count_uncached_queries(&block)

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -13,7 +13,7 @@ module MaintenanceTasks
       assert_title 'Maintenance::UpdatePostsTask'
       assert_text 'Task Maintenance::UpdatePostsTask enqueued.'
       assert_table with_rows: [
-        ['January 09, 2020 09:41', '', 'enqueued', '0', '', '', '', ''],
+        ['January 09, 2020 09:41', '', 'enqueued', '', '', '', ''],
       ]
       assert_no_button 'Run'
     end
@@ -26,7 +26,7 @@ module MaintenanceTasks
       click_on 'Pause'
 
       assert_table with_rows: [
-        ['January 09, 2020 09:41', '', 'paused', '0', '', '', '', ''],
+        ['January 09, 2020 09:41', '', 'paused', '', '', '', ''],
       ]
     end
 
@@ -39,7 +39,7 @@ module MaintenanceTasks
       click_on 'Resume'
 
       assert_table with_rows: [
-        ['January 09, 2020 09:41', '', 'enqueued', '0', '', '', '', ''],
+        ['January 09, 2020 09:41', '', 'enqueued', '', '', '', ''],
       ]
     end
 
@@ -51,7 +51,7 @@ module MaintenanceTasks
       click_on 'Cancel'
 
       assert_table with_rows: [
-        ['January 09, 2020 09:41', '', 'cancelled', '0', '', '', '', ''],
+        ['January 09, 2020 09:41', '', 'cancelled', '', '', '', ''],
       ]
     end
 

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -48,7 +48,7 @@ module MaintenanceTasks
           'Maintenance::UpdatePostsTask',
           'January 09, 2020 09:41',
           'enqueued',
-          '0',
+          '',
         ],
       ]
     end


### PR DESCRIPTION
Closes: Hide tick progress if task enqueued
See also: https://github.com/Shopify/maintenance_tasks/issues/133

This PR prevents the progress from being shown in the UI before the task has started running. Since we only compute the `tick_total` on job start, it results in a not-so-pretty `0` being shown in the progress column up until the point the task starts.

We hide progress unless `Run.started?`.