### PR TITLE
Update Task generator to work with RSpec framework

### DIFF
--- a/lib/generators/maintenance_tasks/task_generator.rb
+++ b/lib/generators/maintenance_tasks/task_generator.rb
@@ -6,7 +6,8 @@ module MaintenanceTasks
   # @api private
   class TaskGenerator < Rails::Generators::NamedBase
     source_root File.expand_path('templates', __dir__)
-    desc 'This generator creates a task file at app/tasks.'
+    desc 'This generator creates a task file at app/tasks and a corresponding '\
+      'test.'
 
     check_class_collision suffix: 'Task'
 
@@ -20,7 +21,21 @@ module MaintenanceTasks
       template('task.rb', template_file)
     end
 
-    # Create the Task test file.
+    # Creates the Task test file, according to the app's test framework.
+    # A spec file is created if the app uses RSpec.
+    # Otherwise, an ActiveSupport::TestCase test is created.
+    def create_test_file
+      return unless test_framework
+
+      if test_framework == :rspec
+        create_task_spec_file
+      else
+        create_task_test_file
+      end
+    end
+
+    private
+
     def create_task_test_file
       template_file = File.join(
         "test/tasks/#{tasks_module_file_path}",
@@ -30,7 +45,14 @@ module MaintenanceTasks
       template('task_test.rb', template_file)
     end
 
-    private
+    def create_task_spec_file
+      template_file = File.join(
+        "spec/tasks/#{tasks_module_file_path}",
+        class_path,
+        "#{file_name}_task_spec.rb"
+      )
+      template('task_spec.rb', template_file)
+    end
 
     def file_name
       super.sub(/_task\z/i, '')
@@ -42,6 +64,10 @@ module MaintenanceTasks
 
     def tasks_module_file_path
       tasks_module.underscore
+    end
+
+    def test_framework
+      Rails.application.config.generators.options[:rails][:test_framework]
     end
   end
   private_constant :TaskGenerator

--- a/lib/generators/maintenance_tasks/templates/task_spec.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/task_spec.rb.tt
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+module <%= tasks_module %>
+<% module_namespacing do -%>
+  RSpec.describe <%= class_name %>Task do
+    # describe '#process' do
+      # it 'performs a task iteration' do
+        # <%= tasks_module %>::<%= class_name %>Task.new.process(element)
+      # end
+    # end
+  end
+<% end -%>
+end

--- a/test/lib/generators/maintenance_tasks/task_generator_test.rb
+++ b/test/lib/generators/maintenance_tasks/task_generator_test.rb
@@ -31,6 +31,21 @@ module MaintenanceTasks
       end
     end
 
+    test 'generator creates a task spec if the application is using RSpec' do
+      generators_config = Rails.application.config.generators
+      old_test_framework = generators_config.options[:rails][:test_framework]
+      generators_config.options[:rails][:test_framework] = :rspec
+
+      run_generator(['sleepy'])
+
+      assert_file('spec/tasks/maintenance/sleepy_task_spec.rb') do |task_spec|
+        assert_match(/module Maintenance/, task_spec)
+        assert_match(/RSpec.describe SleepyTask/, task_spec)
+      end
+    ensure
+      generators_config.options[:rails][:test_framework] = old_test_framework
+    end
+
     test 'generator uses configured tasks module' do
       previous_task_module = MaintenanceTasks.tasks_module
       MaintenanceTasks.tasks_module = 'Foo'


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/253

Updates the `TaskGenerator` to see which test framework the host app is using, generating a spec file if the app is using RSpec, and a Rails test file otherwise.

I've tophatted it in the Partners app to make sure everything works okay:

![Screen Shot 2020-12-16 at 10 14 56 AM](https://user-images.githubusercontent.com/22918438/102367267-8f2a9700-3f87-11eb-979d-ee99b6d4cd1a.png)

After `rails generate maintenance_tasks:task foo`, and uncommenting the example:

![Screen Shot 2020-12-16 at 10 04 53 AM](https://user-images.githubusercontent.com/22918438/102366522-c187c480-3f86-11eb-9820-d25b4b638ab6.png)