### PR TITLE
Allow CSV files for previous runs to be downloaded via the UI

### DIFF
--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -10,7 +10,7 @@ module MaintenanceTasks
 
     # Shows a full list of Runs.
     def index
-      query = Run.all.order(id: :desc)
+      query = Run.with_attached_csv_file.all.order(id: :desc)
       if params[:task_name].present?
         task_name = Run.sanitize_sql_like(params[:task_name])
         query = query.where('task_name LIKE ?', "%#{task_name}%")

--- a/app/helpers/maintenance_tasks/task_helper.rb
+++ b/app/helpers/maintenance_tasks/task_helper.rb
@@ -105,6 +105,14 @@ module MaintenanceTasks
       end
       safe_join(tokens)
     end
+
+    # Returns a download link for a Run's CSV attachment
+    def csv_file_download_path(run)
+      Rails.application.routes.url_helpers.rails_blob_path(
+        run.csv_file,
+        only_path: true
+      )
+    end
   end
   private_constant :TaskHelper
 end

--- a/app/models/maintenance_tasks/task_data.rb
+++ b/app/models/maintenance_tasks/task_data.rb
@@ -135,7 +135,7 @@ module MaintenanceTasks
     private
 
     def runs
-      Run.where(task_name: name).order(created_at: :desc)
+      Run.where(task_name: name).with_attached_csv_file.order(created_at: :desc)
     end
   end
   private_constant :TaskData

--- a/app/views/maintenance_tasks/runs/_info.html.erb
+++ b/app/views/maintenance_tasks/runs/_info.html.erb
@@ -8,3 +8,9 @@
 <div class="content">
   <%= render "maintenance_tasks/runs/info/#{run.status}", run: run %>
 </div>
+
+<% if run.csv_file.attached? %>
+  <div class="block">
+    <%= link_to('Download CSV', csv_file_download_path(run)) %>
+  </div>
+<% end %>

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -11,6 +11,10 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   driven_by :selenium, using: :headless_chrome do |options|
     options.add_argument('--disable-dev-shm-usage')
+    options.add_preference(
+      :download,
+      default_directory: 'test/dummy/tmp/downloads'
+    )
   end
 
   setup do
@@ -21,5 +25,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   teardown do
     assert_empty page.driver.browser.manage.logs.get(:browser)
     Maintenance::UpdatePostsTask.fast_task = true
+    FileUtils.rm_rf('test/dummy/tmp/downloads')
   end
 end

--- a/test/helpers/maintenance_tasks/task_helper_test.rb
+++ b/test/helpers/maintenance_tasks/task_helper_test.rb
@@ -84,5 +84,14 @@ module MaintenanceTasks
         '<span class="ruby-int">2</span>', highlight_code('1 2')
       assert_equal "\n", highlight_code("\n")
     end
+
+    test '#csv_file_download_path generates a download link to the CSV attachment for a Run' do
+      run = Run.create!(task_name: 'Maintenance::ImportPostsTask')
+      csv = Rack::Test::UploadedFile.new(file_fixture('sample.csv'), 'text/csv')
+      run.csv_file.attach(csv)
+
+      assert_match %r{rails\/active_storage\/blobs\/redirect\/\S+\/sample.csv},
+        csv_file_download_path(run)
+    end
   end
 end

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -29,6 +29,26 @@ module MaintenanceTasks
       assert_no_button 'Run'
     end
 
+    test 'download the CSV attached to a run for a CSV Task' do
+      visit(maintenance_tasks_path)
+
+      click_on('Maintenance::ImportPostsTask')
+      attach_file('csv_file', 'test/fixtures/files/sample.csv')
+      click_on('Run')
+
+      perform_enqueued_jobs
+      page.refresh
+
+      click_on('Download CSV')
+
+      downloaded_csv = 'test/dummy/tmp/downloads/sample.csv'
+
+      Timeout.timeout(1) do
+        sleep(0.1) until File.exist?(downloaded_csv)
+      end
+      assert(File.exist?(downloaded_csv))
+    end
+
     test 'pause a Run' do
       visit maintenance_tasks_path
 


### PR DESCRIPTION
This PR leverages [ Active Storage's download link helper](https://guides.rubyonrails.org/active_storage_overview.html#linking-to-files) to provide download links for CSV attachments associated with previous runs for CSV Tasks. Note that we have to use `Rails.application.routes.url_helpers.rails_blob_path` instead of `rails_blob_path` because the download URL is associated with the host app, not the engine (and additionally, we don't specify Active Storage as a dependency of the engine, so this helper isn't even available to us).

Since we're using `run.csv_file.attached?` to check whether to show the download link, I've added preloading for the CSV file attachments when we generate the `ActiveRecord::Relation` for Runs, as @etiennebarrie suggested. (And we can use `with_attached_csv_file`, since [this scope](https://github.com/rails/rails/blob/f815e773412f1064492507d76a9a011e6dde6042/activestorage/lib/active_storage/attached/macros.rb#L44) ships out-of-the-box with ActiveStorage)

To 🎩 
- Go to `http://localhost:3000/maintenance_tasks/tasks/Maintenance::ImportPostsTask/`
- Upload the `sample.csv` from `test/fixtures/files`
- Click the `Download CSV` link that appears when the Task finishes