### PR TITLE
Refactor Task show action and view

### DIFF
--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -19,14 +19,7 @@ module MaintenanceTasks
     # Shows running and completed instances of the Task.
     def show
       @task = TaskData.find(params.fetch(:id))
-      @last_run = @task.last_run
-      if @last_run
-        @pagy, @previous_runs = pagy(
-          @task.runs.where.not(id: @last_run.id).order(created_at: :desc)
-        )
-      else
-        @previous_runs = []
-      end
+      @pagy, @previous_runs = pagy(@task.previous_runs)
     end
 
     # Runs a given Task and redirects to the Task page.

--- a/app/helpers/maintenance_tasks/task_helper.rb
+++ b/app/helpers/maintenance_tasks/task_helper.rb
@@ -8,6 +8,7 @@ module MaintenanceTasks
   # @api private
   module TaskHelper
     STATUS_COLOURS = {
+      'new' => ['is-primary'],
       'enqueued' => ['is-primary is-light'],
       'running' => ['is-info'],
       'interrupted' => ['is-info', 'is-light'],

--- a/app/views/maintenance_tasks/tasks/actions/_cancelled.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_cancelled.html.erb
@@ -1,0 +1,1 @@
+<%= button_to 'Run', run_task_path(task), method: :put, class: 'button is-success', disabled: task.deleted? %>

--- a/app/views/maintenance_tasks/tasks/actions/_cancelling.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_cancelling.html.erb
@@ -1,0 +1,1 @@
+<%= button_to 'Run', run_task_path(task), method: :put, class: 'button is-success', disabled: true %>

--- a/app/views/maintenance_tasks/tasks/actions/_enqueued.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_enqueued.html.erb
@@ -1,0 +1,2 @@
+<%= button_to 'Pause', pause_task_run_path(task, task.last_run), method: :put, class: 'button is-warning', disabled: task.deleted? %>
+<%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger', disabled: task.deleted? %>

--- a/app/views/maintenance_tasks/tasks/actions/_errored.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_errored.html.erb
@@ -1,0 +1,1 @@
+<%= button_to 'Run', run_task_path(task), method: :put, class: 'button is-success', disabled: task.deleted? %>

--- a/app/views/maintenance_tasks/tasks/actions/_interrupted.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_interrupted.html.erb
@@ -1,0 +1,2 @@
+<%= button_to 'Pause', pause_task_run_path(task, task.last_run), method: :put, class: 'button is-warning', disabled: task.deleted? %>
+<%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger', disabled: task.deleted? %>

--- a/app/views/maintenance_tasks/tasks/actions/_new.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_new.html.erb
@@ -1,0 +1,1 @@
+<%= button_to 'Run', run_task_path(task), method: :put, class: 'button is-success', disabled: task.deleted? %>

--- a/app/views/maintenance_tasks/tasks/actions/_paused.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_paused.html.erb
@@ -1,0 +1,2 @@
+<%= button_to 'Resume', run_task_path(task), method: :put, class: 'button is-primary', disabled: task.deleted? %>
+<%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger', disabled: task.deleted? %>

--- a/app/views/maintenance_tasks/tasks/actions/_pausing.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_pausing.html.erb
@@ -1,0 +1,1 @@
+<%= button_to 'Pausing', pause_task_run_path(task, task.last_run), method: :put, class: 'button is-warning', disabled: true %>

--- a/app/views/maintenance_tasks/tasks/actions/_running.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_running.html.erb
@@ -1,0 +1,2 @@
+<%= button_to 'Pause', pause_task_run_path(task, task.last_run), method: :put, class: 'button is-warning', disabled: task.deleted? %>
+<%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger', disabled: task.deleted? %>

--- a/app/views/maintenance_tasks/tasks/actions/_succeeded.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_succeeded.html.erb
@@ -1,0 +1,1 @@
+<%= button_to 'Run', run_task_path(task), method: :put, class: 'button is-success', disabled: task.deleted? %>

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -1,31 +1,13 @@
 <% content_for :page_title, @task %>
 
 <h1 class="title is-1">
-  <%= @task %>
-  <% if @last_run %>
-    <%= status_tag(@last_run.status) %>
-  <% else %>
-    <span class="tag is-primary">New</span>
-  <% end %>
+  <%= @task %> <%= status_tag(@task.status) %>
 </h1>
 
-<%= render 'maintenance_tasks/runs/info', run: @last_run if @last_run %>
+<%= render 'maintenance_tasks/runs/info', run: @task.last_run if @task.last_run %>
 
 <div class="buttons">
-  <% if @last_run.nil? || @last_run.completed? %>
-    <%= button_to 'Run', run_task_path(@task), method: :put, class: 'button is-success', disabled: @task.deleted? %>
-  <% elsif @last_run.cancelling? %>
-    <%= button_to 'Run', run_task_path(@task), method: :put, class: 'button is-success', disabled: true %>
-  <% else %>
-      <% if @last_run.pausing? %>
-        <%= button_to 'Pausing', pause_task_run_path(@task, @last_run), method: :put, class: 'button is-warning', disabled: true %>
-      <% elsif @last_run.paused? %>
-        <%= button_to 'Resume', run_task_path(@task), method: :put, class: 'button is-primary', disabled: @task.deleted? %>
-      <% else %>
-        <%= button_to 'Pause', pause_task_run_path(@task, @last_run), method: :put, class: 'button is-warning', disabled: @task.deleted? %>
-      <% end%>
-    <%= button_to 'Cancel', cancel_task_run_path(@task, @last_run), method: :put, class: 'button is-danger', disabled: @task.deleted? %>
-  <% end %>
+  <%= render "maintenance_tasks/tasks/actions/#{@task.status}", task: @task %>
 </div>
 
 <% if (code = @task.code) %>


### PR DESCRIPTION
Right now we have a messy nesting of conditionals in the Task show view. This PR addresses it.

Similar to what I did before for status information, I broke the different sets of buttons for each status in its own partials. This allows us to easily set and understand the actions we allow for each status. To simplify things even further, I introduced a new `TaskData#status`, which delegates to the last Run status or assumes that the Task is `new`. This also simplified the rendering of the status tag.

Included in this commit is the removal of the `@last_run` instance variable. We don't need it, since we already memoize the last run in the Task Data instance.

Finally, I replaced `TaskData#runs` with `TaskData#previous_runs`, which is what we actually use for presentation of Task Data.

I would like to move us eventually away from `TaskData#last_run`, and just expose any data we need about the last run in Task Data directly. Hopefully this will be done in the next PR. Stay tuned!