### PR TITLE
Show created_at timestamps for latest runs and make views consistent

### DIFF
--- a/app/views/maintenance_tasks/runs/_info.html.erb
+++ b/app/views/maintenance_tasks/runs/_info.html.erb
@@ -1,3 +1,8 @@
+<h5 class="title is-5">
+  <%= time_tag run.created_at, title: run.created_at %>
+  <%= status_tag run.status if with_status %>
+</h5>
+
 <%= progress run %>
 
 <div class="content">

--- a/app/views/maintenance_tasks/runs/_run.html.erb
+++ b/app/views/maintenance_tasks/runs/_run.html.erb
@@ -1,13 +1,11 @@
 <div class="box">
-  <% if task_name %>
+  <% if with_task_name %>
     <h3 class="title is-3">
       <%= link_to run.task_name, task_path(run.task_name) %>
+      <%= status_tag run.status %>
     </h3>
+    <%= render 'maintenance_tasks/runs/info', run: run, with_status: false %>
+  <% else %>
+    <%= render 'maintenance_tasks/runs/info', run: run, with_status: true %>
   <% end %>
-  <h5 class="title is-5">
-    <%= time_tag run.created_at, title: run.created_at %>
-    <%= status_tag run.status %>
-  </h5>
-
-  <%= render 'maintenance_tasks/runs/info', run: run %>
 </div>

--- a/app/views/maintenance_tasks/runs/index.html.erb
+++ b/app/views/maintenance_tasks/runs/index.html.erb
@@ -11,5 +11,5 @@
   <% end %>
 </div>
 
-<%= render @runs, task_name: true %>
+<%= render @runs, with_task_name: true %>
 <%= pagination(@pagy) %>

--- a/app/views/maintenance_tasks/tasks/_task.html.erb
+++ b/app/views/maintenance_tasks/tasks/_task.html.erb
@@ -4,5 +4,5 @@
     <%= status_tag(task.status) %>
   </h3>
 
-  <%= render 'maintenance_tasks/runs/info', run: task.last_run if task.last_run %>
+  <%= render 'maintenance_tasks/runs/info', run: task.last_run, with_status: false if task.last_run %>
 </div>

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -4,7 +4,7 @@
   <%= @task %> <%= status_tag(@task.status) %>
 </h1>
 
-<%= render 'maintenance_tasks/runs/info', run: @task.last_run if @task.last_run %>
+<%= render 'maintenance_tasks/runs/info', run: @task.last_run, with_status: false if @task.last_run %>
 
 <div class="buttons">
   <%= render "maintenance_tasks/tasks/actions/#{@task.status}", task: @task %>
@@ -19,7 +19,7 @@
 
   <h4 class="title is-4">Previous Runs</h4>
 
-  <%= render @previous_runs, task_name: false %>
+  <%= render @previous_runs, with_task_name: false %>
 
   <%= pagination(@pagy) %>
 <% end %>


### PR DESCRIPTION
Second pass at https://github.com/Shopify/maintenance_tasks/issues/252

This PR addresses adding the `created_at` timestamp for latest Runs listed on the Tasks index page, as well as the latest Run at the top of the Task show page. It also makes the Runs index page more consistent by moving the status to be next to the Task name, rather than the date.

To accomplish this, I've moved the timestamp to the info partial inside an `<h5>` heading. The Run's status is showed beside the timestamp if the `with_status` flag is set. Then, the other relevant views have been updated:
* `_run`: 
     * Shows the status next to the Task name if `task_name` is set
     * If `task_name` is set, renders the info partial without the `with_status` flag
     * If `task_name` is not set, renders the info partial with the `with_status` flag
* `_task`:
     * Renders the info partial without the `with_status` flag, since it's displayed next to the Task name
* `show`:
     * Renders the info partial without the `with_status` flag, since it's displayed next to the Task name

## Maintenance Tasks Index
**Before**
![Screen Shot 2021-01-05 at 2 09 40 PM](https://user-images.githubusercontent.com/22918438/103688322-a98cda80-4f5f-11eb-9a44-570f3127c685.png)

**After**
![Screen Shot 2021-01-05 at 2 07 14 PM](https://user-images.githubusercontent.com/22918438/103688112-52870580-4f5f-11eb-86fd-24b5fc53070c.png)

## Task Show Page
**Before**
![Screen Shot 2021-01-05 at 2 10 05 PM](https://user-images.githubusercontent.com/22918438/103688366-b8738d00-4f5f-11eb-9bee-4865dbe63b6d.png)

**After**
![Screen Shot 2021-01-05 at 2 08 12 PM](https://user-images.githubusercontent.com/22918438/103688192-75b1b500-4f5f-11eb-93e4-4274eba51c68.png)

## Runs Index
**Before**
![Screen Shot 2021-01-05 at 2 09 03 PM](https://user-images.githubusercontent.com/22918438/103688266-924ded00-4f5f-11eb-8911-aea789e4f4c4.png)

**After**
![Screen Shot 2021-01-05 at 2 08 37 PM](https://user-images.githubusercontent.com/22918438/103688234-82cea400-4f5f-11eb-809a-b7fbc165fab2.png)
