### PR TITLE
Remove force: true flag on runs table

### DIFF
--- a/db/migrate/20201211151756_create_maintenance_tasks_runs.rb
+++ b/db/migrate/20201211151756_create_maintenance_tasks_runs.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class CreateMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
   def change
-    create_table(:maintenance_tasks_runs, force: true) do |t|
+    create_table(:maintenance_tasks_runs) do |t|
       t.string(:task_name, null: false)
       t.datetime(:started_at)
       t.datetime(:ended_at)


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/238

As we prepare to open-source, we should drop the `force: true` flag from the `maintenance_tasks_runs` table so that we no longer drop the table before creating it. Any changes to our data models will need to be applied as new migrations moving forward.