### PR TITLE
Fix Rails 6.0 compatibility for stylesheet patch

### DIFF
--- a/app/helpers/maintenance_tasks/application_helper.rb
+++ b/app/helpers/maintenance_tasks/application_helper.rb
@@ -32,6 +32,7 @@ module MaintenanceTasks
     # Fix stylesheet_link_tag to handle integrity when preloading.
     # To be reverted once fixed upstream in Rails.
     def stylesheet_link_tag(*sources)
+      return super unless respond_to?(:send_preload_links_header, true)
       options = sources.extract_options!.stringify_keys
       path_options = options.extract!('protocol', 'host', 'skip_pipeline')
         .symbolize_keys


### PR DESCRIPTION
Our patch to fix stylesheet_link_tag with integrity attribute fails on Rails 6.0 because it is missing the `send_preload_links_header` method.

This adds a check with `respond_to?`, I had to use `true` because it's a private method. Maybe we could use `defined?` instead. It's a bit fishy to rely on the existence of a private method, but on the other hand, we are calling this method in the overridden version of `stylesheet_link_tag` so it's fair game IMO.