### PR TITLE
Allow uploading CSVs to CSV supporting Tasks through the UI

### DIFF
--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -19,12 +19,16 @@ module MaintenanceTasks
     # Shows running and completed instances of the Task.
     def show
       @task = TaskData.find(params.fetch(:id))
+      set_refresh if @task.last_run.active?
       @pagy, @previous_runs = pagy(@task.previous_runs)
     end
 
     # Runs a given Task and redirects to the Task page.
     def run
-      task = Runner.run(name: params.fetch(:id))
+      task = Runner.run(
+        name: params.fetch(:id),
+        csv_file: params[:csv_file]
+      )
       redirect_to(task_path(task))
     rescue ActiveRecord::RecordInvalid => error
       redirect_to(task_path(error.record.task_name), alert: error.message)

--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -7,7 +7,7 @@ module MaintenanceTasks
   #
   # @api private
   class TasksController < ApplicationController
-    before_action :set_refresh, only: [:index, :show]
+    before_action :set_refresh, only: [:index]
 
     # Renders the maintenance_tasks/tasks page, displaying
     # available tasks to users, grouped by category.
@@ -19,7 +19,7 @@ module MaintenanceTasks
     # Shows running and completed instances of the Task.
     def show
       @task = TaskData.find(params.fetch(:id))
-      set_refresh if @task.last_run.active?
+      set_refresh if @task.last_run&.active?
       @pagy, @previous_runs = pagy(@task.previous_runs)
     end
 

--- a/app/models/maintenance_tasks/task_data.rb
+++ b/app/models/maintenance_tasks/task_data.rb
@@ -127,6 +127,11 @@ module MaintenanceTasks
       end
     end
 
+    # @return [Boolean] whether the Task inherits from CsvTask.
+    def csv_task?
+      !deleted? && Task.named(name) < CsvTask
+    end
+
     private
 
     def runs

--- a/app/views/maintenance_tasks/tasks/_upload_csv.html.erb
+++ b/app/views/maintenance_tasks/tasks/_upload_csv.html.erb
@@ -1,4 +1,0 @@
-<div class="block">
-  <%= form.label :csv_file %>
-  <%= form.file_field :csv_file %>
-</div>

--- a/app/views/maintenance_tasks/tasks/_upload_csv.html.erb
+++ b/app/views/maintenance_tasks/tasks/_upload_csv.html.erb
@@ -1,0 +1,4 @@
+<div class="block">
+  <%= form.label :csv_file %>
+  <%= form.file_field :csv_file %>
+</div>

--- a/app/views/maintenance_tasks/tasks/actions/_cancelled.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_cancelled.html.erb
@@ -1,1 +1,7 @@
-<%= button_to 'Run', run_task_path(task), method: :put, class: 'button is-success', disabled: task.deleted? %>
+<%= form_with url: run_task_path(task), method: :put do |form| %>
+  <%= render 'maintenance_tasks/tasks/upload_csv', form: form if task.csv_task? %>
+
+  <div class="block">
+    <%= form.submit 'Run', class: "button is-success", disabled: task.deleted? %>
+  </div>
+<% end %>

--- a/app/views/maintenance_tasks/tasks/actions/_cancelled.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_cancelled.html.erb
@@ -1,7 +1,0 @@
-<%= form_with url: run_task_path(task), method: :put do |form| %>
-  <%= render 'maintenance_tasks/tasks/upload_csv', form: form if task.csv_task? %>
-
-  <div class="block">
-    <%= form.submit 'Run', class: "button is-success", disabled: task.deleted? %>
-  </div>
-<% end %>

--- a/app/views/maintenance_tasks/tasks/actions/_cancelling.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_cancelling.html.erb
@@ -1,4 +1,0 @@
-<%= button_to 'Run', run_task_path(task), method: :put, class: 'button is-success', disabled: true %>
-<% if task.last_run.stuck? %>
-  <%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger', disabled: task.deleted? %>
-<% end %>

--- a/app/views/maintenance_tasks/tasks/actions/_enqueued.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_enqueued.html.erb
@@ -1,2 +1,0 @@
-<%= button_to 'Pause', pause_task_run_path(task, task.last_run), method: :put, class: 'button is-warning', disabled: task.deleted? %>
-<%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger' %>

--- a/app/views/maintenance_tasks/tasks/actions/_errored.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_errored.html.erb
@@ -1,1 +1,7 @@
-<%= button_to 'Run', run_task_path(task), method: :put, class: 'button is-success', disabled: task.deleted? %>
+<%= form_with url: run_task_path(task), method: :put do |form| %>
+  <%= render 'maintenance_tasks/tasks/upload_csv', form: form if task.csv_task? %>
+
+  <div class="block">
+    <%= form.submit 'Run', class: "button is-success", disabled: task.deleted? %>
+  </div>
+<% end %>

--- a/app/views/maintenance_tasks/tasks/actions/_errored.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_errored.html.erb
@@ -1,7 +1,0 @@
-<%= form_with url: run_task_path(task), method: :put do |form| %>
-  <%= render 'maintenance_tasks/tasks/upload_csv', form: form if task.csv_task? %>
-
-  <div class="block">
-    <%= form.submit 'Run', class: "button is-success", disabled: task.deleted? %>
-  </div>
-<% end %>

--- a/app/views/maintenance_tasks/tasks/actions/_interrupted.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_interrupted.html.erb
@@ -1,2 +1,0 @@
-<%= button_to 'Pause', pause_task_run_path(task, task.last_run), method: :put, class: 'button is-warning', disabled: task.deleted? %>
-<%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger' %>

--- a/app/views/maintenance_tasks/tasks/actions/_new.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_new.html.erb
@@ -1,1 +1,7 @@
-<%= button_to 'Run', run_task_path(task), method: :put, class: 'button is-success', disabled: task.deleted? %>
+<%= form_with url: run_task_path(task), method: :put do |form| %>
+  <%= render 'maintenance_tasks/tasks/upload_csv', form: form if task.csv_task? %>
+
+  <div class="block">
+    <%= form.submit 'Run', class: "button is-success", disabled: task.deleted? %>
+  </div>
+<% end %>

--- a/app/views/maintenance_tasks/tasks/actions/_new.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_new.html.erb
@@ -1,7 +1,0 @@
-<%= form_with url: run_task_path(task), method: :put do |form| %>
-  <%= render 'maintenance_tasks/tasks/upload_csv', form: form if task.csv_task? %>
-
-  <div class="block">
-    <%= form.submit 'Run', class: "button is-success", disabled: task.deleted? %>
-  </div>
-<% end %>

--- a/app/views/maintenance_tasks/tasks/actions/_paused.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_paused.html.erb
@@ -1,2 +1,0 @@
-<%= button_to 'Resume', run_task_path(task), method: :put, class: 'button is-primary', disabled: task.deleted? %>
-<%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger' %>

--- a/app/views/maintenance_tasks/tasks/actions/_pausing.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_pausing.html.erb
@@ -1,2 +1,0 @@
-<%= button_to 'Pausing', pause_task_run_path(task, task.last_run), method: :put, class: 'button is-warning', disabled: true %>
-<%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger', disabled: task.deleted? %>

--- a/app/views/maintenance_tasks/tasks/actions/_running.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_running.html.erb
@@ -1,2 +1,0 @@
-<%= button_to 'Pause', pause_task_run_path(task, task.last_run), method: :put, class: 'button is-warning', disabled: task.deleted? %>
-<%= button_to 'Cancel', cancel_task_run_path(task, task.last_run), method: :put, class: 'button is-danger' %>

--- a/app/views/maintenance_tasks/tasks/actions/_succeeded.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_succeeded.html.erb
@@ -1,1 +1,7 @@
-<%= button_to 'Run', run_task_path(task), method: :put, class: 'button is-success', disabled: task.deleted? %>
+<%= form_with url: run_task_path(task), method: :put do |form| %>
+  <%= render 'maintenance_tasks/tasks/upload_csv', form: form if task.csv_task? %>
+
+  <div class="block">
+    <%= form.submit 'Run', class: "button is-success", disabled: task.deleted? %>
+  </div>
+<% end %>

--- a/app/views/maintenance_tasks/tasks/actions/_succeeded.html.erb
+++ b/app/views/maintenance_tasks/tasks/actions/_succeeded.html.erb
@@ -1,7 +1,0 @@
-<%= form_with url: run_task_path(task), method: :put do |form| %>
-  <%= render 'maintenance_tasks/tasks/upload_csv', form: form if task.csv_task? %>
-
-  <div class="block">
-    <%= form.submit 'Run', class: "button is-success", disabled: task.deleted? %>
-  </div>
-<% end %>

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -7,7 +7,34 @@
 <%= render 'maintenance_tasks/runs/info', run: @task.last_run, with_status: false if @task.last_run %>
 
 <div class="buttons">
-  <%= render "maintenance_tasks/tasks/actions/#{@task.status}", task: @task %>
+  <% last_run = @task.last_run %>
+  <% if last_run.nil? || last_run.completed? %>
+    <%= form_with url: run_task_path(@task), method: :put do |form| %>
+      <% if @task.csv_task? %>
+        <div class="block">
+          <%= form.label :csv_file %>
+          <%= form.file_field :csv_file %>
+        </div>
+      <% end %>
+      <div class="block">
+        <%= form.submit 'Run', class: "button is-success", disabled: @task.deleted? %>
+      </div>
+    <% end %>
+  <% elsif last_run.cancelling? %>
+    <%= button_to 'Run', run_task_path(@task), method: :put, class: 'button is-success', disabled: true %>
+    <% if last_run.stuck? %>
+      <%= button_to 'Cancel', cancel_task_run_path(@task, last_run), method: :put, class: 'button is-danger', disabled: @task.deleted? %>
+    <% end %>
+  <% elsif last_run.pausing? %>
+    <%= button_to 'Pausing', pause_task_run_path(@task, last_run), method: :put, class: 'button is-warning', disabled: true %>
+    <%= button_to 'Cancel', cancel_task_run_path(@task, last_run), method: :put, class: 'button is-danger' %>
+  <% elsif last_run.paused? %>
+    <%= button_to 'Resume', run_task_path(@task), method: :put, class: 'button is-primary', disabled: @task.deleted? %>
+    <%= button_to 'Cancel', cancel_task_run_path(@task, last_run), method: :put, class: 'button is-danger' %>
+  <% else %>
+    <%= button_to 'Pause', pause_task_run_path(@task, last_run), method: :put, class: 'button is-warning', disabled: @task.deleted? %>
+    <%= button_to 'Cancel', cancel_task_run_path(@task, last_run), method: :put, class: 'button is-danger' %>
+  <% end%>
 </div>
 
 <% if (code = @task.code) %>

--- a/test/models/maintenance_tasks/task_data_test.rb
+++ b/test/models/maintenance_tasks/task_data_test.rb
@@ -130,5 +130,17 @@ module MaintenanceTasks
       task_data = TaskData.new('Maintenance::UpdatePostsTask')
       assert_equal :completed, task_data.category
     end
+
+    test '#csv_task? returns true if the Task includes the CsvTask module' do
+      assert_predicate TaskData.new('Maintenance::ImportPostsTask'), :csv_task?
+    end
+
+    test '#csv_task? returns false if the Task does not include the CsvTask module' do
+      refute_predicate TaskData.new('Maintenance::UpdatePostsTask'), :csv_task?
+    end
+
+    test '#csv_task? returns false if the Task is deleted' do
+      refute_predicate TaskData.new('Maintenance::DoesNotExist'), :csv_task?
+    end
   end
 end

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -16,6 +16,19 @@ module MaintenanceTasks
       assert_no_button 'Run'
     end
 
+    test 'run a CSV Task' do
+      visit maintenance_tasks_path
+
+      click_on('Maintenance::ImportPostsTask')
+      attach_file('csv_file', 'test/fixtures/files/sample.csv')
+      click_on 'Run'
+
+      assert_title 'Maintenance::ImportPostsTask'
+      assert_text 'Enqueued'
+      assert_text 'Waiting to start.'
+      assert_no_button 'Run'
+    end
+
     test 'pause a Run' do
       visit maintenance_tasks_path
 


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/202

Allows files to be uploaded for CSV Tasks in the UI. I've modified any of the action partials that allow a Task to be run to use the [form_helper](https://api.rubyonrails.org/v6.1.1/classes/ActionView/Helpers/FormHelper.html#method-i-form_with) so that we can allow files to be submitted via a file input upload tag. The views call a new method `TaskData#csv_task?` to determine whether to render the file upload element.

I've also modified the TasksController show action to only set `@refresh` if there is an active run - this avoids unnecessarily refreshing when nothing is happening, which is particularly important for CSV Tasks, since the form might get refreshed before it is submitted with the current refresh behaviour (wiping the uploaded file).

We may want to look into allowing CSV tasks to run from the command line, but this is out of scope for this PR.

🎩 

**You can tophat the success case using `Maintenance::ImportPostsTask` and uploading `sample.csv` from the fixtures**
![Screen Shot 2021-01-21 at 3 26 32 PM](https://user-images.githubusercontent.com/22918438/105408504-0d203480-5bfd-11eb-8159-11c91921e22b.png)

**Failing to upload a CSV:**
![Screen Shot 2021-01-21 at 3 34 54 PM](https://user-images.githubusercontent.com/22918438/105409274-37bebd00-5bfe-11eb-9265-3451ecbee0a7.png)

**Uploading a non-CSV file:**
![Screen Shot 2021-01-21 at 3 37 00 PM](https://user-images.githubusercontent.com/22918438/105409483-84a29380-5bfe-11eb-9a7d-1813d83ff69d.png)

(Most scenarios where the CSV is invalid / not a CSV / does not conform to what is expected by `CSvTask#process` will simply be rescued and cause the Run to become `errored`, and don't need special treatment)