### PR TITLE
Make it easier to test mysql or postgresql

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gemspec
 
 gem 'capybara'
 gem 'mocha'
+gem 'mysql2'
+gem 'pg'
 gem 'pry-byebug'
 gem 'puma'
 gem 'rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.2)
     mocha (1.11.2)
+    mysql2 (0.5.3)
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
@@ -111,6 +112,7 @@ GEM
     parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)
+    pg (1.2.3)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -203,6 +205,8 @@ DEPENDENCIES
   capybara
   maintenance_tasks!
   mocha
+  mysql2
+  pg
   pry-byebug
   puma
   rails

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -9,9 +9,21 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
+mysql: &mysql
+  adapter: mysql2
+  database: maintenance_tasks_<%= Rails.env %>
+  username: root
+
+postgresql: &postgresql
+  adapter: postgresql
+  database: maintenance_tasks_<%= Rails.env %>
+
 development:
   <<: *default
   database: db/development.sqlite3
+  # uncomment one of these to enable mysql or postgresql
+  #<<: *mysql
+  #<<: *pg
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".


### PR DESCRIPTION
This PR gives us a way to test mysql or postgresql by simply un-commenting one line in `test/dummy/config/database.yml`.