### PR TITLE
Show helpful text on index page when no tasks

### DIFF
--- a/app/views/maintenance_tasks/tasks/index.html.erb
+++ b/app/views/maintenance_tasks/tasks/index.html.erb
@@ -1,12 +1,22 @@
-<% if active_tasks = @available_tasks[:active] %>
-  <h3 class="title is-3">Active Tasks</h3>
-  <%= render partial: 'task', collection: active_tasks %>
-<% end %>
-<% if new_tasks = @available_tasks[:new] %>
-  <h3 class="title is-3">New Tasks</h3>
-  <%= render partial: 'task', collection: new_tasks %>
-<% end %>
-<% if completed_tasks = @available_tasks[:completed] %>
-  <h3 class="title is-3">Completed Tasks</h3>
-  <%= render partial: 'task', collection: completed_tasks %>
+<% if @available_tasks.empty? %>
+  <div class="content is-large">
+    <h3 class="title is-3"> The MaintenanceTasks gem has been successfully installed! </h3>
+    <p>
+      Any new Tasks will show up here. To start writing your first Task, 
+      run <code>rails generate maintenance_tasks:task my_task</code>.
+    </p>
+  </div>
+<% else %>
+  <% if active_tasks = @available_tasks[:active] %>
+    <h3 class="title is-3">Active Tasks</h3>
+    <%= render partial: 'task', collection: active_tasks %>
+  <% end %>
+  <% if new_tasks = @available_tasks[:new] %>
+    <h3 class="title is-3">New Tasks</h3>
+    <%= render partial: 'task', collection: new_tasks %>
+  <% end %>
+  <% if completed_tasks = @available_tasks[:completed] %>
+    <h3 class="title is-3">Completed Tasks</h3>
+    <%= render partial: 'task', collection: completed_tasks %>
+  <% end %>
 <% end %>


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/234

Right now, the index page is empty if the application doesn't have any Tasks yet. This PR adds some helpful text to let the user know that the gem was installed successfully, and to provide some instructions for next steps.

![Screen Shot 2021-01-05 at 8 35 11 AM](https://user-images.githubusercontent.com/22918438/103652326-f1483d80-4f30-11eb-98f2-38b0cbf9e4be.png)
