### PR TITLE
Move index creating to the create table block

### DIFF
--- a/db/migrate/20201211151756_create_maintenance_tasks_runs.rb
+++ b/db/migrate/20201211151756_create_maintenance_tasks_runs.rb
@@ -15,8 +15,8 @@ class CreateMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
       t.string(:error_message)
       t.text(:backtrace)
       t.timestamps
+      t.index(:created_at)
+      t.index(:task_name)
     end
-    add_index(:maintenance_tasks_runs, :created_at)
-    add_index(:maintenance_tasks_runs, :task_name)
   end
 end


### PR DESCRIPTION
> The default migration adds the indices after creating the table. For Rails apps using LHM, that violates the migration vs LHM policies, so I moved the index calls inside the create_table call.

(@simonlevasseur)