### PR TITLE
List tasks on index page by active, new, then already-run

### DIFF
--- a/app/helpers/maintenance_tasks/task_helper.rb
+++ b/app/helpers/maintenance_tasks/task_helper.rb
@@ -82,6 +82,28 @@ module MaintenanceTasks
     def time_running_in_words(run)
       distance_of_time_in_words(0, run.time_running, include_seconds: true)
     end
+
+    # Returns the list of Task classes, sorted in the following order:
+    #
+    #   * Active tasks (tasks where the last run is active)
+    #   * New tasks
+    #   * Old tasks (tasks where the last run is completed)
+    #
+    # @param tasks [Array<Class>] the list of Task classes to sort.
+    # @return [Array<Class>] the sorted list of Task classes.
+    def sorted_tasks(tasks)
+      tasks.sort_by do |task|
+        last_run = task.last_run
+
+        if last_run.present? && last_run.active?
+          0
+        elsif last_run.nil?
+          1
+        else
+          2
+        end
+      end
+    end
   end
   private_constant :TaskHelper
 end

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -111,6 +111,15 @@ module MaintenanceTasks
       COMPLETED_STATUSES.include?(status.to_sym)
     end
 
+    # Returns whether the Run is active, which is defined as
+    # having a status of enqueued, running, pausing, cancelling,
+    # paused or interrupted.
+    #
+    # @return [Boolean] whether the Run is active.
+    def active?
+      ACTIVE_STATUSES.include?(status.to_sym)
+    end
+
     # Returns the estimated time the task will finish based on the the number of
     # ticks left and the average time needed to process a tick.
     # Returns nil if the Run is completed, or if the tick_count or tick_total is

--- a/app/views/maintenance_tasks/tasks/index.html.erb
+++ b/app/views/maintenance_tasks/tasks/index.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: 'task', collection: @tasks %>
+<%= render partial: 'task', collection: sorted_tasks(@tasks) %>

--- a/test/helpers/maintenance_tasks/task_helper_test.rb
+++ b/test/helpers/maintenance_tasks/task_helper_test.rb
@@ -64,5 +64,31 @@ module MaintenanceTasks
       @run.time_running = 182.5
       assert_equal '3 minutes', time_running_in_words(@run)
     end
+
+    test '#sorted_tasks orders list of tasks by active, new, then old' do
+      Run.create!(task_name: 'Maintenance::UpdatePostsTask')
+      Run.create!(
+        task_name: 'Maintenance::ErrorTask',
+        status: :errored,
+        started_at: Time.now,
+        ended_at: Time.now,
+      )
+      Maintenance.const_set('FooTask', Class.new(Task) {})
+
+      available_tasks = [
+        Maintenance::ErrorTask,
+        Maintenance::FooTask,
+        Maintenance::UpdatePostsTask,
+      ]
+
+      expected = [
+        Maintenance::UpdatePostsTask,
+        Maintenance::FooTask,
+        Maintenance::ErrorTask,
+      ]
+      assert_equal(expected, sorted_tasks(available_tasks))
+    ensure
+      Maintenance.send(:remove_const, :FooTask)
+    end
   end
 end

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -109,6 +109,20 @@ module MaintenanceTasks
       end
     end
 
+    test '#active? returns true if status is among Run::ACTIVE_STATUSES' do
+      run = Run.new(task_name: 'Maintenance::UpdatePostsTask')
+
+      (Run::STATUSES - Run::ACTIVE_STATUSES).each do |status|
+        run.status = status
+        refute_predicate run, :active?
+      end
+
+      Run::ACTIVE_STATUSES.each do |status|
+        run.status = status
+        assert_predicate run, :active?
+      end
+    end
+
     test '#estimated_completion_time returns nil if the run is completed' do
       run = Run.new(
         task_name: 'Maintenance::UpdatePostsTask',


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/210, https://github.com/Shopify/maintenance_tasks/issues/199

In our lovely new UI (thanks Volmer!), we render task info right with the list of available tasks on the main `maintenance_tasks` page. As previously discussed, it would be nice to surface more relevant tasks at the top of the page.
This PR tweaks `Task.available_tasks` to sort them as follows:
1) Tasks with an active `last_run` go first (so that users can keep an eye on running tasks)
2) New tasks next (ie. tasks with no `last_run`)
3) Tasks with an already-completed `last_run` last (ie. tasks that users have already run).

To 🎩 , I suggest the following:
- With a seeded development db, `ErrorTask` should be at the top (new), and then `UpdatePostsTask`
- If you run `UpdatePostsTask`, you should see it move to the top
- Once it completes, it will move back below `ErrorTask`