### PR TITLE
Introducing the Runner class

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ $ bundle
 $ rails generate maintenance_tasks:install
 ```
 
+The generator creates and runs a migration to add the necessary table to your
+database. It also mounts Mainteance Tasks in your `config/routes.rb`. By default
+the web UI can be accessed in the new `/maintenance_tasks` path.
+
 ## Usage
+
+### Creating a Task
 
 A generator is provided to create tasks. Generate a new task by running:
 
@@ -37,7 +43,7 @@ The generated task is a subclass of `MaintenanceTasks::Task` that implements:
 * `count`: return the number of rows that will be iterated over (optional,
   to be able to show progress)
 
-### Example
+Example:
 
 ```ruby
 # app/tasks/maintenance/update_posts_task.rb
@@ -56,6 +62,17 @@ module Maintenance
     end
   end
 end
+```
+
+### Running a Task
+
+You can run your new Task by accessing the Web UI and clicking on "Run".
+
+You can also run a Task in Ruby by sending `run` with a Task name to a Runner
+instance:
+
+```ruby
+MaintenanceTasks::Runner.new.run('Mainteance::UpdatePostsTask')
 ```
 
 ### Configuring the Gem

--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -13,13 +13,10 @@ module MaintenanceTasks
     #
     # Creates a new Run with the given parameters.
     def create
-      run = Run.new(task_name: @task.name)
-      if run.enqueue
-        redirect_to(task_path(@task), notice: "Task #{run.task_name} enqueued.")
-      else
-        errors = run.errors.full_messages.join(' ')
-        redirect_to(task_path(@task), notice: errors)
-      end
+      Runner.new.run(name: @task.name)
+      redirect_to(task_path(@task), notice: "Task #{@task.name} enqueued.")
+    rescue Runner::RunError => error
+      redirect_to(task_path(@task), notice: error.message)
     end
 
     # Updates a Run status to paused.

--- a/app/models/maintenance_tasks/runner.rb
+++ b/app/models/maintenance_tasks/runner.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module MaintenanceTasks
+  # This class is responsible for running a given Task.
+  class Runner
+    class RunError < StandardError; end
+
+    # Runs a Task.
+    #
+    # This method creates a Run record for the given Task name and enqueues the
+    # Run.
+    #
+    # @param name [String] the name of the Task to be run.
+    #
+    # @raise [RunError] if validation errors occur while creating the Run.
+    def run(name:)
+      run = Run.new(task_name: name)
+      unless run.enqueue
+        raise RunError, run.errors.full_messages.join(' ')
+      end
+    end
+  end
+end

--- a/test/lib/maintenance_tasks_test.rb
+++ b/test/lib/maintenance_tasks_test.rb
@@ -28,6 +28,7 @@ class MaintenanceTasksTest < ActiveSupport::TestCase
   test "doesn't leak its internals" do
     expected_public_constants = [
       :Engine,  # to mount
+      :Runner,  # to run a Task
       :Task,    # to define tasks
       :TaskJob, # to customize the job
     ]

--- a/test/models/maintenance_tasks/runner_test.rb
+++ b/test/models/maintenance_tasks/runner_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module MaintenanceTasks
+  class RunnerTest < ActiveSupport::TestCase
+    setup do
+      @name = 'Maintenance::UpdatePostsTask'
+      @run = mock
+      @runner = Runner.new
+    end
+
+    test '#run creates a Run for the given Task name and enqueues the Run' do
+      Run.expects(:new).with(task_name: @name).returns(@run)
+      @run.expects(enqueue: true)
+
+      @runner.run(name: @name)
+    end
+
+    test '#run raises a Run Error with validation errors when Run enqueue fails' do
+      Run.expects(:new).with(task_name: @name).returns(@run)
+      @run.expects(enqueue: false)
+      @run.expects(errors: mock(full_messages: ['error 1', 'error 2']))
+
+      error = assert_raises(Runner::RunError) do
+        @runner.run(name: @name)
+      end
+      assert_equal 'error 1 error 2', error.message
+    end
+  end
+end


### PR DESCRIPTION
This PR sets the foundation for us to have a standard, reusable way to run Tasks in our controllers, binaries, or externally as a Ruby API.

As previously discussed, `Runner#run` will raise in case the Run fails to save due to validation errors. The controller then rescues the error message and renders it as a flash notice.