### PR TITLE
Handle error handling for deleted tasks

### DIFF
--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -90,7 +90,7 @@ module MaintenanceTasks
     end
 
     def on_error(error)
-      @ticker.persist
+      @ticker.persist if defined?(@ticker)
       @run.persist_error(error)
       MaintenanceTasks.error_handler.call(error)
     end

--- a/app/validators/maintenance_tasks/run_status_validator.rb
+++ b/app/validators/maintenance_tasks/run_status_validator.rb
@@ -57,7 +57,9 @@ module MaintenanceTasks
       #   it is interrupted.
       # interrupted -> cancelling occurs when the task is cancelled by the user
       #   while it is interrupted.
-      'interrupted' => ['running', 'pausing', 'cancelling'],
+      # interrupted -> errored occurs when the task is deleted while it is
+      #   interrupted.
+      'interrupted' => ['running', 'pausing', 'cancelling', 'errored'],
     }
 
     # Validate whether a transition from one Run status

--- a/app/validators/maintenance_tasks/run_status_validator.rb
+++ b/app/validators/maintenance_tasks/run_status_validator.rb
@@ -11,7 +11,8 @@ module MaintenanceTasks
       # enqueued -> pausing occurs when the task is paused before starting.
       # enqueued -> cancelling occurs when the task is cancelled
       #   before starting.
-      # enqueued -> errored occurs when the task job fails to be enqueued.
+      # enqueued -> errored occurs when the task job fails to be enqueued, or
+      #   if the Task is deleted before is starts running.
       'enqueued' => ['running', 'pausing', 'cancelling', 'errored'],
       # pausing -> paused occurs when the task actually halts performing and
       #   occupies a status of paused.

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -142,6 +142,16 @@ module MaintenanceTasks
       TaskJob.perform_now(run)
     end
 
+    test '.perform_now handles when the Task cannot be found' do
+      run = Run.new(task_name: 'Maintenance::DeletedTask')
+      run.save(validate: false)
+
+      TaskJob.perform_now(run)
+
+      assert_equal 'MaintenanceTasks::Task::NotFoundError', run.error_class
+      assert_equal 'Task Maintenance::DeletedTask not found.', run.error_message
+    end
+
     test '.perform_now does not enqueue another job if Run errors' do
       run = Run.create!(task_name: 'Maintenance::ErrorTask')
 

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -152,6 +152,18 @@ module MaintenanceTasks
       assert_equal 'Task Maintenance::DeletedTask not found.', run.error_message
     end
 
+    test '.perform_now handles when the Task cannot be found when resuming after interruption' do
+      run = Run.new(task_name: 'Maintenance::DeletedTask')
+      run.save(validate: false)
+      run.running! # the Task existed when the run started
+      run.interrupted! # but not after interruption
+
+      TaskJob.perform_now(run)
+
+      assert_equal 'MaintenanceTasks::Task::NotFoundError', run.error_class
+      assert_equal 'Task Maintenance::DeletedTask not found.', run.error_message
+    end
+
     test '.perform_now does not enqueue another job if Run errors' do
       run = Run.create!(task_name: 'Maintenance::ErrorTask')
 

--- a/test/validators/maintenance_tasks/run_status_validator_test.rb
+++ b/test/validators/maintenance_tasks/run_status_validator_test.rb
@@ -179,7 +179,7 @@ module MaintenanceTasks
       assert_no_invalid_transitions([:running], :interrupted)
     end
 
-    test 'run can go from enqueued, running, pausing or cancelling to errored' do
+    test 'run can go from enqueued, running, pausing, interrupted or cancelling to errored' do
       enqueued_run = Run.create!(task_name: 'Maintenance::UpdatePostsTask')
       enqueued_run.status = :errored
 
@@ -201,6 +201,14 @@ module MaintenanceTasks
 
       assert pausing_run.valid?
 
+      interrupted_run = Run.create!(
+        task_name: 'Maintenance::UpdatePostsTask',
+        status: :interrupted
+      )
+      interrupted_run.status = :errored
+
+      assert interrupted_run.valid?
+
       cancelling_run = Run.create!(
         task_name: 'Maintenance::UpdatePostsTask',
         status: :cancelling
@@ -210,7 +218,7 @@ module MaintenanceTasks
       assert cancelling_run.valid?
 
       assert_no_invalid_transitions(
-        [:enqueued, :running, :pausing, :cancelling],
+        [:enqueued, :running, :pausing, :interrupted, :cancelling],
         :errored
       )
     end


### PR DESCRIPTION
If a Task is enqueued and is then deleted before being performed, or if a Task is interrupted and deleted, it results in a crash.

To repro:

```sh-session
$ bundle add sidekiq
$ $EDITOR test/dummy/config/application.rb
# add this line
# config.active_job.queue_adapter = :sidekiq
```

Start a server, visit http://localhost:3000/maintenance_tasks/tasks/Maintenance::UpdatePostsTask, start a run then:

```
$ rm test/dummy/app/tasks/maintenance/update_posts_task.rb
$ (cd test/dummy; bundle exec sidekiq)
# crash
```

This is fixed by the first commit.

```
$ git checkout task-deleted-during-run^
$ (cd test/dummy; bundle exec sidekiq)
# this should pick up the retry, otherwise clean up and redo the steps above
```

```sh-session
$ git restore -- test/dummy/app/tasks/maintenance/update_posts_task.rb
$ (cd test/dummy; bundle exec sidekiq)
# enqueue the job, once it starts, hit Ctrl-C to stop sidekiq and interrupt the task
$ rm test/dummy/app/tasks/maintenance/update_posts_task.rb
$ (cd test/dummy; bundle exec sidekiq)
# crash
```

This is fixed by the second commit:

```sh-session
$ git checkout task-deleted-during-run^
$ (cd test/dummy; bundle exec sidekiq)
# this should pick up the retry, otherwise clean up and redo the steps above
```