### PR TITLE
Use time_running for Run#estimated_completion_time

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -110,7 +110,7 @@ module MaintenanceTasks
     def estimated_completion_time
       return if completed? || tick_count == 0 || tick_total.to_i == 0
 
-      processed_per_second = (tick_count.to_f / (Time.now - started_at))
+      processed_per_second = (tick_count.to_f / time_running)
       ticks_left = (tick_total - tick_count)
       seconds_to_finished = ticks_left / processed_per_second
       Time.now + seconds_to_finished

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -123,7 +123,8 @@ module MaintenanceTasks
         started_at: started_at,
         status: :running,
         tick_count: 9,
-        tick_total: 10
+        tick_total: 10,
+        time_running: 9,
       )
 
       expected_completion_time = Time.utc(2020, 1, 9, 9, 41, 54)


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/154

Please review this very complicated PR with utmost diligence and deep attention.


....

(All our problems are fixed now that we can rely on an up to date `time_running` value on our Run.)