### PR TITLE
Revert "Merge pull request #248 from Shopify/bugsnag-integration"

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ The generator creates and runs a migration to add the necessary table to your
 database. It also mounts Maintenance Tasks in your `config/routes.rb`. By
 default the web UI can be accessed in the new `/maintenance_tasks` path.
 
+In case you use an exception reporting service (e.g. Bugsnag) you might want to
+define an error handler. See
+[Customizing the error handler](#customizing-the-error-handler) for more
+information.
+
 ## Usage
 
 ### Creating a Task
@@ -224,15 +229,12 @@ be placed in a `maintenance_tasks.rb` initializer.
 Exceptions raised while a Task is performing are rescued and information about
 the error is persisted and visible in the UI.
 
-If your application uses Bugsnag to monitor errors, the gem will automatically
-notify Bugsnag of any errors raised while a Task is performing.
-
-If you want to integrate with another exception monitoring service or customize
-error handling, a callback can be defined:
+If you want to integrate with an exception monitoring service (e.g. Bugsnag),
+you can define an error handler:
 
 ```ruby
 # config/initializers/maintenance_tasks.rb
-MaintenanceTasks.error_handler = ->(error) { MyErrorMonitor.notify(error) }
+MaintenanceTasks.error_handler = ->(error) { Bugsnag.notify(error) }
 ```
 
 #### Customizing the maintenance tasks module

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -34,17 +34,4 @@ module MaintenanceTasks
 
   # Defines a callback to be performed when an error occurs in the task.
   mattr_accessor :error_handler, default: ->(_error) {}
-
-  class << self
-    # Attempts to configure Bugsnag integration. If the application uses
-    # Bugsnag, it is automatically configured to report on errors raised while
-    # a Task is performing.
-    def configure_bugsnag_integration
-      load('maintenance_tasks/integrations/bugsnag_handler.rb')
-    rescue LoadError
-      nil
-    end
-  end
 end
-
-MaintenanceTasks.configure_bugsnag_integration

--- a/lib/maintenance_tasks/integrations/bugsnag_handler.rb
+++ b/lib/maintenance_tasks/integrations/bugsnag_handler.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-require 'bugsnag'
-
-MaintenanceTasks.error_handler = ->(error) { Bugsnag.notify(error) }

--- a/test/lib/maintenance_tasks_test.rb
+++ b/test/lib/maintenance_tasks_test.rb
@@ -2,33 +2,6 @@
 require 'test_helper'
 
 class MaintenanceTasksTest < ActiveSupport::TestCase
-  test '.configure_bugsnag_integration keeps original error handler if no Bugsnag' do
-    original_error_handler = MaintenanceTasks.error_handler
-    MaintenanceTasks.configure_bugsnag_integration
-    assert_equal original_error_handler, MaintenanceTasks.error_handler
-  end
-
-  test '.configure_bugsnag_integration configures error handler to notify Bugsnag if Bugsnag in use' do
-    previous_error_handler = MaintenanceTasks.error_handler
-
-    # Stub Bugsnag being installed on host application
-    Object.const_set(:Bugsnag, Class.new)
-    main_self = TOPLEVEL_BINDING.receiver
-    Mocha::Configuration.override(
-      stubbing_non_public_method: :allow,
-      stubbing_non_existent_method: :allow,
-    ) do
-      main_self.expects(:require).with('bugsnag').returns(true)
-      Bugsnag.expects(:notify).with('Something went wrong')
-    end
-
-    MaintenanceTasks.configure_bugsnag_integration
-    MaintenanceTasks.error_handler.call('Something went wrong')
-  ensure
-    MaintenanceTasks.error_handler = previous_error_handler
-    Object.send(:remove_const, :Bugsnag)
-  end
-
   test "doesn't leak its internals" do
     expected_public_constants = [
       :Engine,  # to mount


### PR DESCRIPTION
This reverts PR #248. I don't think we should make assumptions about the usage of Bugsnag. As long as we make integrating Bugsnag possible, and document it in the README, it should suffice.