### PR TITLE
Whitelist Bulma CDN in Content Security Policy header

### DIFF
--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -7,6 +7,12 @@ module MaintenanceTasks
   class ApplicationController < ActionController::Base
     include Pagy::Backend
 
+    BULMA_CDN = 'https://cdn.jsdelivr.net'
+
+    content_security_policy do |policy|
+      policy.style_src(BULMA_CDN)
+    end
+
     protect_from_forgery with: :exception
   end
   private_constant :ApplicationController

--- a/app/views/layouts/maintenance_tasks/application.html.erb
+++ b/app/views/layouts/maintenance_tasks/application.html.erb
@@ -13,7 +13,7 @@
     <%= csp_meta_tag %>
 
     <%=
-      stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.css',
+      stylesheet_link_tag URI.join(controller.class::BULMA_CDN, 'npm/bulma@0.9.1/css/bulma.css'),
         media: :all,
         integrity: 'sha256-67AR2JVjhMZCLVxapLuBSMap5RrXbksv4vlllenHBSE=',
         crossorigin: 'anonymous'

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -17,5 +17,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     Maintenance::UpdatePostsTask.fast_task = false
   end
 
-  teardown { Maintenance::UpdatePostsTask.fast_task = true }
+  teardown do
+    assert_empty page.driver.browser.manage.logs.get(:browser)
+    Maintenance::UpdatePostsTask.fast_task = true
+  end
 end

--- a/test/dummy/config/initializers/content_security_policy.rb
+++ b/test/dummy/config/initializers/content_security_policy.rb
@@ -5,25 +5,23 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
+Rails.application.config.content_security_policy do |policy|
+  policy.base_uri(:none)
+  policy.default_src(:self)
+  policy.object_src(:none)
+  policy.script_src(:self, :strict_dynamic)
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+  policy.block_all_mixed_content
 
-# If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator =
-#   -> request { SecureRandom.base64(16) }
+  # Specify URI for violation reports
+  # policy.report_uri "/csp-violation-report-endpoint"
+end
 
-# Set the nonce only to specific directives
-# Rails.application.config.content_security_policy_nonce_directives =
-#   %w(script-src)
+Rails.application.config.content_security_policy_nonce_generator =
+  ->(_request) { SecureRandom.base64(16) }
+
+Rails.application.config.content_security_policy_nonce_directives =
+  ['script-src']
 
 # Report CSP violations to a specified URI
 # For further information see the following documentation:


### PR DESCRIPTION
Fixes #162 

For now the most straightforward solution to prevent Bulma's CSS from being blocked by the main app's CSP header is to override it in our controllers to allow the CDN to be used for style sourcing. I implemented a strict content security policy in the dummy app that blocks any external sources and then whitelisted the CDN only for the Engine. 

I am also adding a check to all system tests to ensure that after each test case there are no logs outputted by the browser. Those are almost always errors and warnings that we should avoid, including sources being blocked by CSP.

cc @elfassy 