### PR TITLE
Disable TaskJob.retry_on

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ end
 
 The Job class **must inherit** from `MaintenanceTasks::TaskJob`.
 
+Note that `retry_on` is not supported for custom Job
+classes, so failed jobs cannot be retried.
+
 #### Customizing the rate at which task progress gets updated
 
 `MaintenanceTasks.ticker_delay` can be configured to customize how frequently

--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -15,6 +15,14 @@ module MaintenanceTasks
 
     rescue_from StandardError, with: :on_error
 
+    class << self
+      # Overrides ActiveJob::Exceptions.retry_on to declare it unsupported.
+      # The use of rescue_from prevents retry_on from being usable.
+      def retry_on(*, **)
+        raise NotImplementedError, 'retry_on is not supported'
+      end
+    end
+
     private
 
     def build_enumerator(_run, cursor:)

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -210,5 +210,11 @@ module MaintenanceTasks
         'must be either an Active Record Relation or an Array.'
       assert_equal expected_message, @run.error_message
     end
+
+    test '.retry_on raises NotImplementedError' do
+      assert_raises NotImplementedError do
+        Class.new(TaskJob) { retry_on StandardError }
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/226

Currently, users are able to write retry logic (ie. `retry_on ArgumentError`) in a custom `TaskJob` class, set the gem up to use that job class, and then have a task retry if it errors. The problem is that `retry_on` uses `rescue_from`, so if the retries max out their attempts, the job will stop retrying, but errors will not bubble up to be rescued by our `rescue_from StandardError, with: on_error`. Consequently, the job will get stuck in running.

I investigated whether there was a way to get these to work together, but there isn't an easy solution. So, I think we should make it clear that this functionality is not supported.