### PR TITLE
Add rubygems source to Gemfile line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,10 @@ Watch this demo video to see the gem in action:
 
 ## Installation
 
-Add this line to your application's Gemfile:
-
-```ruby
-gem 'maintenance_tasks'
-```
-
-And then execute:
+To install the gem and run the install generator, execute:
 
 ```bash
-$ bundle
+$ bundle add maintenance_tasks
 $ rails generate maintenance_tasks:install
 ```
 


### PR DESCRIPTION
Users at Shopify encounter a warning during `bundle install` due to the fact that the gem is registered at rubygems.org and in our internal package system:
```bash
Warning: the gem 'maintenance_tasks' was found in multiple sources.
Installed from: https://rubygems.org/
Also found in:
  * https://packages.shopify.io/shopify/gems/
You should add a source requirement to restrict this gem to your preferred source.
For example:
    gem 'maintenance_tasks', :source => 'https://rubygems.org/'
Then uninstall the gem 'maintenance_tasks' (or delete all bundled gems) and then install again.
```

 IMHO we should tell users to source the gem from the public source in the README to prevent this issue. 