### PR TITLE
Add a error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ rails generate maintenance_tasks:install
 ```
 
 The generator creates and runs a migration to add the necessary table to your
-database. It also mounts Mainteance Tasks in your `config/routes.rb`. By default
+database. It also mounts Maintenance Tasks in your `config/routes.rb`. By default
 the web UI can be accessed in the new `/maintenance_tasks` path.
 
 ## Usage
@@ -109,8 +109,21 @@ MaintenanceTasks::Runner.new.run('Mainteance::UpdatePostsTask')
 
 ### Configuring the Gem
 
-There are a couple configurable options for the gem.
+There are a few configurable options for the gem.
 Custom configurations should be placed in a `maintenance_tasks.rb` initializer.
+
+#### Customizing the error handler
+
+Exceptions raised while a Task is performing are rescued and information about
+the error is persisted and visible in the UI.
+
+If you want to integrate with an exception monitoring service (e.g. Bugsnag),
+you can define an error handler:
+
+```ruby
+# config/initializers/maintenance_tasks.rb
+MaintenanceTasks.error_handler = ->(error) { Bugsnag.notify(error) }
+```
 
 #### Customizing the maintenance tasks module
 

--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -99,6 +99,8 @@ module MaintenanceTasks
         backtrace: Rails.backtrace_cleaner.clean(error.backtrace),
         ended_at: Time.now
       )
+
+      MaintenanceTasks.error_handler.call(error)
     end
   end
 end

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -32,6 +32,9 @@ module MaintenanceTasks
   #   the ticker during Task iterations.
   mattr_accessor :ticker_delay, default: 1.second
 
+  # Defines a callback to be performed when an error occurs in the task.
+  mattr_accessor :error_handler, default: ->(_error) {}
+
   # Retrieves the module that Tasks are namespaced in.
   #
   # @return [Module] the constantized tasks_module value.


### PR DESCRIPTION
Give a way for our users to plug their error monitoring service, even though we catch the errors and don't let them bubble to the queue adapter.