### PR TITLE
Set Task as errored if the Task doesn't define collection or process

### DIFF
--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -72,8 +72,7 @@ module MaintenanceTasks
     # @raise [NotImplementedError] with a message advising subclasses to
     #   implement an override for this method.
     def collection
-      raise NotImplementedError,
-        "#{self.class.name} must implement `collection`."
+      raise NoMethodError, "#{self.class.name} must implement `collection`."
     end
 
     # Placeholder method to raise in case a subclass fails to implement the
@@ -84,8 +83,7 @@ module MaintenanceTasks
     # @raise [NotImplementedError] with a message advising subclasses to
     #   implement an override for this method.
     def process(_item)
-      raise NotImplementedError,
-        "#{self.class.name} must implement `process`."
+      raise NoMethodError, "#{self.class.name} must implement `process`."
     end
 
     # Total count of iterations to be performed.

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -233,6 +233,26 @@ module MaintenanceTasks
       assert_equal expected_message, @run.error_message
     end
 
+    test '.perform_now sets the Run as errored when the Task collection is not defined' do
+      collection_method = Maintenance::TestTask.instance_method(:collection)
+      Maintenance::TestTask.remove_method(:collection)
+      TaskJob.perform_now(@run)
+      @run.reload
+      assert_predicate(@run, :errored?)
+    ensure
+      Maintenance::TestTask.define_method(:collection, collection_method)
+    end
+
+    test '.perform_now sets the Run as errored when the Task process is not defined' do
+      collection_method = Maintenance::TestTask.instance_method(:process)
+      Maintenance::TestTask.remove_method(:process)
+      TaskJob.perform_now(@run)
+      @run.reload
+      assert_predicate(@run, :errored?)
+    ensure
+      Maintenance::TestTask.define_method(:process, collection_method)
+    end
+
     test '.retry_on raises NotImplementedError' do
       assert_raises NotImplementedError do
         Class.new(TaskJob) { retry_on StandardError }

--- a/test/tasks/maintenance_tasks/task_test.rb
+++ b/test/tasks/maintenance_tasks/task_test.rb
@@ -48,16 +48,14 @@ module MaintenanceTasks
       assert_nil task.count
     end
 
-    test '#collection raises NotImplementedError' do
-      error = assert_raises(NotImplementedError) { Task.new.collection }
+    test '#collection raises NoMethodError' do
+      error = assert_raises(NoMethodError) { Task.new.collection }
       message = 'MaintenanceTasks::Task must implement `collection`.'
       assert_equal message, error.message
     end
 
-    test '#process raises NotImplementedError' do
-      error = assert_raises(NotImplementedError) do
-        Task.new.process('an item')
-      end
+    test '#process raises NoMethodError' do
+      error = assert_raises(NoMethodError) { Task.new.process('an item') }
       message = 'MaintenanceTasks::Task must implement `process`.'
       assert_equal message, error.message
     end


### PR DESCRIPTION
Before this commit, we raised a `NotImplementedError` exception, which doesn't inherit from `StandardError` so is not caught by our `rescue_from`.

Even if we try to change our rescue_from to rescue from `NotImplementedError`, `ActiveJob::Execution#perform_now` doesn't rescue `Exception` like `ActionController::Rescue#process` does, so it doesn't catch the exception.

https://github.com/rails/rails/blob/v6.1.1/activejob/lib/active_job/execution.rb#L50
https://github.com/rails/rails/blob/v6.1.1/actionpack/lib/action_controller/metal/rescue.rb#L23

Close #301 