### PR TITLE
Update MaintenanceTasks.tasks_module to return string instead of constant

### DIFF
--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -33,7 +33,8 @@ module MaintenanceTasks
       private
 
       def load_constants
-        namespace = MaintenanceTasks.tasks_module
+        namespace = MaintenanceTasks.tasks_module.safe_constantize
+        return unless namespace
         namespace.constants.map { |constant| namespace.const_get(constant) }
       end
     end

--- a/lib/generators/maintenance_tasks/task_generator.rb
+++ b/lib/generators/maintenance_tasks/task_generator.rb
@@ -41,7 +41,7 @@ module MaintenanceTasks
     end
 
     def tasks_module_file_path
-      tasks_module.to_s.underscore
+      tasks_module.underscore
     end
   end
   private_constant :TaskGenerator

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -13,9 +13,9 @@ require 'pagy/extras/bulma'
 # application's code and the engine-specific code. Top-level engine constants
 # and variables are defined under this module.
 module MaintenanceTasks
-  # Sets the value of tasks_module, the intended module to namespace Tasks in.
-  # Defaults to 'Maintenance'.
-  mattr_writer :tasks_module, default: 'Maintenance'
+  # The module to namespace Tasks in, as a String. Defaults to 'Maintenance'.
+  # @param [String] the tasks_module value.
+  mattr_accessor :tasks_module, default: 'Maintenance'
 
   # Defines the job to be used to perform Tasks. This job must be either
   # `MaintenanceTasks::TaskJob` or a class that inherits from it.
@@ -36,13 +36,6 @@ module MaintenanceTasks
   mattr_accessor :error_handler, default: ->(_error) {}
 
   class << self
-    # Retrieves the module that Tasks are namespaced in.
-    #
-    # @return [Module] the constantized tasks_module value.
-    def tasks_module
-      @@tasks_module.constantize
-    end
-
     # Retrieves the class that is configured as the Task Job to be used to
     # perform Tasks.
     #

--- a/lib/maintenance_tasks/engine.rb
+++ b/lib/maintenance_tasks/engine.rb
@@ -9,15 +9,9 @@ module MaintenanceTasks
 
     config.to_prepare do
       unless Rails.autoloaders.zeitwerk_enabled?
-        begin
-          tasks_module = MaintenanceTasks.tasks_module.name.underscore
-        rescue NameError
-          nil
-        end
-        if tasks_module
-          Dir["#{Rails.root}/app/tasks/#{tasks_module}/*.rb"].each do |file|
-            require_dependency(file)
-          end
+        tasks_module = MaintenanceTasks.tasks_module.underscore
+        Dir["#{Rails.root}/app/tasks/#{tasks_module}/*.rb"].each do |file|
+          require_dependency(file)
         end
       end
     end

--- a/test/lib/generators/maintenance_tasks/task_generator_test.rb
+++ b/test/lib/generators/maintenance_tasks/task_generator_test.rb
@@ -32,8 +32,7 @@ module MaintenanceTasks
     end
 
     test 'generator uses configured tasks module' do
-      previous_task_module = MaintenanceTasks.tasks_module.name
-      Object.const_set('Foo', Module.new {})
+      previous_task_module = MaintenanceTasks.tasks_module
       MaintenanceTasks.tasks_module = 'Foo'
 
       run_generator(['sleepy'])
@@ -42,7 +41,6 @@ module MaintenanceTasks
       end
     ensure
       MaintenanceTasks.tasks_module = previous_task_module
-      Object.send(:remove_const, :Foo)
     end
 
     test 'generator namespaces task properly' do

--- a/test/lib/maintenance_tasks_test.rb
+++ b/test/lib/maintenance_tasks_test.rb
@@ -3,18 +3,16 @@ require 'test_helper'
 
 class MaintenanceTasksTest < ActiveSupport::TestCase
   test '.tasks_module defaults to constant Maintenance' do
-    assert_equal Maintenance, MaintenanceTasks.tasks_module
+    assert_equal('Maintenance', MaintenanceTasks.tasks_module)
   end
 
   test '.tasks_module can be set' do
-    previous_task_module = MaintenanceTasks.tasks_module.name
+    previous_task_module = MaintenanceTasks.tasks_module
 
-    Object.const_set('Task', Module.new {})
     MaintenanceTasks.tasks_module = 'Task'
-    assert_equal(Task, MaintenanceTasks.tasks_module)
+    assert_equal('Task', MaintenanceTasks.tasks_module)
   ensure
     MaintenanceTasks.tasks_module = previous_task_module
-    Object.send(:remove_const, :Task)
   end
 
   test '.job can be set' do


### PR DESCRIPTION
Right now the TaskGenerator fails in apps without a defined `Maintenance` constant, because `MaintenanceTasks.tasks_module` constantizes the string.

The only place the constant version is actually needed is in `Task.load_constants`, which can accommodate  the constant not existing. Consequently, we should `safe_constantize` there, returning early if the constant doesn't exist, and then use the string version of the tasks module everywhere else.

This also prevents us from having to rescue `NameError` in the `Engine` and generally makes our code clearer.