### PR TITLE
Remove dead code in Task

### DIFF
--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -97,14 +97,5 @@ module MaintenanceTasks
     # @return [Integer, nil]
     def count
     end
-
-    # Convenience method to allow tasks define enumerators with cursors for
-    # compatibility with Job Iteration.
-    #
-    # @return [JobIteration::EnumeratorBuilder] instance of an enumerator
-    #   builder available to tasks.
-    def enumerator_builder
-      JobIteration.enumerator_builder.new(nil)
-    end
   end
 end

--- a/test/tasks/maintenance_tasks/task_test.rb
+++ b/test/tasks/maintenance_tasks/task_test.rb
@@ -60,10 +60,5 @@ module MaintenanceTasks
       message = 'MaintenanceTasks::Task must implement `process`.'
       assert_equal message, error.message
     end
-
-    test '#enumerator_builder is an instance of JobIteration::EnumeratorBuilder' do
-      task = Task.new
-      assert_kind_of JobIteration::EnumeratorBuilder, task.enumerator_builder
-    end
   end
 end


### PR DESCRIPTION
This code was introduced [in this PR](https://github.com/Shopify/maintenance_tasks/pull/77) in an attempt to decouple Tasks from Jobs. In introducing the Task class, we had to couple it with JobIteration's enumerator builder so that we wouldn't change the existing API too much (we were trying to minimize changes in that single PR IIRC).

https://github.com/Shopify/maintenance_tasks/pull/93 was opened as a follow up to decouple Task from JobIteration's enumerator builder, but this convenience method was left over.

There's no need for it now that Task's API is decoupled entirely from JobIteration.
