### PR TITLE
Use superclass for CSV method

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,16 +123,13 @@ Generate a CSV Task by running:
 $ rails generate maintenance_tasks:task import_posts --csv
 ```
 
-The generated task is a subclass of `MaintenanceTasks::Task` that includes a
-`MaintenanceTasks::CsvTask` module and implements:
+The generated task is a subclass of `MaintenanceTasks::CsvTask` that implements:
 * `process`: do the work of your maintenance task on a `CSV::Row`
 
 ```ruby
 # app/tasks/maintenance/import_posts_task.rb
 module Maintenance
-  class ImportPostsTask < MaintenanceTasks::Task
-    include MaintenanceTasks::CsvTask
-
+  class ImportPostsTask < MaintenanceTasks::CsvTask
     def process(row)
       Post.create!(title: row["title"], content: row["content"])
     end

--- a/app/tasks/maintenance_tasks/csv_task.rb
+++ b/app/tasks/maintenance_tasks/csv_task.rb
@@ -3,8 +3,9 @@
 require 'csv'
 
 module MaintenanceTasks
-  # A mixin that provides a Task with the ability to process CSV files.
-  module CsvTask
+  # Base class that is inherited by the host application's Task classes for
+  # processing CSV files.
+  class CsvTask < Task
     # The contents of a CSV file to be processed by a Task.
     #
     # @return [String] the content of the CSV file to process.

--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -27,7 +27,7 @@ module MaintenanceTasks
       # @return [Array<Class>] the list of classes.
       def available_tasks
         load_constants
-        descendants
+        descendants.without(CsvTask)
       end
 
       # Processes one item.

--- a/lib/generators/maintenance_tasks/templates/csv_task.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/csv_task.rb.tt
@@ -2,9 +2,7 @@
 
 module <%= tasks_module %>
 <% module_namespacing do -%>
-  class <%= class_name %>Task < MaintenanceTasks::Task
-    include MaintenanceTasks::CsvTask
-
+  class <%= class_name %>Task < MaintenanceTasks::CsvTask
     def process(row)
       # The work to be done on a row of the CSV
     end

--- a/test/dummy/app/tasks/maintenance/import_posts_task.rb
+++ b/test/dummy/app/tasks/maintenance/import_posts_task.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 module Maintenance
-  class ImportPostsTask < MaintenanceTasks::Task
-    include MaintenanceTasks::CsvTask
-
+  class ImportPostsTask < MaintenanceTasks::CsvTask
     def process(row)
       Post.create!(title: row['title'], content: row['content'])
     end

--- a/test/lib/generators/maintenance_tasks/task_generator_test.rb
+++ b/test/lib/generators/maintenance_tasks/task_generator_test.rb
@@ -75,7 +75,7 @@ module MaintenanceTasks
     test 'generator creates a CSV Task if the --csv option is supplied' do
       run_generator ['sleepy', '--csv']
       assert_file 'app/tasks/maintenance/sleepy_task.rb' do |task|
-        assert_match(/include MaintenanceTasks::CsvTask/, task)
+        assert_match(/class SleepyTask < MaintenanceTasks::CsvTask/, task)
         assert_match(/def process\(row\)/, task)
       end
     end


### PR DESCRIPTION
Change the implementation of `CsvTask` to be a class from which application Tasks can inherit from, instead of a mixin.

It was unclear to me whether we're okay keeping the use of `respond_to?(csv_content=)` in `TaskJob` when setting `csv_content` on a Task:
https://github.com/Shopify/maintenance_tasks/blob/d5835468ea104dbe7c58fe4932c207229eaacb35/app/jobs/maintenance_tasks/task_job.rb#L59-L62

Or whether we wanted to introduce a class-level method like `csv_task?` instead. Let me know!