### PR TITLE
Refactor progress view helper with a new Progress class

### DIFF
--- a/app/helpers/maintenance_tasks/task_helper.rb
+++ b/app/helpers/maintenance_tasks/task_helper.rb
@@ -39,23 +39,12 @@ module MaintenanceTasks
     def progress(run)
       return unless run.started?
 
-      value = run.tick_count
-      max = run.tick_total
-      title = "Processed #{pluralize(run.tick_count, 'item')}."
-
-      if run.tick_total.to_i > 0
-        percentage = 100.0 * run.tick_count / run.tick_total
-        title = "Processed #{run.tick_count} out of #{run.tick_total} "\
-        "(#{number_to_percentage(percentage.floor, precision: 0)})"
-      else
-        max = run.tick_count
-        value = nil unless run.completed? || run.paused?
-      end
+      progress = Progress.new(run)
 
       tag.progress(
-        value: value,
-        max: max,
-        title: title,
+        value: progress.value,
+        max: progress.max,
+        title: progress.title,
         class: ['progress'] + STATUS_COLOURS.fetch(run.status)
       )
     end

--- a/app/models/maintenance_tasks/progress.rb
+++ b/app/models/maintenance_tasks/progress.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module MaintenanceTasks
+  # This class generates progress information about a Run.
+  class Progress
+    include ActiveSupport::NumberHelper
+
+    # Sets the Progress initial state with a Run.
+    #
+    # @param run [Run] the source of progress information.
+    def initialize(run)
+      @run = run
+    end
+
+    # Defines the value of progress information. This represents the amount that
+    # is already done out of the progress maximum.
+    #
+    # For indefinite-style progress information, value is nil. That highlights
+    # that a Run is in progress but it is not possible to estimate how close to
+    # completion it is.
+    #
+    # When a Run is stopped, the value is present even if there is no total.
+    # That represents a progress information that assumes that the current value
+    # is also equal to is max, showing a progress as completed.
+    #
+    # @return [Integer] if progress can be determined or the Run is stopped.
+    # @return [nil] if progress can't be determined and the Run isn't stopped.
+    def value
+      @run.tick_count if total_present? || @run.stopped?
+    end
+
+    # The maximum amount of work expected to be done. This is extracted from the
+    # Run's tick total attribute when present, or it is equal to the Run's
+    # tick count.
+    #
+    # @return [Integer] the progress maximum amount.
+    def max
+      total_present? ? @run.tick_total : @run.tick_count
+    end
+
+    # The title for the progress information. This is a text that describes the
+    # progress of the Run so far. It includes the percentage that is done out of
+    # the maximum, if an estimate is possible.
+    #
+    # @return [String] the title for the Run progress.
+    def title
+      if total_present?
+        percentage = 100.0 * @run.tick_count / @run.tick_total
+
+        "Processed #{@run.tick_count} out of #{@run.tick_total} "\
+          "(#{number_to_percentage(percentage, precision: 0)})"
+      else
+        "Processed #{@run.tick_count} #{'item'.pluralize(@run.tick_count)}."
+      end
+    end
+
+    private
+
+    def total_present?
+      @run.tick_total.to_i > 0
+    end
+  end
+  private_constant :Progress
+end

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -87,6 +87,14 @@ module MaintenanceTasks
       pausing? || cancelling?
     end
 
+    # Returns whether the Run is stopped, which is defined as having a status of
+    # paused, succeeded, cancelled, or errored.
+    #
+    # @return [Boolean] whether the Run is stopped.
+    def stopped?
+      completed? || paused?
+    end
+
     # Returns whether the Run has been started, which is indicated by the
     # started_at timestamp being present.
     #

--- a/test/models/maintenance_tasks/progress_test.rb
+++ b/test/models/maintenance_tasks/progress_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module MaintenanceTasks
+  class ProgressTest < ActiveSupport::TestCase
+    setup do
+      @run = Run.new(tick_total: 7, tick_count: 4, status: :running)
+      @progress = Progress.new(@run)
+    end
+
+    test '#value is the Run tick count' do
+      assert_equal 4, @progress.value
+    end
+
+    test '#value is nil if the Run does not have a tick total' do
+      @run.tick_total = nil
+      assert_nil @progress.value
+    end
+
+    test '#value is the Run tick count if the Run does not have a tick total and it is stopped' do
+      @run.status = :paused
+      @run.tick_total = nil
+
+      assert_equal 4, @progress.value
+    end
+
+    test '#max is the Run tick total' do
+      assert_equal 7, @progress.max
+    end
+
+    test '#max is the Run tick count if the Run does not have a tick total' do
+      @run.tick_total = nil
+      assert_equal 4, @progress.max
+    end
+
+    test '#title returns a description with tick count, tick total, and percentage' do
+      assert_equal 'Processed 4 out of 7 (57%)', @progress.title
+    end
+
+    test '#title returns a description with tick count when tick total is not present' do
+      @run.tick_total = nil
+      assert_equal 'Processed 4 items.', @progress.title
+    end
+
+    test '#title pluralizes the description according to the tick count' do
+      @run.tick_count = 1
+      @run.tick_total = nil
+      assert_equal 'Processed 1 item.', @progress.title
+    end
+  end
+end

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -57,6 +57,31 @@ module MaintenanceTasks
       assert_predicate run, :stopping?
     end
 
+    test '#stopped? is true if Run is paused' do
+      run = Run.new(task_name: 'Maintenance::UpdatePostsTask')
+
+      run.status = :paused
+      assert_predicate run, :stopped?
+    end
+
+    test '#stopped? is true if Run is completed' do
+      run = Run.new(task_name: 'Maintenance::UpdatePostsTask')
+
+      Run::COMPLETED_STATUSES.each do |status|
+        run.status = status
+        assert_predicate run, :stopped?
+      end
+    end
+
+    test '#stopped? is false if Run is not paused nor completed' do
+      run = Run.new(task_name: 'Maintenance::UpdatePostsTask')
+
+      Run::STATUSES.excluding(Run::COMPLETED_STATUSES, :paused).each do |status|
+        run.status = status
+        refute_predicate run, :stopped?
+      end
+    end
+
     test '#started? returns false if the Run has no started_at timestamp' do
       run = Run.new(task_name: 'Maintenance::UpdatePostsTask')
       refute_predicate run, :started?


### PR DESCRIPTION
The current `progress` view helper is too complex, and it is going to become even worse as we tweak special progress information cases such as progress overflow.

To avoid that I extracted all progress calculation that happens to a new `Progress` class. The view helper now only takes care of formatting and rendering.

This is a pure refactor, so there should not be any changes in behaviours in our views.