### PR TITLE
Enqueue CSVs from the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,10 +229,26 @@ Alternatively, you can run your Task in the command line:
 $ bundle exec maintenance_tasks perform Maintenance::UpdatePostsTask
 ```
 
+To run a Task that processes CSVs from the command line, use the --csv option:
+
+```bash
+$ bundle exec maintenance_tasks perform Maintenance::ImportPostsTask --csv 'path/to/my_csv.csv'
+```
+
 You can also run a Task in Ruby by sending `run` with a Task name to Runner:
 
 ```ruby
 MaintenanceTasks::Runner.run(name: 'Maintenance::UpdatePostsTask')
+```
+
+To run a Task that processes CSVs using the Runner, provide a Hash containing an
+open IO object and a filename to `run`:
+
+```ruby
+MaintenanceTasks::Runner.run(
+  name: 'Maintenance::ImportPostsTask'
+  csv_file: { io: File.open('path/to/my_csv.csv'), filename: 'my_csv.csv' }
+)
 ```
 
 ### Monitoring your Task's status

--- a/lib/maintenance_tasks/cli.rb
+++ b/lib/maintenance_tasks/cli.rb
@@ -24,16 +24,31 @@ module MaintenanceTasks
       #{MaintenanceTasks::Task.available_tasks.join("\n\n")}
     LONGDESC
 
+    # Specify the CSV file to process for CSV Tasks
+    option :csv, desc: 'Supply a CSV file to be processed by a CSV Task, '\
+      '--csv "path/to/csv/file.csv"'
+
     # Command to run a Task.
     #
     # It instantiates a Runner and sends a run message with the given Task name.
+    # If a CSV file is supplied using the --csv option, an attachable with the
+    # File IO object is sent along with the Task name to run.
     #
     # @param name [String] the name of the Task to be run.
     def perform(name)
-      task = Runner.run(name: name)
+      task = Runner.run(name: name, csv_file: csv_file)
       say_status(:success, "#{task.name} was enqueued.", :green)
     rescue => error
       say_status(:error, error.message, :red)
+    end
+
+    private
+
+    def csv_file
+      csv_option = options[:csv]
+      if csv_option
+        { io: File.open(csv_option), filename: File.basename(csv_option) }
+      end
     end
   end
   private_constant :CLI

--- a/test/helpers/maintenance_tasks/task_helper_test.rb
+++ b/test/helpers/maintenance_tasks/task_helper_test.rb
@@ -86,7 +86,7 @@ module MaintenanceTasks
     end
 
     test '#csv_file_download_path generates a download link to the CSV attachment for a Run' do
-      run = Run.create!(task_name: 'Maintenance::ImportPostsTask')
+      run = Run.new(task_name: 'Maintenance::ImportPostsTask')
       csv = Rack::Test::UploadedFile.new(file_fixture('sample.csv'), 'text/csv')
       run.csv_file.attach(csv)
 

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -208,12 +208,13 @@ module MaintenanceTasks
     end
 
     test '.perform_now accepts CSVs as collection' do
-      Maintenance::ImportPostsTask.any_instance.stubs(
-        csv_content: file_fixture('sample.csv').read
-      )
       Maintenance::ImportPostsTask.any_instance.expects(:process).times(5)
 
       run = Run.new(task_name: 'Maintenance::ImportPostsTask')
+      run.csv_file.attach(
+        { io: File.open(file_fixture('sample.csv')), filename: 'sample.csv' }
+      )
+      run.save
       TaskJob.perform_now(run)
 
       assert_predicate run.reload, :succeeded?

--- a/test/lib/maintenance_tasks/cli_test.rb
+++ b/test/lib/maintenance_tasks/cli_test.rb
@@ -16,17 +16,34 @@ module MaintenanceTasks
     test '#perfom runs the given Task and prints a success message' do
       task = mock(name: 'MyTask')
 
-      Runner.expects(:run).with(name: 'MyTask').returns(task)
+      Runner.expects(:run).with(name: 'MyTask', csv_file: nil).returns(task)
       @cli.expects(:say_status).with(:success, 'MyTask was enqueued.', :green)
 
       @cli.perform('MyTask')
     end
 
     test '#perfom prints an error message when the runner raises' do
-      Runner.expects(:run).with(name: 'Wrong').raises('Invalid!')
+      Runner.expects(:run).with(name: 'Wrong', csv_file: nil).raises('Invalid!')
       @cli.expects(:say_status).with(:error, 'Invalid!', :red)
 
       @cli.perform('Wrong')
+    end
+
+    test '#perform runs a CSV Task with the supplied CSV when --csv option used' do
+      task = mock(name: 'MyCsvTask')
+      csv_file_path = file_fixture('sample.csv')
+      opened_csv_file = File.open(csv_file_path)
+      expected_attachable = { io: opened_csv_file, filename: 'sample.csv' }
+
+      @cli.expects(:options).returns(csv: csv_file_path)
+      File.expects(:open).with(csv_file_path).returns(opened_csv_file)
+      Runner.expects(:run)
+        .with(name: 'MyCsvTask', csv_file: expected_attachable)
+        .returns(task)
+      @cli.expects(:say_status)
+        .with(:success, 'MyCsvTask was enqueued.', :green)
+
+      @cli.perform('MyCsvTask')
     end
   end
 end

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -8,6 +8,18 @@ module MaintenanceTasks
       refute run.valid?
     end
 
+    test 'invalid if associated with CSV Task and no attachment' do
+      run = Run.new(task_name: 'Maintenance::ImportPostsTask')
+      refute run.valid?
+    end
+
+    test 'invalid if unassociated with CSV Task and attachment' do
+      run = Run.new(task_name: 'Maintenance::UpdatePostsTask')
+      csv = Rack::Test::UploadedFile.new(file_fixture('sample.csv'), 'text/csv')
+      run.csv_file.attach(csv)
+      refute run.valid?
+    end
+
     test '#persist_progress persists increments to tick count and time_running' do
       run = Run.create!(
         task_name: 'Maintenance::UpdatePostsTask',

--- a/test/models/maintenance_tasks/runner_test.rb
+++ b/test/models/maintenance_tasks/runner_test.rb
@@ -10,6 +10,7 @@ module MaintenanceTasks
       @name = 'Maintenance::UpdatePostsTask'
       @runner = Runner
       @job = MaintenanceTasks.job.constantize
+      @csv = file_fixture('sample.csv')
     end
 
     test '#run creates and performs a Run for the given Task when there is no active Run' do
@@ -31,8 +32,8 @@ module MaintenanceTasks
       end
     end
 
-    test '#run raises validation errors' do
-      assert_no_difference -> { Run.where(task_name: @name).count } do
+    test '#run raises validation error if no Task for given name' do
+      assert_no_difference -> { Run.where(task_name: 'Invalid').count } do
         assert_no_enqueued_jobs do
           error = assert_raises(ActiveRecord::RecordInvalid) do
             @runner.run(name: 'Invalid')
@@ -83,13 +84,46 @@ module MaintenanceTasks
     end
 
     test '#run attaches CSV file to Run if one is provided' do
-      csv_file = file_fixture('sample.csv')
-      uploaded_csv = Rack::Test::UploadedFile.new(csv_file, 'text/csv')
-      @runner.run(name: @name, csv_file: uploaded_csv)
+      @runner.run(name: 'Maintenance::ImportPostsTask', csv_file: csv_io)
 
       run = Run.last
       assert_predicate run.csv_file, :attached?
-      assert_equal File.read(csv_file), run.csv_file.download
+      assert_equal File.read(@csv), run.csv_file.download
+    end
+
+    test '#run raises if CSV file is provided but Task does not process CSVs' do
+      assert_no_difference -> { Run.where(task_name: @name).count } do
+        error = assert_raises(ActiveRecord::RecordInvalid) do
+          @runner.run(name: @name, csv_file: csv_io)
+        end
+
+        assert_equal(
+          'Validation failed: Csv file should not be attached to non-CSV Task.',
+          error.message
+        )
+      end
+    end
+
+    test '#run raises if no CSV file is provided and Task processes CSVs' do
+      task_name = 'Maintenance::ImportPostsTask'
+      assert_no_difference -> { Run.where(task_name: task_name).count } do
+        assert_no_enqueued_jobs do
+          error = assert_raises(ActiveRecord::RecordInvalid) do
+            @runner.run(name: task_name, csv_file: nil)
+          end
+
+          assert_equal(
+            'Validation failed: Csv file must be attached to CSV Task.',
+            error.message
+          )
+        end
+      end
+    end
+
+    private
+
+    def csv_io
+      { io: File.open(@csv), filename: 'sample.csv' }
     end
   end
 end


### PR DESCRIPTION
This should be the last missing piece for CSV functionality in the gem. This PR allows a file to be passed via a `--csv` option on the CLI in order to run CSV processing Tasks from the command line.

## Changes
- https://github.com/Shopify/maintenance_tasks/commit/039e3e9889e348ea5dd2671cb860a7848160730d adds a `--csv` option to the CLI. If a file is supplied, we build an attachable (see https://edgeguides.rubyonrails.org/active_storage_overview.html#attaching-file-io-objects) to send to `Runner.run`. The CLI will surface the error if the file doesn't exist / isn't openable / etc.
- https://github.com/Shopify/maintenance_tasks/commit/ab1ee8c943867b6f7265de4efb43fe9e07c14c97 modifies `Runner.run` to verify that the Task processes CSVs before attaching the CSV (since a user can now pass a CSV for a non-CSV Task via the CLI).
     - Why not do this check in the CLI? This would involve performing `Task.named` from the CLI to check if the Task includes the `CsvCollection` module, and I felt like the CLI should not be aware of such constants and the details of how `Task` and `CsvCollection` are related
- https://github.com/Shopify/maintenance_tasks/commit/84074ee1033cb68ccf506e29238e228b72f50cde this commit could potentially be dropped - it makes it so that if a CSV task is run from the Runner without a `csv_file` supplied, we raise. 
     - Why _wouldn't_ we want this? The system will fail gracefully without this code, in the same way that it does if you run a CSV Task from the UI without attaching a file:
![Screen Shot 2021-02-04 at 12 15 16 PM](https://user-images.githubusercontent.com/22918438/106929665-a6157c00-66e2-11eb-969d-42bcdbf61c01.png)
     - Why _would_ we want this? It offers a better UX from the CLI in my opinion, as we fail early without enqueuing and then they know to supply a CSV from the command line.
-  https://github.com/Shopify/maintenance_tasks/commit/8867b515f52cfd50c34d6069298971cdd1256e18 updates the docs, including adding documentation for using `Runner.run` to run a CSV Task (which is possible today, but not documented)

## Tophatting
The following scenarios are relevant to 🎩 
In `test/dummy`:
*  `be maintenance_tasks perform 'Maintenance::ImportPostsTask'` =>
     * produces `error  Maintenance::ImportPostsTask must be supplied with a CSV file to process.`
     * If we drop https://github.com/Shopify/maintenance_tasks/commit/84074ee1033cb68ccf506e29238e228b72f50cde, will enqueue successfully, and error `Cannot parse nil as CSV` will be surfaced in the UI
*  `be maintenance_tasks perform 'Maintenance::ImportPostsTask' --csv 'invalid.csv'` =>
     * produces `error  No such file or directory @ rb_sysopen - invalid.csv`
* `be maintenance_tasks perform 'Maintenance::ImportPostsTask' --csv '../fixtures/files/sample.csv'`
     * Make sure to use inline queue adapter / Sidekiq / etc.. so this runs
     * This should be successful
*  `be maintenance_tasks perform 'Maintenance::UpdatePostsTask'` --csv '../fixtures/files/sample.csv'`
     * Should be successful
     * Should not attach a CSV to the Run for this Task