### PR TITLE
Use a class method to declare a CSV task

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,16 @@ Generate a CSV Task by running:
 $ rails generate maintenance_tasks:task import_posts --csv
 ```
 
-The generated task is a subclass of `MaintenanceTasks::CsvTask` that implements:
+The generated task is a subclass of `MaintenanceTasks::Task` that implements:
+
 * `process`: do the work of your maintenance task on a `CSV::Row`
 
 ```ruby
 # app/tasks/maintenance/import_posts_task.rb
 module Maintenance
-  class ImportPostsTask < MaintenanceTasks::CsvTask
+  class ImportPostsTask < MaintenanceTasks::Task
+    csv_collection
+
     def process(row)
       Post.create!(title: row["title"], content: row["content"])
     end

--- a/app/models/maintenance_tasks/csv_collection.rb
+++ b/app/models/maintenance_tasks/csv_collection.rb
@@ -3,9 +3,11 @@
 require 'csv'
 
 module MaintenanceTasks
-  # Base class that is inherited by the host application's Task classes for
+  # Module that is included into Task classes by Task.csv_collection for
   # processing CSV files.
-  class CsvTask < Task
+  #
+  # @api private
+  module CsvCollection
     # The contents of a CSV file to be processed by a Task.
     #
     # @return [String] the content of the CSV file to process.
@@ -28,4 +30,5 @@ module MaintenanceTasks
       csv_content.count("\n") - 1
     end
   end
+  private_constant :CsvCollection
 end

--- a/app/models/maintenance_tasks/task_data.rb
+++ b/app/models/maintenance_tasks/task_data.rb
@@ -129,7 +129,7 @@ module MaintenanceTasks
 
     # @return [Boolean] whether the Task inherits from CsvTask.
     def csv_task?
-      !deleted? && Task.named(name) < CsvTask
+      !deleted? && Task.named(name) < CsvCollection
     end
 
     private

--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -27,7 +27,15 @@ module MaintenanceTasks
       # @return [Array<Class>] the list of classes.
       def available_tasks
         load_constants
-        descendants.without(CsvTask)
+        descendants
+      end
+
+      # Make this Task a task that handles CSV.
+      #
+      # An input to upload a CSV will be added in the form to start a Run. The
+      # collection and count method are implemented.
+      def csv_collection
+        include(CsvCollection)
       end
 
       # Processes one item.

--- a/lib/generators/maintenance_tasks/templates/csv_task.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/csv_task.rb.tt
@@ -2,7 +2,9 @@
 
 module <%= tasks_module %>
 <% module_namespacing do -%>
-  class <%= class_name %>Task < MaintenanceTasks::CsvTask
+  class <%= class_name %>Task < MaintenanceTasks::Task
+    csv_collection
+
     def process(row)
       # The work to be done on a row of the CSV
     end

--- a/test/dummy/app/tasks/maintenance/import_posts_task.rb
+++ b/test/dummy/app/tasks/maintenance/import_posts_task.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Maintenance
-  class ImportPostsTask < MaintenanceTasks::CsvTask
+  class ImportPostsTask < MaintenanceTasks::Task
+    csv_collection
+
     def process(row)
       Post.create!(title: row['title'], content: row['content'])
     end

--- a/test/lib/generators/maintenance_tasks/task_generator_test.rb
+++ b/test/lib/generators/maintenance_tasks/task_generator_test.rb
@@ -75,7 +75,8 @@ module MaintenanceTasks
     test 'generator creates a CSV Task if the --csv option is supplied' do
       run_generator ['sleepy', '--csv']
       assert_file 'app/tasks/maintenance/sleepy_task.rb' do |task|
-        assert_match(/class SleepyTask < MaintenanceTasks::CsvTask/, task)
+        assert_match(/class SleepyTask < MaintenanceTasks::Task/, task)
+        assert_match(/csv_collection/, task)
         assert_match(/def process\(row\)/, task)
       end
     end

--- a/test/lib/maintenance_tasks_test.rb
+++ b/test/lib/maintenance_tasks_test.rb
@@ -7,7 +7,6 @@ class MaintenanceTasksTest < ActiveSupport::TestCase
       :Engine,  # to mount
       :Runner,  # to run a Task
       :Task,    # to define Tasks
-      :CsvTask, # to define CSV Tasks
       :TaskJob, # to customize the job
     ]
     public_constants = MaintenanceTasks.constants.select do |constant|


### PR DESCRIPTION
In #302 we went with a new subclass, which we refactored to a module to be included in a Task.

We got feedback in https://github.com/Shopify/maintenance_tasks/pull/302#discussion_r562911483 but we can't really change the behavior only based on data from the Run (a CSV file being present), since we need to know something about the class to show the input which results in a CSV file being updated. The class itself needs to somehow declare that it supports CSV.

Rafael pointed out that we shouldn't use `include` as an API for changing behavior to the classes, we discussed that on Slack but we missed the mark with #313 when we went instead with a superclass, as explained in https://github.com/Shopify/maintenance_tasks/pull/310#issuecomment-768529654.

So instead this PR uses a class method on Task, doesn't require the Task authors to include a module or inherit from a different class. They simply call `csv_collection`. I'm open to feedback about the name, but the idea with this one is that it defines a `collection` like a Task author would do for you, so there some parallel between defining a method `collection` and calling `csv_collection` on the class.

Using a class method opens up features like being able to choose whether the CSV should have headers, changing the column separator, using converters, etc. as arguments to the method call that could be passed in to [CSV.new](https://ruby-doc.org/stdlib-2.7.2/libdoc/csv/rdoc/CSV.html#method-c-new).

Internally this still includes a module into the class rather than adding conditionals to `collection` and `count` and adding the `csv_content` attribute to the receiver.