### PR TITLE
Update index on :created_at to be [:task_name, :created_at]

### DIFF
--- a/db/migrate/20201211151756_create_maintenance_tasks_runs.rb
+++ b/db/migrate/20201211151756_create_maintenance_tasks_runs.rb
@@ -15,8 +15,8 @@ class CreateMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
       t.string(:error_message)
       t.text(:backtrace)
       t.timestamps
-      t.index(:created_at)
       t.index(:task_name)
+      t.index([:task_name, :created_at], order: { created_at: :desc })
     end
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 2020_12_11_151756) do
     t.text "backtrace"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["created_at"], name: "index_maintenance_tasks_runs_on_created_at"
+    t.index ["task_name", "created_at"], name: "index_maintenance_tasks_runs_on_task_name_and_created_at", order: { created_at: :desc }
     t.index ["task_name"], name: "index_maintenance_tasks_runs_on_task_name"
   end
 


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/260

~~We might as well use the primary key on `maintenance_tasks_runs` for ordering in `TaskData#previous_runs`, since it is an autoincremented id, rather than using `created_at` and having to maintain this index on writes to the db.~~

~~This PR removes the index from `created_at` and changes our query in `TaskData#runs` to order by `id: :desc` instead.~~

Per Étienne's comment below, looks like we actually want to make this a compound index with `task_name`, so I will leave the `.order(created_at: :desc)` and update the index instead. The index is now `[:task_name, :created_at]` and we have a sort order of `:desc` on `:created_at` (sort order defaults to `:asc`, so we don't need to specify one for `:task_name`).