### PR TITLE
Enable Contributor License Agreement bot

### DIFF
--- a/.github/probots.yml
+++ b/.github/probots.yml
@@ -1,0 +1,2 @@
+enabled:
+  - cla


### PR DESCRIPTION
Part of #205 

It is critical that the project has some kind of process for vetting the pedigree of contributions and obtaining all necessary rights to use the contribution in the project. We must ensure contributors sign Shopify’s Contributor License Agreement (CLA).

This config will add a check to pull requests which fails if anyone outside of Shopify has not signed a CLA. The check will automatically pass for all members of Shopify. 

Pedigree of contributions is a concern especially when the contributor works for a company and has signed a typical employer IP agreement that gives their company ownership over their work and the contributor has not obtained an exception for their open source contributions from their employer.