### PR TITLE
Make Task Not Found Error a Name Error

### DIFF
--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -5,7 +5,7 @@ module MaintenanceTasks
   class Task
     extend ActiveSupport::DescendantsTracker
 
-    class NotFoundError < StandardError; end
+    class NotFoundError < NameError; end
 
     class << self
       # Finds a Task with the given name.
@@ -18,7 +18,7 @@ module MaintenanceTasks
       def named(name)
         name.constantize
       rescue NameError
-        raise NotFoundError
+        raise NotFoundError.new("Task #{name} not found.", name)
       end
 
       # Returns a list of concrete classes that inherit from the Task

--- a/test/tasks/maintenance_tasks/task_test.rb
+++ b/test/tasks/maintenance_tasks/task_test.rb
@@ -19,9 +19,11 @@ module MaintenanceTasks
     end
 
     test ".named raises Not Found Error if the task doesn't exist" do
-      assert_raises Task::NotFoundError do
+      error = assert_raises(Task::NotFoundError) do
         Task.named('Maintenance::DoesNotExist')
       end
+      assert_equal 'Task Maintenance::DoesNotExist not found.', error.message
+      assert_equal 'Maintenance::DoesNotExist', error.name
     end
 
     test '.runs returns the Active Record relation of the runs associated with a Task' do


### PR DESCRIPTION
Follow-up #157, use `NameError` for Task Not Found so we can have the name in the error.