### PR TITLE
Raise original error in TaskJob#on_error if the run is invalid.

### DIFF
--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -83,6 +83,8 @@ module MaintenanceTasks
     end
 
     def on_error(error)
+      raise error if @run.invalid?
+
       @ticker.persist
 
       @run.update!(

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -210,5 +210,18 @@ module MaintenanceTasks
         'must be either an Active Record Relation or an Array.'
       assert_equal expected_message, @run.error_message
     end
+
+    test 'raises original error in rescue if run is invalid' do
+      run = Run.create!(
+        task_name: 'MaintenanceTasks::TaskJobTest::TestTask',
+        status: :paused,
+      )
+
+      error = assert_raises(ActiveRecord::RecordInvalid) do
+        TaskJob.perform_now(run)
+      end
+      assert_match 'Status Cannot transition run from status paused to running',
+        error.message
+    end
   end
 end


### PR DESCRIPTION
More context here: https://github.com/Shopify/maintenance_tasks/pull/190#issuecomment-735844078

TL;DR: we shouldn't set a run to `errored` because it is invalid. This is indicative that there is something wrong with our code. Legitimate cases where a run becomes invalid should be rescued and surfaced to the user in a way that makes sense, such as here:
https://github.com/Shopify/maintenance_tasks/blob/53e7c1c3e71fd4482cdf0fd3eda055e8666fe6fb/app/controllers/maintenance_tasks/tasks_controller.rb#L32-L34

Consequently, if a run is `invalid` in `TaskJob#on_error`, we should raise the original error. This way we don't:
a) hide the error inside the `Run's ` error attributes if transitioning from the current state to `errored` is valid
(ie. Run updated from `running` -> `enqueued`; this raises validation error, and in `on_error` we would transition to `errored`, which is valid bc `running` -> `errored` is valid, but actually unhelpful bc it isn't obvious an exception resulting from our own code has been raised)
b) raise an unhelpful `Status Cannot transition run from status <some_status> to errored` if transitioning from the current state to `errored` is invalid.
