### PR TITLE
Upgrade instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,17 @@ MaintenanceTasks.ticker_delay = 2.seconds
 
 If no value is specified, it will default to 1 second.
 
+## Upgrading
+
+Use bundler to check for and upgrade to newer versions. After installing a new
+version, re-run the install command:
+
+```bash
+$ rails generate maintenance_tasks:install
+```
+
+This ensures that new migrations are installed and run as well.
+
 ## Contributing
 
 Would you like to report an issue or contribute with code? We accept issues and

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -18,6 +18,10 @@ Gem::Specification.new do |spec|
   spec.bindir = 'exe'
   spec.executables = ['maintenance_tasks']
 
+  spec.post_install_message = 'Thank you for installing Maintenance Tasks '\
+    "#{spec.version}. To complete, please run:\n\nrails generate "\
+    'maintenance_tasks:install'
+
   spec.add_dependency('actionpack', '>= 6.0')
   spec.add_dependency('activejob', '>= 6.0')
   spec.add_dependency('activerecord', '>= 6.0')


### PR DESCRIPTION
Fixes #195

We might ship database migrations with new versions, so users might need to install and run new migrations after they bundle update. This change adds instructions about how to upgrade the gem, which essentially would be to bundle update but also re-run the install command. 