### PR TITLE
Executable to run Maintenance Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ end
 
 You can run your new Task by accessing the Web UI and clicking on "Run".
 
+Alternatively, you can run your Task in the command line:
+
+```bash
+$ bundle exec maintenance_tasks perform Maintenance::UpdatePostsTask
+```
+
 You can also run a Task in Ruby by sending `run` with a Task name to a Runner
 instance:
 

--- a/exe/maintenance_tasks
+++ b/exe/maintenance_tasks
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby -w
+
+# frozen_string_literal: true
+
+require File.expand_path('config/application', Dir.pwd)
+
+Rails.application.require_environment!
+
+require 'maintenance_tasks/cli'
+
+module MaintenanceTasks
+  CLI.start(ARGV)
+end

--- a/lib/maintenance_tasks/cli.rb
+++ b/lib/maintenance_tasks/cli.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'thor'
+
+module MaintenanceTasks
+  # Defines the command line interface commands exposed by Maintenance Tasks in
+  # the executable file.
+  class CLI < Thor
+    class << self
+      # Return a failed exit status in case of an error.
+      def exit_on_failure?
+        true
+      end
+    end
+
+    desc 'perform [TASK NAME]', 'Runs the given Maintenance Task'
+
+    long_desc <<-LONGDESC
+      `maintenance_tasks perform` will run the Mainteance Task specified by the
+      [TASK NAME] argument.
+
+      Available Tasks:
+
+      #{MaintenanceTasks::Task.available_tasks.join("\n\n")}
+    LONGDESC
+
+    # Command to run a Task.
+    #
+    # It instantiates a Runner and sends a run message with the given Task name.
+    #
+    # @param name [String] the name of the Task to be run.
+    def perform(name)
+      task = Runner.new.run(name: name)
+      say_status(:success, "#{task.name} was enqueued.", :green)
+    rescue => error
+      say_status(:error, error.message, :red)
+    end
+  end
+  private_constant :CLI
+end

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |spec|
   }
 
   spec.files = Dir['{app,config,db,lib}/**/*', 'Rakefile', 'README.md']
+  spec.bindir = 'exe'
+  spec.executables = ['maintenance_tasks']
 
   spec.add_dependency('actionpack', '>= 6.0')
   spec.add_dependency('activejob', '>= 6.0')

--- a/test/lib/maintenance_tasks/cli_test.rb
+++ b/test/lib/maintenance_tasks/cli_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'maintenance_tasks/cli'
+
+module MaintenanceTasks
+  class CLITest < ActiveSupport::TestCase
+    setup do
+      @cli = CLI.new
+    end
+
+    test '.exit_on_failure? is true' do
+      assert_predicate CLI, :exit_on_failure?
+    end
+
+    test '#perfom runs the given Task and prints a success message' do
+      task = mock(name: 'MyTask')
+
+      Runner.any_instance.expects(:run).with(name: 'MyTask').returns(task)
+      @cli.expects(:say_status).with(:success, 'MyTask was enqueued.', :green)
+
+      @cli.perform('MyTask')
+    end
+
+    test '#perfom prints an error message when the runner raises' do
+      Runner.any_instance.expects(:run).with(name: 'Wrong').raises('Invalid!')
+      @cli.expects(:say_status).with(:error, 'Invalid!', :red)
+
+      @cli.perform('Wrong')
+    end
+  end
+end


### PR DESCRIPTION
This change adds an executable to the gem so users can enqueue Tasks from the command line. This will enable them to set cron routines to run Tasks repeatedly, for instance.

Note that I am rescuing all standard errors in the new CLI class so we can show a nicely formatted message to Users. But we might want to restrict this to only the error returned by the Runner (which right now is `ActiveRecord::RecordInvalid`, which is a bit weird). As I mentioned previously, I would like to improve things both in the CLI and in the controller by having a more specific error with a nicer message returned. But for now my proposal is to create the executable and then improve the message later.

To 🎩  is very simple:

* cd `test/dummy`
* run `bundle exec maintenance_tasks`

Fixes #147 