### PR TITLE
Allow to skip slow tests with SKIP_SLOW

### DIFF
--- a/test/lib/generators/maintenance_tasks/install_generator_test.rb
+++ b/test/lib/generators/maintenance_tasks/install_generator_test.rb
@@ -9,12 +9,12 @@ module MaintenanceTasks
     destination SAMPLE_APP_PATH
     setup :prepare_destination
 
-    def setup
-      super
+    setup do
+      skip 'This test is too slow' if ENV['SKIP_SLOW'].present?
       setup_sample_app
     end
 
-    def teardown
+    teardown do
       FileUtils.rm_rf(SAMPLE_APP_PATH)
     end
 


### PR DESCRIPTION
The rails generator test takes most of the time spent testing even including system tests.

I like fast feedback loops, and I don't necessarily want to choose exactly which tests to run, using just `rails test` while I'm changing things around. (`git ls-files | entr rails test`).

Baseline, all the tests:

```sh-session
$ time rails test 'test/**/*_test.rb' >/dev/null

real	0m19.293s
user	0m10.451s
sys	0m5.634s
```

All the tests except the slow one:

```sh-session
$ time SKIP_SLOW=1 rails test 'test/**/*_test.rb' >/dev/null

real	0m11.924s
user	0m6.107s
sys	0m2.685s
```

More realistically, non-system tests:

```sh-session
$ time rails test >/dev/null

real	0m13.366s
user	0m8.454s
sys	0m4.713s
```

Non-system tests except the slow one:

```sh-session
$ time SKIP_SLOW=1 rails test >/dev/null

real	0m5.026s
user	0m3.445s
sys	0m1.479s
```

---

5 seconds is still not fast in terms of feedback loop, but considering what is left tests most things including the database layer and should catch most failures, it's much better IMO.

I should add that this doesn't change a thing to CI or if you don't want to use `SKIP_SLOW` obviously.
