### PR TITLE
Move Resume logic to Runner

### DIFF
--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -9,16 +9,6 @@ module MaintenanceTasks
     before_action :set_run, only: [:pause, :cancel, :resume]
     before_action :set_task
 
-    # POST /maintenance_tasks/runs
-    #
-    # Creates a new Run with the given parameters.
-    def create
-      Runner.new.run(name: @task.name)
-      redirect_to(task_path(@task), notice: "Task #{@task.name} enqueued.")
-    rescue Runner::RunError => error
-      redirect_to(task_path(@task), notice: error.message)
-    end
-
     # Updates a Run status to paused.
     def pause
       @run.paused!
@@ -28,13 +18,6 @@ module MaintenanceTasks
     # Updates a Run status to cancelled.
     def cancel
       @run.cancelled!
-      redirect_to(task_path(@task))
-    end
-
-    # Updates a Run status from paused to running.
-    def resume
-      @run.enqueued!
-      @run.enqueue
       redirect_to(task_path(@task))
     end
 

--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -24,6 +24,14 @@ module MaintenanceTasks
       set_refresh if @active_run
     end
 
+    # Runs a given Task and redirects to the Task page.
+    def run
+      task = Runner.new.run(name: params.fetch(:id))
+      redirect_to(task_path(task), notice: "Task #{task.name} enqueued.")
+    rescue ActiveRecord::RecordInvalid => error
+      redirect_to(task_path(task), notice: error.message)
+    end
+
     private
 
     def set_refresh

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -44,13 +44,6 @@ module MaintenanceTasks
 
     validates_with RunStatusValidator, on: :update
 
-    # Enqueues the job after validating and persisting the run.
-    def enqueue
-      if save
-        MaintenanceTasks.job.perform_later(self)
-      end
-    end
-
     # Increments +tick_count+ by +number_of_ticks+, directly in the DB.
     # The attribute value is not set in the current instance, you need
     # to reload the record.

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -8,9 +8,9 @@
 
 <div class="buttons">
   <% if @active_run.nil? %>
-    <%= button_to 'Run', task_runs_path(@task), class: 'button is-success' %>
+    <%= button_to 'Run', run_task_path(@task), method: :put, class: 'button is-success' %>
   <% elsif @active_run.paused? %>
-    <%= button_to 'Resume', resume_task_run_path(@task, @active_run), method: :put, class: 'button is-primary' %>
+    <%= button_to 'Resume', run_task_path(@task), method: :put, class: 'button is-primary' %>
   <% else %>
     <%= button_to 'Pause', pause_task_run_path(@task, @active_run), method: :put, class: 'button is-warning' %>
     <%= button_to 'Cancel', cancel_task_run_path(@task, @active_run), method: :put, class: 'button is-danger' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 MaintenanceTasks::Engine.routes.draw do
   resources :tasks, only: [:index, :show], format: false do
-    resources :runs, only: [:create], format: false do
+    member do
+      put 'run'
+    end
+
+    resources :runs, only: [], format: false do
       member do
         put 'pause'
-        put 'resume'
         put 'cancel'
       end
     end

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -3,17 +3,6 @@ require 'test_helper'
 
 module MaintenanceTasks
   class RunTest < ActiveSupport::TestCase
-    include ActiveJob::TestHelper
-
-    test '#enqueue enqueues the Task Job for the current Run' do
-      run = Run.new(task_name: 'Maintenance::UpdatePostsTask')
-
-      assert_enqueued_with job: MaintenanceTasks.job, args: [run] do
-        run.enqueue
-        assert_predicate run, :persisted?
-      end
-    end
-
     test "invalid if the task doesn't exist" do
       run = Run.new(task_name: 'Maintenance::DoesNotExist')
       refute run.valid?


### PR DESCRIPTION
This PR consolidates both `run` and `resume` actions in a single `run` action in Tasks Controller. That action uses a Runner, which internally creates a Run in case an active one doesn't exist yet.

A few caveats, though:

* I couldn't use `find_or_create_by` since "active" includes multiple possible values.
* I couldn't rely on on `Task.active` because at the Runner level I only have a Task name, not a fully fledged Task (yet). Changes on that coming soon in my 404 PR (#146).
* I changed tests to rely on actual records being created and jobs being enqueued instead of mocks. Less unit-teste-y, some may say, but stubbing every single call was getting ridiculous. The problem is just that I can't assert the args for the job in case a Run doesn't exist.