### PR TITLE
Remove the need to call new for public APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ module Maintenance
     test "#process performs a task iteration" do
       post = Post.new
 
-      Maintenance::UpdatePostsTask.new.process(post)
+      Maintenance::UpdatePostsTask.process(post)
 
       assert_equal 'New content!', post.content
     end

--- a/README.md
+++ b/README.md
@@ -150,11 +150,10 @@ Alternatively, you can run your Task in the command line:
 $ bundle exec maintenance_tasks perform Maintenance::UpdatePostsTask
 ```
 
-You can also run a Task in Ruby by sending `run` with a Task name to a Runner
-instance:
+You can also run a Task in Ruby by sending `run` with a Task name to Runner:
 
 ```ruby
-MaintenanceTasks::Runner.new.run(name: 'Maintenance::UpdatePostsTask')
+MaintenanceTasks::Runner.run(name: 'Maintenance::UpdatePostsTask')
 ```
 
 ### Monitoring your Task's status

--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -24,7 +24,7 @@ module MaintenanceTasks
 
     # Runs a given Task and redirects to the Task page.
     def run
-      task = Runner.new.run(name: params.fetch(:id))
+      task = Runner.run(name: params.fetch(:id))
       redirect_to(task_path(task))
     rescue ActiveRecord::RecordInvalid => error
       redirect_to(task_path(error.record.task_name), alert: error.message)

--- a/app/models/maintenance_tasks/runner.rb
+++ b/app/models/maintenance_tasks/runner.rb
@@ -2,7 +2,9 @@
 
 module MaintenanceTasks
   # This class is responsible for running a given Task.
-  class Runner
+  module Runner
+    extend self
+
     # Exception raised when a Task Job couldn't be enqueued.
     class EnqueuingError < StandardError
       # Initializes a Enqueuing Error.

--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -39,6 +39,15 @@ module MaintenanceTasks
         new.process(item)
       end
 
+      # Returns the collection for this Task.
+      #
+      # Especially useful for tests.
+      #
+      # @return the collection.
+      def collection
+        new.collection
+      end
+
       private
 
       def load_constants

--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -48,6 +48,15 @@ module MaintenanceTasks
         new.collection
       end
 
+      # Returns the count of items for this Task.
+      #
+      # Especially useful for tests.
+      #
+      # @return the count of items.
+      def count
+        new.count
+      end
+
       private
 
       def load_constants

--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -30,6 +30,15 @@ module MaintenanceTasks
         descendants
       end
 
+      # Processes one item.
+      #
+      # Especially useful for tests.
+      #
+      # @param item the item to process.
+      def process(item)
+        new.process(item)
+      end
+
       private
 
       def load_constants

--- a/lib/generators/maintenance_tasks/templates/task_spec.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/task_spec.rb.tt
@@ -6,7 +6,7 @@ module <%= tasks_module %>
   RSpec.describe <%= class_name %>Task do
     # describe '#process' do
       # it 'performs a task iteration' do
-        # <%= tasks_module %>::<%= class_name %>Task.new.process(element)
+        # <%= tasks_module %>::<%= class_name %>Task.process(element)
       # end
     # end
   end

--- a/lib/generators/maintenance_tasks/templates/task_test.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/task_test.rb.tt
@@ -5,7 +5,7 @@ module <%= tasks_module %>
 <% module_namespacing do -%>
   class <%= class_name %>TaskTest < ActiveSupport::TestCase
     # test "#process performs a task iteration" do
-    #   <%= tasks_module %>::<%= class_name %>Task.new.process(element)
+    #   <%= tasks_module %>::<%= class_name %>Task.process(element)
     # end
   end
 <% end -%>

--- a/lib/maintenance_tasks/cli.rb
+++ b/lib/maintenance_tasks/cli.rb
@@ -30,7 +30,7 @@ module MaintenanceTasks
     #
     # @param name [String] the name of the Task to be run.
     def perform(name)
-      task = Runner.new.run(name: name)
+      task = Runner.run(name: name)
       say_status(:success, "#{task.name} was enqueued.", :green)
     rescue => error
       say_status(:error, error.message, :red)

--- a/test/lib/maintenance_tasks/cli_test.rb
+++ b/test/lib/maintenance_tasks/cli_test.rb
@@ -16,14 +16,14 @@ module MaintenanceTasks
     test '#perfom runs the given Task and prints a success message' do
       task = mock(name: 'MyTask')
 
-      Runner.any_instance.expects(:run).with(name: 'MyTask').returns(task)
+      Runner.expects(:run).with(name: 'MyTask').returns(task)
       @cli.expects(:say_status).with(:success, 'MyTask was enqueued.', :green)
 
       @cli.perform('MyTask')
     end
 
     test '#perfom prints an error message when the runner raises' do
-      Runner.any_instance.expects(:run).with(name: 'Wrong').raises('Invalid!')
+      Runner.expects(:run).with(name: 'Wrong').raises('Invalid!')
       @cli.expects(:say_status).with(:error, 'Invalid!', :red)
 
       @cli.perform('Wrong')

--- a/test/models/maintenance_tasks/runner_test.rb
+++ b/test/models/maintenance_tasks/runner_test.rb
@@ -8,7 +8,7 @@ module MaintenanceTasks
 
     setup do
       @name = 'Maintenance::UpdatePostsTask'
-      @runner = Runner.new
+      @runner = Runner
       @job = MaintenanceTasks.job.constantize
     end
 

--- a/test/tasks/maintenance_tasks/task_test.rb
+++ b/test/tasks/maintenance_tasks/task_test.rb
@@ -38,6 +38,10 @@ module MaintenanceTasks
       assert_equal [1, 2], Maintenance::TestTask.collection
     end
 
+    test '.count calls #count' do
+      assert_equal 2, Maintenance::TestTask.count
+    end
+
     test '#count is nil by default' do
       task = Task.new
       assert_nil task.count

--- a/test/tasks/maintenance_tasks/task_test.rb
+++ b/test/tasks/maintenance_tasks/task_test.rb
@@ -28,6 +28,12 @@ module MaintenanceTasks
       assert_equal 'Maintenance::DoesNotExist', error.name
     end
 
+    test '.process calls #process' do
+      item = mock
+      Maintenance::TestTask.any_instance.expects(:process).with(item)
+      Maintenance::TestTask.process(item)
+    end
+
     test '#count is nil by default' do
       task = Task.new
       assert_nil task.count

--- a/test/tasks/maintenance_tasks/task_test.rb
+++ b/test/tasks/maintenance_tasks/task_test.rb
@@ -34,6 +34,10 @@ module MaintenanceTasks
       Maintenance::TestTask.process(item)
     end
 
+    test '.collection calls #collection' do
+      assert_equal [1, 2], Maintenance::TestTask.collection
+    end
+
     test '#count is nil by default' do
       task = Task.new
       assert_nil task.count


### PR DESCRIPTION
This PR simplifies the API by removing the need to call new for public APIs:

```diff
- MaintenanceTasks::Runner.new.run(name: 'Maintenance::UpdatePostsTask')
+ MaintenanceTasks::Runner.run(name: 'Maintenance::UpdatePostsTask')
```

Mostly for tests, but I could see the `process` one being used:
```diff
- MaintenanceTasks::Task.new.process(item)
+ MaintenanceTasks::Task.process(item)

- MaintenanceTasks::Task.new.collection
+ MaintenanceTasks::Task.collection

- MaintenanceTasks::Task.new.count
+ MaintenanceTasks::Task.count
```