### PR TITLE
Fix Run transitions to :errored

### DIFF
--- a/app/validators/maintenance_tasks/run_status_validator.rb
+++ b/app/validators/maintenance_tasks/run_status_validator.rb
@@ -20,12 +20,16 @@ module MaintenanceTasks
       #   being paused. This can happen if the task is on its last iteration
       #   when it is paused, or if the task is paused after enqueue but has
       #   nothing in its collection to process.
-      'pausing' => ['paused', 'cancelling', 'succeeded'],
+      # pausing -> errored occurs when the job raises an exception after the
+      #   user has paused it.
+      'pausing' => ['paused', 'cancelling', 'succeeded', 'errored'],
       # cancelling -> cancelled occurs when the task actually halts performing
       #   and occupies a status of cancelled.
       # cancelling -> succeeded occurs when the task completes immediately after
       #   being cancelled. See description for pausing -> succeeded.
-      'cancelling' => ['cancelled', 'succeeded'],
+      # cancelling -> errored occurs when the job raises an exception after the
+      #   user has cancelled it.
+      'cancelling' => ['cancelled', 'succeeded', 'errored'],
       # running -> succeeded occurs when the task completes successfully.
       # running -> pausing occurs when a user pauses the task as
       #   it's performing.

--- a/test/validators/maintenance_tasks/run_status_validator_test.rb
+++ b/test/validators/maintenance_tasks/run_status_validator_test.rb
@@ -179,7 +179,7 @@ module MaintenanceTasks
       assert_no_invalid_transitions([:running], :interrupted)
     end
 
-    test 'run can go from running to errored' do
+    test 'run can go from running, pausing or cancelling to errored' do
       running_run = Run.create!(
         task_name: 'Maintenance::UpdatePostsTask',
         status: :running
@@ -188,7 +188,23 @@ module MaintenanceTasks
 
       assert running_run.valid?
 
-      assert_no_invalid_transitions([:running], :errored)
+      pausing_run = Run.create!(
+        task_name: 'Maintenance::UpdatePostsTask',
+        status: :pausing
+      )
+      pausing_run.status = :errored
+
+      assert pausing_run.valid?
+
+      cancelling_run = Run.create!(
+        task_name: 'Maintenance::UpdatePostsTask',
+        status: :cancelling
+      )
+      cancelling_run.status = :errored
+
+      assert cancelling_run.valid?
+
+      assert_no_invalid_transitions([:running, :pausing, :cancelling], :errored)
     end
 
     private


### PR DESCRIPTION
For: https://github.com/Shopify/maintenance_tasks/issues/188

- `cancelling` and `pausing` runs should be able to transition to `errored`