### PR TITLE
Remove unnecessary transition pausing -> interrupted

### DIFF
--- a/app/validators/maintenance_tasks/run_status_validator.rb
+++ b/app/validators/maintenance_tasks/run_status_validator.rb
@@ -14,15 +14,13 @@ module MaintenanceTasks
       'enqueued' => ['running', 'pausing', 'cancelling'],
       # pausing -> paused occurs when the task actually halts performing and
       #   occupies a status of paused.
-      # pausing -> interrupted occurs when the job infra shuts down the task
-      #   after it was paused by the user, but before performing halted.
       # pausing -> cancelling occurs when the user cancels a task immediately
       #   after it was paused, such that the task had not actually halted yet.
       # pausing -> succeeded occurs when the task completes immediately after
       #   being paused. This can happen if the task is on its last iteration
       #   when it is paused, or if the task is paused after enqueue but has
       #   nothing in its collection to process.
-      'pausing' => ['paused', 'interrupted', 'cancelling', 'succeeded'],
+      'pausing' => ['paused', 'cancelling', 'succeeded'],
       # cancelling -> cancelled occurs when the task actually halts performing
       #   and occupies a status of cancelled.
       # cancelling -> succeeded occurs when the task completes immediately after

--- a/test/validators/maintenance_tasks/run_status_validator_test.rb
+++ b/test/validators/maintenance_tasks/run_status_validator_test.rb
@@ -167,7 +167,7 @@ module MaintenanceTasks
       assert_no_invalid_transitions([:cancelling, :paused], :cancelled)
     end
 
-    test 'run can go from running or pausing to interrupted' do
+    test 'run can go from running to interrupted' do
       running_run = Run.create!(
         task_name: 'Maintenance::UpdatePostsTask',
         status: :running
@@ -176,15 +176,7 @@ module MaintenanceTasks
 
       assert running_run.valid?
 
-      pausing_run = Run.create!(
-        task_name: 'Maintenance::UpdatePostsTask',
-        status: :pausing
-      )
-      pausing_run.status = :interrupted
-
-      assert pausing_run.valid?
-
-      assert_no_invalid_transitions([:running, :pausing], :interrupted)
+      assert_no_invalid_transitions([:running], :interrupted)
     end
 
     test 'run can go from running to errored' do


### PR DESCRIPTION
The logic in `shutdown_job` looks like this, following the update in https://github.com/Shopify/maintenance_tasks/pull/166:
```ruby
    def shutdown_job
      if @run.cancelling?
        @run.status = :cancelled
        @run.ended_at = Time.now
      else
        @run.status = @run.pausing? ? :paused : :interrupted
        @run.cursor = cursor_position
      end
    end
```

This means that a `pausing` Run actually cannot go to `interrupted`, because it will be transitioned to `paused` instead on shutdown.

We can remove this state transition from the status validator.