### PR TITLE
Fix redirect when there's an exception running/resuming a task

### DIFF
--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -29,7 +29,7 @@ module MaintenanceTasks
       task = Runner.new.run(name: params.fetch(:id))
       redirect_to(task_path(task), notice: "Task #{task.name} enqueued.")
     rescue ActiveRecord::RecordInvalid => error
-      redirect_to(task_path(task), notice: error.message)
+      redirect_to(task_path(error.record.task_name), notice: error.message)
     end
 
     private

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -82,5 +82,21 @@ module MaintenanceTasks
         ],
       ]
     end
+
+    test 'errors are shown' do
+      visit maintenance_tasks_path
+      within('.menu') { click_on('Maintenance::UpdatePostsTask') }
+
+      url = page.current_url
+      using_session(:other_tab) do
+        visit url
+        click_on 'Run'
+        click_on 'Pause'
+      end
+
+      click_on 'Run'
+
+      assert_text 'Validation failed'
+    end
   end
 end


### PR DESCRIPTION
Follow-up to #156

The redirect code is trying to use the task but it doesn't exist since the method raised before returning.

To repro, open a task page with no run in two tabs, then click run in first tab which starts a run, and then run in the second tab, which fails because there's already a run, so it can't move to running to enqueued.