### PR TITLE
Refactor views to show created at for latest runs

### DIFF
--- a/app/views/maintenance_tasks/runs/_info.html.erb
+++ b/app/views/maintenance_tasks/runs/_info.html.erb
@@ -1,5 +1,0 @@
-<%= progress run %>
-
-<div class="content">
-  <%= render "maintenance_tasks/runs/info/#{run.status}", run: run %>
-</div>

--- a/app/views/maintenance_tasks/runs/_run.html.erb
+++ b/app/views/maintenance_tasks/runs/_run.html.erb
@@ -3,6 +3,9 @@
     <%= time_tag run.created_at, title: run.created_at %>
     <%= status_tag run.status %>
   </h5>
+  <%= progress run %>
 
-  <%= render 'maintenance_tasks/runs/info', run: run %>
+  <div class="content">
+    <%= render "maintenance_tasks/runs/info/#{run.status}", run: run %>
+  </div>
 </div>

--- a/app/views/maintenance_tasks/tasks/_task.html.erb
+++ b/app/views/maintenance_tasks/tasks/_task.html.erb
@@ -4,5 +4,14 @@
     <%= status_tag(task.status) %>
   </h3>
 
-  <%= render 'maintenance_tasks/runs/info', run: task.last_run if task.last_run %>
+  <% if run = task.last_run %>
+    <h5 class="title is-5">
+      <%= time_tag run.created_at, title: run.created_at %>
+    </h5>
+    <%= progress run %>
+
+    <div class="content">
+      <%= render "maintenance_tasks/runs/info/#{run.status}", run: run %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -1,10 +1,10 @@
 <% content_for :page_title, @task %>
 
 <h1 class="title is-1">
-  <%= @task %> <%= status_tag(@task.status) %>
+  <%= @task %> <%= status_tag(@task.status) unless @task.last_run %>
 </h1>
 
-<%= render 'maintenance_tasks/runs/info', run: @task.last_run if @task.last_run %>
+<%= render @task.last_run if @task.last_run %>
 
 <div class="buttons">
   <%= render "maintenance_tasks/tasks/actions/#{@task.status}", task: @task %>


### PR DESCRIPTION
Closes:https://github.com/Shopify/maintenance_tasks/issues/252

Right now, the views don't show the `created_at` timestamp for the latest run, both in the Tasks index page and the topmost run on a Task's show page. This PR modifies the views so that we show the `created_at` timestamp for every Run card.

I've removed the `task_info` partial as well, as I felt it was just adding extra complexity, and it was easier to just include the info needed in the `run` and `task` partials directly.
* The `run` partial needs to show created at, status, progress, and the info card
* The `task` partial needs to show the Task status, link to the Task show page, and then if there's a latest Run: the created at, progress, and the info card
* I've modified the show page to remove the status from the title header, and to render a `run` instead of rendering `task_info` like it was before. This allows the created_at to be displayed, and IMHO makes the UI a bit more consistent.

## Maintenance Tasks Index
**Before**
![Screen Shot 2021-01-05 at 9 18 29 AM](https://user-images.githubusercontent.com/22918438/103658323-0f19a080-4f39-11eb-9bd0-45c8edd42e67.png)

**After**
![Screen Shot 2021-01-05 at 9 18 07 AM](https://user-images.githubusercontent.com/22918438/103658320-0e810a00-4f39-11eb-94e2-8a2c4dadc475.png)

## Task Show Page

**Before**
![Screen Shot 2021-01-05 at 9 18 45 AM](https://user-images.githubusercontent.com/22918438/103658359-2062ad00-4f39-11eb-9135-90e16a602c3c.png)

**After**
![Screen Shot 2021-01-05 at 9 19 04 AM](https://user-images.githubusercontent.com/22918438/103658362-20fb4380-4f39-11eb-8cdd-4963f3fb3131.png)

## Task Show Page for New Tasks (Same)
**Before**
![Screen Shot 2021-01-05 at 10 31 44 AM](https://user-images.githubusercontent.com/22918438/103665406-60c62900-4f41-11eb-8502-f400fc2d2235.png)

**After**
![Screen Shot 2021-01-05 at 10 32 15 AM](https://user-images.githubusercontent.com/22918438/103665412-615ebf80-4f41-11eb-8c19-3ea6f04a1520.png)
