### PR TITLE
Respond with 404 if Task is not found

### DIFF
--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -5,13 +5,20 @@ module MaintenanceTasks
   class Task
     extend ActiveSupport::DescendantsTracker
 
+    class NotFoundError < StandardError; end
+
     class << self
-      # Given the name of a Task, returns the Task subclass. Returns nil if
-      # there's no task with that name.
+      # Finds a Task with the given name.
+      #
+      # @param name [String] the name of the Task to be found.
+      #
+      # @return [Task] the Task with the given name.
+      #
+      # @raise [NotFoundError] if a Task with the given name does not exist.
       def named(name)
         name.constantize
       rescue NameError
-        nil
+        raise NotFoundError
       end
 
       # Returns a list of concrete classes that inherit from the Task

--- a/lib/maintenance_tasks/engine.rb
+++ b/lib/maintenance_tasks/engine.rb
@@ -25,5 +25,9 @@ module MaintenanceTasks
     config.after_initialize do
       eager_load! unless Rails.autoloaders.zeitwerk_enabled?
     end
+
+    config.action_dispatch.rescue_responses.merge!(
+      'MaintenanceTasks::Task::NotFoundError' => :not_found,
+    )
   end
 end

--- a/test/tasks/maintenance_tasks/task_test.rb
+++ b/test/tasks/maintenance_tasks/task_test.rb
@@ -18,8 +18,10 @@ module MaintenanceTasks
       assert_equal expected_task, Task.named('Maintenance::UpdatePostsTask')
     end
 
-    test ".named returns nil if the task doesn't exist" do
-      assert_nil Task.named('Maintenance::DoesNotExist')
+    test ".named raises Not Found Error if the task doesn't exist" do
+      assert_raises Task::NotFoundError do
+        Task.named('Maintenance::DoesNotExist')
+      end
     end
 
     test '.runs returns the Active Record relation of the runs associated with a Task' do


### PR DESCRIPTION
We should respond with 404 when a Task is not found. This change achieves that by raising a specific Task Not Found Error that is then rescued by Action Dispatch which handles it as a not found response.

To tophat how it's going to look like in production simply set your `config.consider_all_requests_local = false` in `development.rb` in the test dummy app.

Fixes #146