### PR TITLE
Attach CSVs to runs

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -41,6 +41,8 @@ module MaintenanceTasks
 
     validates_with RunStatusValidator, on: :update
 
+    has_one_attached :csv_file
+
     # Sets the run status to enqueued, making sure the transition is validated
     # in case it's already enqueued.
     def enqueued!

--- a/app/models/maintenance_tasks/runner.rb
+++ b/app/models/maintenance_tasks/runner.rb
@@ -22,17 +22,22 @@ module MaintenanceTasks
     # Runs a Task.
     #
     # This method creates a Run record for the given Task name and enqueues the
-    # Run.
+    # Run. If a CSV file is provided, it is attached to the Run record.
     #
     # @param name [String] the name of the Task to be run.
+    # @param csv_file [attachable, nil] a CSV file that provides the collection
+    #   for the Task to iterate over when running, in the form of an attachable
+    #   (see https://edgeapi.rubyonrails.org/classes/ActiveStorage/Attached/One.html#method-i-attach).
+    #   Value is nil if the Task does not use CSV iteration.
     #
     # @return [Task] the Task that was run.
     #
     # @raise [EnqueuingError] if an error occurs while enqueuing the Run.
     # @raise [ActiveRecord::RecordInvalid] if validation errors occur while
     #   creating the Run.
-    def run(name:)
+    def run(name:, csv_file: nil)
       run = Run.active.find_by(task_name: name) || Run.new(task_name: name)
+      run.csv_file.attach(csv_file) if csv_file
 
       run.enqueued!
       enqueue(run)

--- a/test/fixtures/files/sample.csv
+++ b/test/fixtures/files/sample.csv
@@ -1,0 +1,12 @@
+shop_id,product_id,title
+1,101,Apple
+2,102,Banana
+3,103,Orange
+4,104,Cranberry
+5,105,Raspberry
+6,106,Kiwi
+7,107,Grapefruit
+8,108,Mango
+9,109,Watermellon
+10,110,Mellon
+11,111,Peach

--- a/test/models/maintenance_tasks/runner_test.rb
+++ b/test/models/maintenance_tasks/runner_test.rb
@@ -81,5 +81,15 @@ module MaintenanceTasks
         )
       end
     end
+
+    test '#run attaches CSV file to Run if one is provided' do
+      csv_file = file_fixture('sample.csv')
+      uploaded_csv = Rack::Test::UploadedFile.new(csv_file, 'text/csv')
+      @runner.run(name: @name, csv_file: uploaded_csv)
+
+      run = Run.last
+      assert_predicate run.csv_file, :attached?
+      assert_equal File.read(csv_file), run.csv_file.download
+    end
   end
 end


### PR DESCRIPTION
Smallish PR, as ActiveStorage handles all of the complexity associated with attaching an uploaded file to an ActiveRecord.
This PR attaches a `csv_file` to our Run model using the `has_one_attached` macro (this will always be a 1:1 relationship).

The `Runner` class is now responsible for attaching an incoming `csv_file` to newly created runs in its `#run` method. It will be up to the `TasksController` / CLI to pass the CSV from the UI or command line to the runner.