### PR TITLE
Explain how tasks run and handle stuck tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,17 @@ forcefully terminating them (this is the default but can be configured with the
 to re-enqueue the job so your Task will be resumed. However, the position in the
 collection won't be persisted so at least one iteration may run again.
 
+#### Help: my Task is stuck
+
+Finally, if the queue adapter configured for your application doesn't have this
+property, or if Sidekiq crashes, is forcefully terminated, or is unable to
+re-enqueue the jobs that were in progress, the Task may be in a seemingly stuck
+situation where it appears to be running but is not. In that situation, pausing
+or cancelling it will not result in the Task being paused or cancelled, as the
+Task will get stuck in a state of `pausing` or `cancelling`. As a work-around,
+if a Task is `cancelling` for more than 5 minutes, you will be able to cancel it
+for good, which will just mark it as cancelled, allowing you to run it again.
+
 ### Writing Tasks
 
 MaintenanceTasks relies on the queue adapter configured for your application to

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -142,12 +142,24 @@ module MaintenanceTasks
     # will be updated.
     #
     # If the Run is not paused, the Run will transition to cancelling.
+    #
+    # If the Run is already cancelling, and has last been updated more than 5
+    # minutes ago, it will transition to cancelled, and the ended_at timestamp
+    # will be updated.
     def cancel
-      if paused?
+      if paused? || stuck?
         update!(status: :cancelled, ended_at: Time.now)
       else
         cancelling!
       end
+    end
+
+    # Returns whether a Run is stuck, which is defined as having a status of
+    # cancelling, and not having been updated in the last 5 minutes.
+    #
+    # @return [Boolean] whether the Run is stuck.
+    def stuck?
+      cancelling? && updated_at <= 5.minutes.ago
     end
   end
   private_constant :Run

--- a/app/views/maintenance_tasks/tasks/actions/_cancelling.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_cancelling.html.erb
@@ -1,1 +1,4 @@
 <%= button_to 'Run', run_task_path(task), method: :put, class: 'button is-success', disabled: true %>
+<% if task.last_run.stuck? %>
+  <%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger', disabled: task.deleted? %>
+<% end %>

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -64,6 +64,23 @@ module MaintenanceTasks
       assert_text 'Cancelling…'
     end
 
+    test 'cancel a stuck Run' do
+      visit maintenance_tasks_path
+
+      click_on('Maintenance::UpdatePostsTask')
+      click_on 'Run'
+      click_on 'Cancel'
+
+      assert_text 'Cancelling…'
+      refute_button 'Cancel'
+
+      travel 5.minutes
+
+      refresh
+      click_on 'Cancel'
+      assert_text 'Cancelled'
+    end
+
     test 'run a Task that errors' do
       visit maintenance_tasks_path
 


### PR DESCRIPTION
Fixes #196 

This PR gives an explanation of how tasks run with regards to the queue adapter (delving more deeply in the case of Sidekiq, which seems to be [the clear leader in the space](https://rails-hosting.com/2020/#which-active-job-adapters-do-you-use-to-use-to-process-background-jobs)), and how to write Tasks to be able to work better with the rest of the system.

Then it adds a paragraph about the Task being stuck if the job is actually terminated with no recourse for us to do anything about it, and explains how to get out of this, adding the necessary code to support it: now a Run which has been in the `cancelling` status for more than 5 minutes can be transitioned to the `cancelled` status directly, allowing users to run the task again.