### PR TITLE
No update in #job_started if @run is cancelling

### DIFF
--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -56,10 +56,12 @@ module MaintenanceTasks
     end
 
     def job_started
-      @run.update!(
-        started_at: Time.now,
-        tick_total: @task.count
-      )
+      unless @run.cancelling?
+        @run.update!(
+          started_at: Time.now,
+          tick_total: @task.count
+        )
+      end
     end
 
     def shutdown_job

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -102,6 +102,15 @@ module MaintenanceTasks
       assert_equal 2, @run.tick_total
     end
 
+    test '.perform_now does not set started_at or tick_total when the job starts if it is cancelling' do
+      @run.cancelling!
+
+      TaskJob.perform_now(@run)
+
+      assert_nil @run.reload.started_at
+      assert_nil @run.tick_total
+    end
+
     test '.perform_now updates Run to running and persists job_id when job starts performing' do
       TestTask.any_instance.expects(:process).twice.with do
         assert_predicate @run.reload, :running?


### PR DESCRIPTION
Right now, if a user cancels a Task prior to it starting, we still set a `started_at` timestamp and compute the `tick_total` in `TaskJob#job_started`. This is both confusing (why did my job get a `started_at` timestamp, I cancelled it before it started?!) and produces an unnecessary computation (potentially query) in order to set `tick_total`.

I suggest we skip the update to `@run` in `#job_started` in the run is `:cancelling`.