### PR TITLE
Use ruby/setup-ruby instead of actions/setup-ruby in workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,9 +11,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1.1.3
-      with:
-        ruby-version: '2.7.2'
+      uses: ruby/setup-ruby@v1
     - name: Restore cache
       uses: actions/cache@v2.1.4
       with:


### PR DESCRIPTION
`actions/setup-ruby` has been deprecated as of `v1.1.3`: https://github.com/actions/setup-ruby/commit/e932e7af67fc4a8fc77bd86b744acd4e42fe3543

We also no longer need to specify a version, as it gets picked up from [the .ruby-version file](https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby#single-job).