### PR TITLE
Revert "Merge pull request #216 from Shopify/deleted-tasks"

### DIFF
--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -6,7 +6,7 @@ module MaintenanceTasks
   #
   # @api private
   class RunsController < ApplicationController
-    before_action :set_run, except: :index
+    before_action :set_run, :set_task, except: :index
 
     # Shows a full list of Runs.
     def index
@@ -21,7 +21,7 @@ module MaintenanceTasks
     # Updates a Run status to paused.
     def pause
       @run.pausing!
-      redirect_to(task_path(@run.task_name))
+      redirect_to(task_path(@task))
     rescue ActiveRecord::RecordInvalid => error
       redirect_to(task_path(@run.task_name), alert: error.message)
     end
@@ -29,7 +29,7 @@ module MaintenanceTasks
     # Updates a Run status to cancelling.
     def cancel
       @run.cancel
-      redirect_to(task_path(@run.task_name))
+      redirect_to(task_path(@task))
     rescue ActiveRecord::RecordInvalid => error
       redirect_to(task_path(@run.task_name), alert: error.message)
     end
@@ -38,6 +38,10 @@ module MaintenanceTasks
 
     def set_run
       @run = Run.find(params.fetch(:id))
+    end
+
+    def set_task
+      @task = Task.named(params.fetch(:task_id))
     end
   end
   private_constant :RunsController

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -30,10 +30,9 @@ module MaintenanceTasks
 
     enum status: STATUSES.to_h { |status| [status, status.to_s] }
 
-    validates :task_name, on: :create, inclusion: { in: ->(_) {
+    validates :task_name, inclusion: { in: ->(_) {
       Task.available_tasks.map(&:to_s)
     } }
-    attr_readonly :task_name
 
     serialize :backtrace
 

--- a/app/views/maintenance_tasks/tasks/actions/_enqueued.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_enqueued.html.erb
@@ -1,2 +1,2 @@
 <%= button_to 'Pause', pause_task_run_path(task, task.last_run), method: :put, class: 'button is-warning', disabled: task.deleted? %>
-<%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger' %>
+<%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger', disabled: task.deleted? %>

--- a/app/views/maintenance_tasks/tasks/actions/_interrupted.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_interrupted.html.erb
@@ -1,2 +1,2 @@
 <%= button_to 'Pause', pause_task_run_path(task, task.last_run), method: :put, class: 'button is-warning', disabled: task.deleted? %>
-<%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger' %>
+<%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger', disabled: task.deleted? %>

--- a/app/views/maintenance_tasks/tasks/actions/_paused.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_paused.html.erb
@@ -1,2 +1,2 @@
 <%= button_to 'Resume', run_task_path(task), method: :put, class: 'button is-primary', disabled: task.deleted? %>
-<%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger' %>
+<%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger', disabled: task.deleted? %>

--- a/app/views/maintenance_tasks/tasks/actions/_running.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_running.html.erb
@@ -1,2 +1,2 @@
 <%= button_to 'Pause', pause_task_run_path(task, task.last_run), method: :put, class: 'button is-warning', disabled: task.deleted? %>
-<%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger' %>
+<%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger', disabled: task.deleted? %>

--- a/test/fixtures/maintenance_tasks/runs.yml
+++ b/test/fixtures/maintenance_tasks/runs.yml
@@ -19,12 +19,3 @@ deleted_task:
   created_at: '01 Jan 2020 01:00:00'
   started_at: '01 Jan 2020 01:00:25'
   ended_at: '01 Jan 2020 01:00:36'
-
-paused_deleted_task:
-  task_name: Maintenance::PausedDeletedTask
-  tick_count: 5
-  tick_total: 10
-  job_id: '123abc'
-  status: 'paused'
-  created_at: '09 Jan 2020 09:30:00'
-  started_at: '09 Jan 2020 09:30:25'

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -78,13 +78,6 @@ module MaintenanceTasks
 
       refresh
       click_on 'Cancel'
-    end
-
-    test 'cancel a deleted task' do
-      visit maintenance_tasks_path + '/tasks/Maintenance::PausedDeletedTask'
-
-      click_on 'Cancel'
-
       assert_text 'Cancelled'
     end
 
@@ -161,11 +154,11 @@ module MaintenanceTasks
       assert_text alert_text
     end
 
-    test 'list Runs including from deleted Tasks' do
+    test 'list Runs' do
       visit maintenance_tasks_path
       click_on 'Runs'
 
-      assert_text 'Ran for', count: 3
+      assert_text 'Ran for', count: 2
       assert_text 'Maintenance::DeletedTask'
     end
 
@@ -176,9 +169,8 @@ module MaintenanceTasks
       fill_in 'Task name', with: 'deleted'
       click_on 'Search'
 
-      assert_text 'Ran for', count: 2
+      assert_text 'Ran for', count: 1
       assert_text 'Maintenance::DeletedTask'
-      assert_text 'Maintenance::PausedDeletedTask'
     end
   end
 end


### PR DESCRIPTION
This reverts pull request #216.

The conversation about deleted tasks is still ongoing. While we don't have a clear vision about discoverability and what to do about orphaned runs, or even if we care about this at all, we should not ship optimizations regarding them.