### PR TITLE
Add ActiveStorage to the dummy app

### DIFF
--- a/test/dummy/db/migrate/20210112141723_create_active_storage_tables.active_storage.rb
+++ b/test/dummy/db/migrate/20210112141723_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table(:active_storage_blobs) do |t|
+      t.string(:key,          null: false)
+      t.string(:filename,     null: false)
+      t.string(:content_type)
+      t.text(:metadata)
+      t.string(:service_name, null: false)
+      t.bigint(:byte_size,    null: false)
+      t.string(:checksum,     null: false)
+      t.datetime(:created_at, null: false)
+
+      t.index([:key], unique: true)
+    end
+
+    create_table(:active_storage_attachments) do |t|
+      t.string(:name, null: false)
+      t.references(:record,   null: false, polymorphic: true, index: false)
+      t.references(:blob,     null: false)
+
+      t.datetime(:created_at, null: false)
+
+      t.index(
+        [:record_type, :record_id, :name, :blob_id],
+        name: 'index_active_storage_attachments_uniqueness', unique: true
+      )
+      t.foreign_key(:active_storage_blobs, column: :blob_id)
+    end
+
+    create_table(:active_storage_variant_records) do |t|
+      t.belongs_to(:blob, null: false, index: false)
+      t.string(:variation_digest, null: false)
+
+      t.index(
+        [:blob_id, :variation_digest],
+        name: 'index_active_storage_variant_records_uniqueness',
+        unique: true
+      )
+      t.foreign_key(:active_storage_blobs, column: :blob_id)
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_11_151756) do
+ActiveRecord::Schema.define(version: 2021_01_12_141723) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.integer "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "maintenance_tasks_runs", force: :cascade do |t|
     t.string "task_name", null: false
@@ -38,4 +66,6 @@ ActiveRecord::Schema.define(version: 2020_12_11_151756) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/200

CSV functionality has been requested by a number of users at this point, so I think it makes sense to start building out this feature.

This PR sets up ActiveStorage in the dummy app by adding the necessary tables (from https://edgeguides.rubyonrails.org/active_storage_overview.html#setup, these were generated by doing `cd test/dummy; rails active_storage:install; rails db:migrate`).

We've settled on using the ActiveStorage library Rails provides because it seems reasonable for an uploaded CSV to be attached to a `Run` record, and ActiveStorage makes it simple for users to set up their apps with a cloud storage solution to store their uploaded CSVs.