### PR TITLE
Remove unnecessary timestamp indexes and add index to :task_name

### DIFF
--- a/db/migrate/20201211151756_create_maintenance_tasks_runs.rb
+++ b/db/migrate/20201211151756_create_maintenance_tasks_runs.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class CreateMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
   def change
-    create_table(:maintenance_tasks_runs) do |t|
+    create_table(:maintenance_tasks_runs, force: true) do |t|
       t.string(:task_name, null: false)
       t.datetime(:started_at)
       t.datetime(:ended_at)
@@ -14,11 +14,9 @@ class CreateMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
       t.string(:error_class)
       t.string(:error_message)
       t.text(:backtrace)
-
       t.timestamps
     end
     add_index(:maintenance_tasks_runs, :created_at)
-    add_index(:maintenance_tasks_runs, :started_at)
-    add_index(:maintenance_tasks_runs, :ended_at)
+    add_index(:maintenance_tasks_runs, :task_name)
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_26_180058) do
+ActiveRecord::Schema.define(version: 2020_12_11_151756) do
 
   create_table "maintenance_tasks_runs", force: :cascade do |t|
     t.string "task_name", null: false
@@ -28,8 +28,7 @@ ActiveRecord::Schema.define(version: 2020_10_26_180058) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["created_at"], name: "index_maintenance_tasks_runs_on_created_at"
-    t.index ["ended_at"], name: "index_maintenance_tasks_runs_on_ended_at"
-    t.index ["started_at"], name: "index_maintenance_tasks_runs_on_started_at"
+    t.index ["task_name"], name: "index_maintenance_tasks_runs_on_task_name"
   end
 
   create_table "posts", force: :cascade do |t|


### PR DESCRIPTION
When we introduced the timestamp columns I indexed them because I thought we might want the option to sort by a timestamp other than `created_at`. However, this is unnecessary at this point, so we should get rid of those indexes.

Additionally, `TaskData` queries `Runs` based on `task_name`, so we _should_ have an index for this.