### PR TITLE
Remove TestTask class leak

### DIFF
--- a/test/dummy/app/tasks/maintenance/test_task.rb
+++ b/test/dummy/app/tasks/maintenance/test_task.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module Maintenance
+  class TestTask < MaintenanceTasks::Task
+    def collection
+      [1, 2]
+    end
+
+    def count
+      collection.count
+    end
+
+    def process(number)
+      Rails.logger.debug("number: #{number}")
+    end
+  end
+end

--- a/test/models/maintenance_tasks/task_data_test.rb
+++ b/test/models/maintenance_tasks/task_data_test.rb
@@ -22,8 +22,8 @@ module MaintenanceTasks
     test '.available_tasks returns a list of Tasks as TaskData, ordered alphabetically by name' do
       expected = [
         'Maintenance::ErrorTask',
+        'Maintenance::TestTask',
         'Maintenance::UpdatePostsTask',
-        'MaintenanceTasks::TaskJobTest::TestTask',
       ]
       assert_equal expected, TaskData.available_tasks.map(&:name)
     end

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -19,6 +19,7 @@ module MaintenanceTasks
       expected = [
         'New Tasks',
         "Maintenance::ErrorTask\nNew",
+        "Maintenance::TestTask\nNew",
         'Completed Tasks',
         "Maintenance::UpdatePostsTask\nSucceeded",
       ]

--- a/test/tasks/maintenance_tasks/task_test.rb
+++ b/test/tasks/maintenance_tasks/task_test.rb
@@ -6,8 +6,8 @@ module MaintenanceTasks
     test '.available_tasks returns list of tasks that inherit from the Task superclass' do
       expected = [
         'Maintenance::ErrorTask',
+        'Maintenance::TestTask',
         'Maintenance::UpdatePostsTask',
-        'MaintenanceTasks::TaskJobTest::TestTask',
       ]
       assert_equal expected,
         MaintenanceTasks::Task.available_tasks.map(&:name).sort


### PR DESCRIPTION
Defining a Task in a test class results in the Task being leaked across the test suite. Since we list the descendants of Task in
Task.available_task, as soon as the test file defining the class is loaded, other tests expect the Task to exist.

This is why we have TaskDataTest referring to the TestTask, meaning this test file can't be run by itself, since it needs the other test file to be loaded as well to define the TestTask.

When we run all the tests using the Rake task, it adds another difficulty where the system tests now fail because the TestTask now is in the list of task, when it's not when TasksTest runs individually or with rails test:system.

This removes the TestTask defined in TaskJobTest to replace it with a regular Task that is always present.