### PR TITLE
Tweak progress title when tick count is over expectations

### DIFF
--- a/test/models/maintenance_tasks/progress_test.rb
+++ b/test/models/maintenance_tasks/progress_test.rb
@@ -25,6 +25,12 @@ module MaintenanceTasks
       assert_equal 4, @progress.value
     end
 
+    test '#value is nil if the Run tick count is greater than its tick total' do
+      @run.tick_count = 8
+
+      assert_nil @progress.value
+    end
+
     test '#max is the Run tick total' do
       assert_equal 7, @progress.max
     end
@@ -34,6 +40,11 @@ module MaintenanceTasks
       assert_equal 4, @progress.max
     end
 
+    test '#max is the Run tick count if the Run tick count is greater than its tick total' do
+      @run.tick_count = 8
+      assert_equal 8, @progress.max
+    end
+
     test '#title returns a description with tick count, tick total, and percentage' do
       assert_equal 'Processed 4 out of 7 (57%)', @progress.title
     end
@@ -41,6 +52,11 @@ module MaintenanceTasks
     test '#title returns a description with tick count when tick total is not present' do
       @run.tick_total = nil
       assert_equal 'Processed 4 items.', @progress.title
+    end
+
+    test '#title returns a description with tick count and tick total when tick count is greater than its tick total' do
+      @run.tick_count = 8
+      assert_equal 'Processed 8 items (expected 7).', @progress.title
     end
 
     test '#title pluralizes the description according to the tick count' do


### PR DESCRIPTION
> for each desired change, make the change easy (warning: this may be hard), then make the easy change
>
> -- Kent Beck

Fixes #133

As discussed in the issue, we would hide the percentage of over 100% and show how many items were initially expected.