### PR TITLE
Remove unnecessary Capybara configuration

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -2,8 +2,9 @@
 
 require 'test_helper'
 require 'webdrivers/chromedriver'
+require 'action_dispatch/system_testing/server'
 
-Capybara.server = :puma, { Silent: true, environment: 'test' }
+ActionDispatch::SystemTesting::Server.silence_puma = true
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include ActiveJob::TestHelper


### PR DESCRIPTION
Use Rails directly to silence puma in system tests.

This reverts commit 1076f2ede6f05f9d8713cd23e9d2e66f80969421.

Capybara was updated in #191.