### PR TITLE
Fix ETA for paused tasks

### DIFF
--- a/db/migrate/20201026180058_create_maintenance_tasks_runs.rb
+++ b/db/migrate/20201026180058_create_maintenance_tasks_runs.rb
@@ -5,7 +5,6 @@ class CreateMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
       t.string(:task_name, null: false)
       t.datetime(:started_at)
       t.datetime(:ended_at)
-      t.datetime(:last_resumed_at)
       t.float(:time_running, default: 0, null: false)
       t.integer(:tick_count, default: 0, null: false)
       t.integer(:tick_total)

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -16,7 +16,6 @@ ActiveRecord::Schema.define(version: 2020_10_26_180058) do
     t.string "task_name", null: false
     t.datetime "started_at"
     t.datetime "ended_at"
-    t.datetime "last_resumed_at"
     t.float "time_running", default: 0.0, null: false
     t.integer "tick_count", default: 0, null: false
     t.integer "tick_total"

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -178,34 +178,7 @@ module MaintenanceTasks
       TaskJob.perform_now(@run)
     end
 
-    test '.perform_now persists last_resumed_at to Run if the job was paused and resumes' do
-      freeze_time
-
-      @run.pausing!
-      @run.update!(status: :paused, time_running: 1.minute)
-
-      TestTask.any_instance.expects(:process).twice
-
-      @run.enqueued!
-      TaskJob.perform_now(@run)
-
-      assert_equal Time.now, @run.reload.last_resumed_at
-    end
-
-    test '.perform_now does not persist last_resumed_at to Run if job was interrupted and re-enqueued' do
-      JobIteration.stubs(interruption_adapter: -> { true })
-      TestTask.any_instance.expects(:process).twice
-
-      TaskJob.perform_now(@run)
-
-      assert_predicate @run.reload, :interrupted?
-
-      TaskJob.perform_now(@run)
-
-      assert_nil @run.reload.last_resumed_at
-    end
-
-    test '.perform_now tells Run to adjust time_running during shutdown' do
+    test '.perform_now adjusts time_running on Run during shutdown' do
       TestTask.any_instance.expects(:process).twice
 
       TaskJob.perform_now(@run)

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -151,38 +151,6 @@ module MaintenanceTasks
       assert_equal Time.now, run.ended_at
     end
 
-    test "#adjust_time_running sets time_running to the difference between now and Run's started_at" do
-      freeze_time
-      run = Run.new(
-        task_name: 'Maintenance::UpdatePostsTask',
-        started_at: Time.now
-      )
-
-      travel 2.seconds
-
-      run.adjust_time_running
-      assert_equal 2, run.time_running
-    end
-
-    test '#adjust_time_running adds to existing time_running if Run has last_resumed_at timestamp' do
-      freeze_time
-      started_at = Time.now
-      travel 2.seconds
-
-      run = Run.create!(
-        task_name: 'Maintenance::UpdatePostsTask',
-        started_at: started_at,
-        time_running: 2
-      )
-
-      run.update!(status: :running, last_resumed_at: Time.now)
-
-      travel 1.second
-
-      run.adjust_time_running
-      assert_equal 3, run.time_running
-    end
-
     test '#estimated_completion_time computes completion time correctly when run is paused' do
       started_at = Time.utc(2020, 1, 9, 9, 41, 44)
       travel_to started_at + 9.seconds
@@ -219,7 +187,7 @@ module MaintenanceTasks
 
       travel 2.minutes
 
-      run.assign_attributes(status: :running, last_resumed_at: Time.now)
+      run.assign_attributes(status: :running, latest_running_at: Time.now)
 
       expected_completion_time = Time.utc(2020, 1, 9, 9, 43, 54)
       assert_equal expected_completion_time, run.estimated_completion_time
@@ -240,7 +208,7 @@ module MaintenanceTasks
       run.assign_attributes(status: :paused, time_running: 6.seconds)
 
       travel 2.minutes
-      run.assign_attributes(status: :running, last_resumed_at: Time.now)
+      run.assign_attributes(status: :running, latest_running_at: Time.now)
 
       travel 2.seconds
       run.tick_count = 8


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/154

Right now, the `#estimated_completion_time` method in `Run` is not accurate for paused runs, because it computes the ETA based on the total time elapsed since the run started, including time while paused. This PR solves that problem by introducing 2 new columns on the `maintenance_tasks_runs` table: `:last_paused_at` and `:time_paused`. The two new columns are used as follows:
- When a run is paused in `task_job.rb`, we update the `:last_paused_at` timestamp
- In the `job_running` callback (ie. right before a `TaskJob` starts performing), we check if the run has a `:last_paused_at` timestamp - if it does, we calculate the time that has passed since the Run was paused, and update `:time_paused` with that amount. Note that `:time_paused` is the aggregate across all periods where the Run was paused.

Then, we update `#estimated_completion_time`:
- If the `run` is currently paused, ETA is the time the Run was last paused, less the start time, less the amount of `time_paused` (in case the run was paused before, we need to factor this in)
- If the `run` is _not_ paused, but has a  `:last_paused_at`, ETA is the current time minus the start time, less any amount of `time_paused`
- Else (the run is not paused, and has never been paused), ETA is what we had before - current time minus the start time.