### PR TITLE
Allow users to configure tasks location

### DIFF
--- a/lib/generators/maintenance_tasks/task_generator.rb
+++ b/lib/generators/maintenance_tasks/task_generator.rb
@@ -14,7 +14,7 @@ module MaintenanceTasks
     # Creates the Task file.
     def create_task_file
       template_file = File.join(
-        "app/tasks/#{tasks_module_file_path}",
+        "app/#{tasks_location}/#{tasks_module_file_path}",
         class_path,
         "#{file_name}_task.rb"
       )
@@ -38,7 +38,7 @@ module MaintenanceTasks
 
     def create_task_test_file
       template_file = File.join(
-        "test/tasks/#{tasks_module_file_path}",
+        "test/#{tasks_location}/#{tasks_module_file_path}",
         class_path,
         "#{file_name}_task_test.rb"
       )
@@ -47,7 +47,7 @@ module MaintenanceTasks
 
     def create_task_spec_file
       template_file = File.join(
-        "spec/tasks/#{tasks_module_file_path}",
+        "spec/#{tasks_location}/#{tasks_module_file_path}",
         class_path,
         "#{file_name}_task_spec.rb"
       )
@@ -60,6 +60,10 @@ module MaintenanceTasks
 
     def tasks_module
       MaintenanceTasks.tasks_module
+    end
+
+    def tasks_location
+      MaintenanceTasks.tasks_location
     end
 
     def tasks_module_file_path

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -17,6 +17,15 @@ module MaintenanceTasks
   # @param [String] the tasks_module value.
   mattr_accessor :tasks_module, default: 'Maintenance'
 
+  # The default file location where Tasks were be located, as a String.
+  # Defaults to 'tasks'.
+  #
+  # i.e.  tasks and corresponding tests will be stored under
+  #       app/tasks/maintenance and {test|spec}/tasks/maintenance
+  #
+  # @param [String] the tasks_location value.
+  mattr_accessor :tasks_location, default: 'tasks'
+
   # Defines the job to be used to perform Tasks. This job must be either
   # `MaintenanceTasks::TaskJob` or a class that inherits from it.
   #

--- a/test/lib/generators/maintenance_tasks/task_generator_test.rb
+++ b/test/lib/generators/maintenance_tasks/task_generator_test.rb
@@ -58,6 +58,18 @@ module MaintenanceTasks
       MaintenanceTasks.tasks_module = previous_task_module
     end
 
+    test 'generator uses configured tasks location' do
+      previous_task_location = MaintenanceTasks.tasks_location
+      MaintenanceTasks.tasks_location = 'jobs'
+
+      run_generator(['sleepy'])
+      assert_file('app/jobs/sleepy_task.rb') do |task|
+        refute_match(/jobs/, task)
+      end
+    ensure
+      MaintenanceTasks.tasks_location = previous_task_location
+    end
+
     test 'generator namespaces task properly' do
       run_generator ['admin/sleepy']
       assert_file 'app/tasks/maintenance/admin/sleepy_task.rb' do |task|

--- a/test/lib/generators/maintenance_tasks/task_generator_test.rb
+++ b/test/lib/generators/maintenance_tasks/task_generator_test.rb
@@ -63,7 +63,7 @@ module MaintenanceTasks
       MaintenanceTasks.tasks_location = 'jobs'
 
       run_generator(['sleepy'])
-      assert_file('app/jobs/sleepy_task.rb') do |task|
+      assert_file('app/jobs/maintenance/sleepy_task.rb') do |task|
         refute_match(/jobs/, task)
       end
     ensure

--- a/test/lib/maintenance_tasks_test.rb
+++ b/test/lib/maintenance_tasks_test.rb
@@ -15,6 +15,19 @@ class MaintenanceTasksTest < ActiveSupport::TestCase
     MaintenanceTasks.tasks_module = previous_task_module
   end
 
+  test '.tasks_location defaults to "tasks"' do
+    assert_equal('tasks', MaintenanceTasks.tasks_location)
+  end
+
+  test '.tasks_location can be set' do
+    previous_task_location = MaintenanceTasks.tasks_location
+
+    MaintenanceTasks.tasks_location = 'jobs'
+    assert_equal('jobs', MaintenanceTasks.tasks_location)
+  ensure
+    MaintenanceTasks.tasks_location = previous_task_location
+  end
+
   test '.job can be set' do
     original_job = MaintenanceTasks.job.name
     MaintenanceTasks.job = 'CustomTaskJob'


### PR DESCRIPTION
Right now, when you install a new task, it's located by default under `app/tasks` and `{test|spec}/tasks`. In legacy systems, this might not be a convenient location, and I think it would be worth it to expose this location for configurability, since the typical location would be `app/jobs/migration` instead. 

EDIT: Sorry, I meant `app/jobs/maintenance` instead of `app/jobs/migration`