### PR TITLE
Improve query in TaskData.available_tasks

### DIFF
--- a/app/models/maintenance_tasks/task_data.rb
+++ b/app/models/maintenance_tasks/task_data.rb
@@ -38,13 +38,15 @@ module MaintenanceTasks
       #
       # @return [Array<TaskData>] the list of Task Data.
       def available_tasks
-        last_runs = Run.where(
-          id: Run.select('MAX(id) as id').group(:task_name)
+        task_names = Task.available_tasks.map(&:name)
+        available_task_runs = Run.where(task_name: task_names)
+        last_runs = available_task_runs.where(
+          id: available_task_runs.select('MAX(id) as id').group(:task_name)
         )
 
-        Task.available_tasks.map do |task|
-          last_run = last_runs.find { |run| run.task_name == task.name }
-          TaskData.new(task.name, last_run)
+        task_names.map do |task_name|
+          last_run = last_runs.find { |run| run.task_name == task_name }
+          TaskData.new(task_name, last_run)
         end.sort!
       end
     end


### PR DESCRIPTION
We can reduce the number of allocations occurring in `TaskData.available_tasks` and speed up load time by modifying the query to fetch `last_runs`. Rather than loading all `runs` as Active Records only to throw them away if they aren't associated with a task in `Task.available_tasks`, we can first filter based on `runs` that have a `task_name` that is in `Task.available_tasks.map(&:name)`.

A quick comparison:
In the console, I did:
```ruby
1000.times do |i|
  run = Run.new(
    task_name: "Maintenance::DeletedTask#{i}",
    started_at: Time.now,
    tick_count: 10,
    tick_total: 10,
    status: :succeeded,
    ended_at: Time.now
  )
  run.save(validate: false)
end
```

**Loading times on `main`:**
The first time the index page loaded: `Completed 200 OK in 91ms (ActiveRecord: 15.8ms | Allocations: 37486)`
After that, `Active Record ~6ms and allocations ~19000`

**Loading times on this branch**
The first time the index page loaded: `Completed 200 OK in 84ms (ActiveRecord: 3.1ms | Allocations: 21939)`
After that, `Active Record ~0.3ms and allocations ~3000`

A pretty big improvement!