### PR TITLE
[Do not merge] Prevent data races by using optimistic locking

### DIFF
--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -15,9 +15,6 @@ module MaintenanceTasks
       redirect_to(task_path(@task))
     rescue ActiveRecord::RecordInvalid => error
       redirect_to(task_path(@run.task_name), alert: error.message)
-    rescue ActiveRecord::StaleObjectError
-      @run.reload_status
-      retry
     end
 
     # Updates a Run status to cancelling.
@@ -26,9 +23,6 @@ module MaintenanceTasks
       redirect_to(task_path(@task))
     rescue ActiveRecord::RecordInvalid => error
       redirect_to(task_path(@run.task_name), alert: error.message)
-    rescue ActiveRecord::StaleObjectError
-      @run.reload_status
-      retry
     end
 
     private

--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -15,6 +15,9 @@ module MaintenanceTasks
       redirect_to(task_path(@task))
     rescue ActiveRecord::RecordInvalid => error
       redirect_to(task_path(@run.task_name), alert: error.message)
+    rescue ActiveRecord::StaleObjectError
+      @run.reload_status
+      retry
     end
 
     # Updates a Run status to cancelling.
@@ -23,6 +26,9 @@ module MaintenanceTasks
       redirect_to(task_path(@task))
     rescue ActiveRecord::RecordInvalid => error
       redirect_to(task_path(@run.task_name), alert: error.message)
+    rescue ActiveRecord::StaleObjectError
+      @run.reload_status
+      retry
     end
 
     private

--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -53,6 +53,9 @@ module MaintenanceTasks
       @run.job_id = job_id
 
       @run.running! unless @run.stopping?
+    rescue ActiveRecord::StaleObjectError
+      @run.reload_status
+      retry
     end
 
     def job_started
@@ -99,6 +102,7 @@ module MaintenanceTasks
     def setup_ticker
       @ticker = Ticker.new(MaintenanceTasks.ticker_delay) do |ticks, duration|
         @run.persist_progress(ticks, duration)
+        @run.lock_version += 1
       end
     end
 

--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -50,12 +50,7 @@ module MaintenanceTasks
     def job_running
       @run = arguments.first
       @task = Task.named(@run.task_name).new
-      @run.job_id = job_id
-
-      @run.running! unless @run.stopping?
-    rescue ActiveRecord::StaleObjectError
-      @run.reload_status
-      retry
+      @run.run(job_id)
     end
 
     def job_started

--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -59,13 +59,7 @@ module MaintenanceTasks
     end
 
     def job_started
-      @run.update!(
-        started_at: Time.now,
-        tick_total: @task.count
-      )
-    rescue ActiveRecord::StaleObjectError
-      @run.reload_status
-      retry
+      @run.start(@task.count)
     end
 
     def shutdown_job

--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -63,6 +63,9 @@ module MaintenanceTasks
         started_at: Time.now,
         tick_total: @task.count
       )
+    rescue ActiveRecord::StaleObjectError
+      @run.reload_status
+      retry
     end
 
     def shutdown_job

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -55,6 +55,18 @@ module MaintenanceTasks
       retry
     end
 
+    # Sets the job_id, and additionally updates the run status to running
+    # unless the Run is stopping.
+    #
+    # @param job_id [String] the job_id of the job being performed for the Run
+    def run(job_id)
+      self.job_id = job_id
+      running! unless stopping?
+    rescue ActiveRecord::StaleObjectError
+      reload_status
+      retry
+    end
+
     # Starts a Run, setting it's started_at timestamp and tick_total.
     #
     # @param task_count [Integer] the total iterations to be performed, as

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -55,6 +55,10 @@ module MaintenanceTasks
       retry
     end
 
+    # Starts a Run, setting it's started_at timestamp and tick_total.
+    #
+    # @param task_count [Integer] the total iterations to be performed, as
+    #   specified by the Task.
     def start(task_count)
       update!(started_at: Time.now, tick_total: task_count)
     rescue ActiveRecord::StaleObjectError

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -69,18 +69,20 @@ module MaintenanceTasks
       )
     end
 
-    # Refreshes just the status attribute on the Active Record object, and
-    # ensures ActiveModel::Dirty does not mark the object as changed.
-    # This allows us to get the Run's most up-to-date status without needing
-    # to reload the entire record.
+    # Refreshes just the status and lock_version attributes on the ActiveRecord
+    # object, and ensures ActiveModel::Dirty does not mark the object as
+    # changed.
+    # This allows us to get the Run's most up-to-date status without needing to
+    # reload the entire record.
     #
     # @return [MaintenanceTasks::Run] the Run record with its updated status.
     def reload_status
-      updated_status = Run.uncached do
-        Run.where(id: id).pluck(:status).first
+      updated_status, updated_lock_version = Run.uncached do
+        Run.where(id: id).pluck(:status, :lock_version).first
       end
       self.status = updated_status
-      clear_attribute_changes([:status])
+      self.lock_version = updated_lock_version
+      clear_attribute_changes([:status, :lock_version])
       self
     end
 

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -50,6 +50,16 @@ module MaintenanceTasks
     def enqueued!
       status_will_change!
       super
+    rescue ActiveRecord::StaleObjectError
+      reload_status
+      retry
+    end
+
+    def start(task_count)
+      update!(started_at: Time.now, tick_total: task_count)
+    rescue ActiveRecord::StaleObjectError
+      reload_status
+      retry
     end
 
     # Cancels a Run, rescuing and retrying if an ActiveRecord::StaleObjectError

--- a/db/migrate/20201026180058_create_maintenance_tasks_runs.rb
+++ b/db/migrate/20201026180058_create_maintenance_tasks_runs.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 class CreateMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
   def change
-    create_table(:maintenance_tasks_runs) do |t|
+    # TODO: remove force option before 1.0
+    create_table(:maintenance_tasks_runs, force: true) do |t|
+      t.integer(:lock_version, default: 0, null: false)
       t.string(:task_name, null: false)
       t.datetime(:started_at)
       t.datetime(:ended_at)

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -13,6 +13,7 @@
 ActiveRecord::Schema.define(version: 2020_10_26_180058) do
 
   create_table "maintenance_tasks_runs", force: :cascade do |t|
+    t.integer "lock_version", default: 0, null: false
     t.string "task_name", null: false
     t.datetime "started_at"
     t.datetime "ended_at"

--- a/test/fixtures/maintenance_tasks/runs.yml
+++ b/test/fixtures/maintenance_tasks/runs.yml
@@ -1,6 +1,7 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 update_posts_task:
+  lock_version: 4
   task_name: Maintenance::UpdatePostsTask
   tick_count: 10
   tick_total: 10

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -51,6 +51,16 @@ module MaintenanceTasks
       assert_equal Time.now, @run.reload.ended_at
     end
 
+    test '.perform_now handles data race where Run is stale' do
+      Run.find(@run.id).pausing!
+
+      assert_nothing_raised do
+        TaskJob.perform_now(@run)
+      end
+
+      assert_predicate @run.reload, :paused?
+    end
+
     test '.perform_now skips iterations when Run is paused' do
       @run.pausing!
 

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -158,6 +158,28 @@ module MaintenanceTasks
       assert_equal Time.now, run.ended_at
     end
 
+    test '#cancel rescues and retries ActiveRecord::StaleObjectError' do
+      run = Run.create!(task_name: 'Maintenance::UpdatePostsTask')
+      Run.find(run.id).pausing!
+
+      assert_nothing_raised do
+        run.cancel
+      end
+
+      assert_predicate run, :cancelling?
+    end
+
+    test '#pausing! rescues and retries ActiveRecord::StaleObjectError' do
+      run = Run.create!(task_name: 'Maintenance::UpdatePostsTask')
+      Run.find(run.id).running!
+
+      assert_nothing_raised do
+        run.pausing!
+      end
+
+      assert_predicate run, :pausing?
+    end
+
     test '#enqueued! ensures the status is marked as changed' do
       run = Run.new(task_name: 'Maintenance::UpdatePostsTask')
       run.enqueued!

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -22,12 +22,15 @@ module MaintenanceTasks
       assert_equal 12.2, run.time_running
     end
 
-    test '#reload_status reloads status and clears dirty tracking' do
+    test '#reload_status reloads status and lock_version and clears dirty tracking' do
       run = Run.create!(task_name: 'Maintenance::UpdatePostsTask')
-      Run.find(run.id).running!
+      original_lock_version = run.lock_version
 
+      Run.find(run.id).running!
       run.reload_status
+
       assert_predicate run, :running?
+      assert_equal original_lock_version + 1, run.lock_version
       refute run.changed?
     end
 

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -194,6 +194,18 @@ module MaintenanceTasks
       end
     end
 
+    test '#enqueued! rescues and retries ActiveRecord::StaleObjectError' do
+      run = Run.create!(
+        task_name: 'Maintenance::UpdatePostsTask',
+        status: :paused
+      )
+      Run.find(run.id).enqueued!
+
+      assert_raises(ActiveRecord::RecordInvalid) do
+        run.enqueued!
+      end
+    end
+
     private
 
     def count_uncached_queries(&block)


### PR DESCRIPTION
This uses ActiveRecord::Locking::Optimistic to prevent any kind of data races that we don't already expect and handle via status transitions.

We avoided StaleObjectError from the regular flow by keeping the lock version in sync when updating counters ([`update_counters` handles optimistic locking](https://api.rubyonrails.org/classes/ActiveRecord/Locking/Optimistic/ClassMethods.html#method-i-update_counters) but doesn't increment the attribute in memory).
We also refreshed the lock version in `reload_status` so that pauses and cancels still work as expected.

We also audited the code for all the writes, and found a data race that's more uncommon between the active job deserialization (read) and the transition to running (write). The rest of the writes have up-to-date lock version so should be fine.

There should not be any more StaleObjectError exceptions raised in the code but if we missed any, it means there's a data race that needs to be handled.

We did not use the ability to include a lock_version in a form to prevent data races driven by the UI because the transition validation protects from these: we get a 500 when cancelling then pausing in another tab. We may want to fix the 500 with a validation error like resume. Pausing then cancelling works but that's something that lock_version in the form would protect from.

Closes #164 