### PR TITLE
Supply additional task info as argument when calling error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,8 +319,30 @@ you can define an error handler:
 
 ```ruby
 # config/initializers/maintenance_tasks.rb
-MaintenanceTasks.error_handler = ->(error) { Bugsnag.notify(error) }
+MaintenanceTasks.error_handler = ->(error, task_context, _errored_element) do
+  Bugsnag.notify(error) do |notification|
+    notification.add_tab(:task, task_context)
+  end
+end
 ```
+
+The error handler should be a lambda that accepts three arguments:
+
+* `error`: The object containing the exception that was raised.
+* `task_context`: A hash with additional information about the Task and the
+  error:
+  * `task_name`: The name of the Task that errored
+  * `started_at`: The time the Task started
+  * `ended_at`: The time the Task errored
+* `errored_element`: The element, if any, that was being processed when the
+  Task raised an exception. If you would like to pass this object to your
+  exception monitoring service, make sure you **sanitize the object** to avoid
+  leaking sensitive data and **convert it to a format** that is compatible with
+  your bug tracker. For example, Bugsnag only sends the id and class name of
+  ActiveRecord objects in order to protect sensitive data. CSV rows, on the
+  other hand, are converted to strings and passed raw to Bugsnag, so make sure
+  to filter any personal data from these objects before adding them to a
+  report.
 
 #### Customizing the maintenance tasks module
 

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -32,6 +32,23 @@ module MaintenanceTasks
   #   the ticker during Task iterations.
   mattr_accessor :ticker_delay, default: 1.second
 
+  # Retrieves the callback to be performed when an error occurs in the task.
+  def self.error_handler
+    return @error_handler if defined?(@error_handler)
+    @error_handler = ->(_error, _task_context, _errored_element) {}
+  end
+
   # Defines a callback to be performed when an error occurs in the task.
-  mattr_accessor :error_handler, default: ->(_error) {}
+  def self.error_handler=(error_handler)
+    unless error_handler.arity == 3
+      ActiveSupport::Deprecation.warn(
+        'MaintenanceTasks.error_handler should be a lambda that takes three '\
+         'arguments: error, task_context, and errored_element.'
+      )
+      @error_handler = ->(error, _task_context, _errored_element) do
+        error_handler.call(error)
+      end
+    end
+    @error_handler = error_handler
+  end
 end

--- a/test/lib/maintenance_tasks_test.rb
+++ b/test/lib/maintenance_tasks_test.rb
@@ -19,4 +19,14 @@ class MaintenanceTasksTest < ActiveSupport::TestCase
     end
     assert_equal expected_public_constants.sort, public_constants.sort
   end
+
+  test 'deprecation warning raised when error_handler does not accept three arguments' do
+    error_handler_before = MaintenanceTasks.error_handler
+
+    dep_msg = 'MaintenanceTasks.error_handler should be a lambda that takes '\
+    'three arguments: error, task_context, and errored_element.'
+    assert_deprecated(dep_msg) { MaintenanceTasks.error_handler = ->(error) {} }
+  ensure
+    MaintenanceTasks.error_handler = error_handler_before
+  end
 end


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/309

This PR changes the call to the defined error handler to pass along an additional `task_context` argument. This arg is a hash containing some additional information about the Task and the corresponding run.

An example of how users can leverage this info has been added to the `README`: if they integrate with Bugsnag, the simplest thing to do would just be to add a tab containing the details of the Task's context when notifying.

We might want to think a bit more about what information it makes sense to expose. Assuming that most users are using Sidekiq for their queuing backend, a lot of the information pertaining to the job is exposed through the `job_context` (as shown in the original issue) - `job_id`, `cursor`, `job_class`, etc... I thought it might make sense to expose `started_at` and `ended_at` (although `enqueued_at` is available from the job context). Alternatively, we could expose as much information about the Task as possible (include `job_id`, `cursor`, `time_running`, etc...) under the assumption that not everyone will use Sidekiq and have access to all this additional information to augment their error notifier.

cc @timgladwell 