### PR TITLE
Return the Task Job as a string in the config

### DIFF
--- a/app/models/maintenance_tasks/runner.rb
+++ b/app/models/maintenance_tasks/runner.rb
@@ -40,7 +40,7 @@ module MaintenanceTasks
     private
 
     def enqueue(run)
-      unless MaintenanceTasks.job.perform_later(run)
+      unless MaintenanceTasks.job.constantize.perform_later(run)
         raise "The job to perform #{run.task_name} could not be enqueued. "\
           'Enqueuing has been prevented by a callback.'
       end

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -21,7 +21,7 @@ module MaintenanceTasks
   # `MaintenanceTasks::TaskJob` or a class that inherits from it.
   #
   # @param [String] the name of the job class.
-  mattr_writer :job, default: 'MaintenanceTasks::TaskJob'
+  mattr_accessor :job, default: 'MaintenanceTasks::TaskJob'
 
   # After each iteration, the progress of the task may be updated. This duration
   # in seconds limits these updates, skipping if the duration since the last
@@ -36,14 +36,6 @@ module MaintenanceTasks
   mattr_accessor :error_handler, default: ->(_error) {}
 
   class << self
-    # Retrieves the class that is configured as the Task Job to be used to
-    # perform Tasks.
-    #
-    # @return [TaskJob] the job class.
-    def job
-      @@job.constantize
-    end
-
     # Attempts to configure Bugsnag integration. If the application uses
     # Bugsnag, it is automatically configured to report on errors raised while
     # a Task is performing.

--- a/test/lib/maintenance_tasks_test.rb
+++ b/test/lib/maintenance_tasks_test.rb
@@ -15,14 +15,6 @@ class MaintenanceTasksTest < ActiveSupport::TestCase
     MaintenanceTasks.tasks_module = previous_task_module
   end
 
-  test '.job can be set' do
-    original_job = MaintenanceTasks.job.name
-    MaintenanceTasks.job = 'CustomTaskJob'
-    assert_equal(CustomTaskJob, MaintenanceTasks.job)
-  ensure
-    MaintenanceTasks.job = original_job
-  end
-
   test '.configure_bugsnag_integration keeps original error handler if no Bugsnag' do
     original_error_handler = MaintenanceTasks.error_handler
     MaintenanceTasks.configure_bugsnag_integration

--- a/test/lib/maintenance_tasks_test.rb
+++ b/test/lib/maintenance_tasks_test.rb
@@ -2,19 +2,6 @@
 require 'test_helper'
 
 class MaintenanceTasksTest < ActiveSupport::TestCase
-  test '.tasks_module defaults to constant Maintenance' do
-    assert_equal('Maintenance', MaintenanceTasks.tasks_module)
-  end
-
-  test '.tasks_module can be set' do
-    previous_task_module = MaintenanceTasks.tasks_module
-
-    MaintenanceTasks.tasks_module = 'Task'
-    assert_equal('Task', MaintenanceTasks.tasks_module)
-  ensure
-    MaintenanceTasks.tasks_module = previous_task_module
-  end
-
   test '.configure_bugsnag_integration keeps original error handler if no Bugsnag' do
     original_error_handler = MaintenanceTasks.error_handler
     MaintenanceTasks.configure_bugsnag_integration


### PR DESCRIPTION
Similar to what was done in #255 for `task_module`, this change returns a String for the job class name, which can be constantized where necessary.