### PR TITLE
Set JobIteration.max_job_runtime to 5 minutes

### DIFF
--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'job-iteration'
 
 module MaintenanceTasks
   # Base class that is inherited by the host application's task classes.

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -4,6 +4,7 @@ require 'action_view'
 require 'active_job'
 require 'active_record'
 
+require 'job-iteration'
 require 'maintenance_tasks/engine'
 require 'pagy'
 require 'pagy/extras/bulma'

--- a/lib/maintenance_tasks/engine.rb
+++ b/lib/maintenance_tasks/engine.rb
@@ -24,6 +24,7 @@ module MaintenanceTasks
 
     config.after_initialize do
       eager_load! unless Rails.autoloaders.zeitwerk_enabled?
+      JobIteration.max_job_runtime ||= 5.minutes
     end
 
     config.action_dispatch.rescue_responses.merge!(


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/206

As documented in [JobIteration's best practices guide](https://github.com/Shopify/job-iteration/blob/a76168b5e0d342634e72abd6928c792e821a113d/guides/best-practices.md#max-iteration-time), setting a `max_job_runtime` value on `JobIteration` is a good idea to preserve worker capacity, especially when there fairly long-running jobs being processed.

5 minutes is the suggested default, so I think we should stick with that.

For now, I've added this to the gem's railtie. If this is something we would eventually like to allow users to customize, we can make it a config option at a later point.