### PR TITLE
[Explore] Allow Tasks to specify throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,14 @@ My Title,Hello World!
 
 TODO: Add generation instructions
 
-If you have a special use case requiring iteration over an unsupported collection type, such as external resources fetched from some API, you can implement the `enumerator_builder` method instead.
+If you have a special use case requiring iteration over an unsupported
+collection type, such as external resources fetched from some API, you can
+implement the `enumerator_builder` method instead.
 
-This method should return an object responding to `enumerator(context:)` with an Enumerator, yielding pairs of `[item, item_cursor]`. In order for your enumerator to support resuming iteration part way through, you may use the `context.cursor`.
+This method should return an object responding to `enumerator(context:)` with
+an Enumerator, yielding pairs of `[item, item_cursor]` to the `process` method
+your Task defines. In order for your enumerator to support resuming iteration
+part way through, you may use the `context.cursor`.
 
 You may optionally provide an implementation for `count`, if appropriate.
 
@@ -208,7 +213,9 @@ module Maintenance
 end
 ```
 
-In some cases, you may have no use for a cursor (e.g. iterating over some collection until it is empty), in which case your Enumerator may yield `nil` cursors (i.e. pairs of `[item, nil]`).
+In some cases, you may have no use for a cursor (e.g. iterating over some
+collection until it is empty), in which case your Enumerator may yield `nil`
+cursors (i.e. pairs of `[item, nil]`).
 
 ```ruby
 # app/tasks/maintenance/ingredient_purge_task.rb
@@ -316,9 +323,14 @@ end
 
 ### Writing test for a custom Task
 
-As with other tasks, you should write tests for your `#process` method. It will receive the first item in each pair your custom Enumerator yields (`[item, item_cursor]`).
+As with other tasks, you should write tests for your `#process` method. It will
+receive the first item in each pair your custom Enumerator yields (`[item,
+item_cursor]`).
 
-You should also ensure your Enumerator is tested, by unit testing it in isolation, testing your `#enumerator_builder` method, or both. Make sure you test how your Enumerator handles the absence or presence of a `context.cursor`, if applicable.
+You should also ensure your Enumerator is tested, by unit testing it in
+isolation, testing your `#enumerator_builder` method, or both. Make sure you
+test how your Enumerator handles the absence or presence of a `context.cursor`,
+if applicable.
 
 ```ruby
 # test/tasks/maintenance/shopping_list_task_test.rb

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ My Title,Hello World!
 
 TODO: Add generation instructions
 
-If you have a special use case requiring iteration over an unsupported resource, you can implement the `enumerator_builder` method instead. For example, you may need to iterate over external resources fetch from some API.
+If you have a special use case requiring iteration over an unsupported collection type, such as external resources fetched from some API, you can implement the `enumerator_builder` method instead.
 
 This method should return an object responding to `enumerator(context:)` with an Enumerator, yielding pairs of `[item, item_cursor]`. In order for your enumerator to support resuming iteration part way through, you may use the `context.cursor`.
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,51 @@ title,content
 My Title,Hello World!
 ```
 
+### Creating a custom Task
+
+```ruby
+# app/tasks/maintenance/pay_last_months_invoices_task.rb
+module Maintenance
+  class PayLastMonthsInvoicesTask < MaintenanceTasks::Task
+    def enumerator_builder
+      InvoiceEnumerator.new
+    end
+
+    def count
+      InvoiceAPI.last_month.count
+    end
+
+    def process(invoice)
+      invoice.pay!
+    end
+
+    class InvoiceEnumerator
+      def enumerator(context:)
+        Enumerator.new do |yielder|
+          cursor = context.cursor
+
+          loop do
+            page = if cursor.nil?
+              InvoiceAPI.last_month(max: 100)
+            else
+              InvoiceAPI.last_month(max: 100, after: context.cursor)
+            end
+
+            page.entries.each do |invoice|
+              cursor = invoice.id
+              yielder.yield [invoice, cursor]
+            end
+
+            break unless page.has_next?
+          end
+        end
+      end
+    end
+  end
+end
+```
+
+
 ### Considerations when writing Tasks
 
 MaintenanceTasks relies on the queue adapter configured for your application to

--- a/README.md
+++ b/README.md
@@ -159,36 +159,44 @@ This method should return an object responding to `enumerator(context:)` with an
 You may optionally provide an implementation for `count`, if appropriate.
 
 ```ruby
-# app/tasks/maintenance/pay_last_months_invoices_task.rb
+# app/tasks/maintenance/shopping_list_task.rb
 module Maintenance
-  class PayLastMonthsInvoicesTask < MaintenanceTasks::Task
+  class ShoppingListTask < MaintenanceTasks::Task
     def enumerator_builder
-      InvoiceEnumerator.new
+      IngredientsEnumerator.new
     end
 
-    def count
-      InvoiceAPI.last_month.count
+    def process(ingredient)
+      ShoppingList.add(ingredient)
     end
 
-    def process(invoice)
-      invoice.pay!
-    end
-
-    class InvoiceEnumerator
+    class IngredientEnumerator
       def enumerator(context:)
         Enumerator.new do |yielder|
           cursor = context.cursor
 
+          if cursor.nil?
+            recipe = FancyRecipeAPI.random_recipe
+            ingredient_id = nil
+          else
+            recipe_id, ingredient_id = cursor.split(':', 2)
+            recipe = FancyRecipeAPI.recipe(recipe_id)
+          end
+
           loop do
-            page = if cursor.nil?
-              InvoiceAPI.last_month(max: 100)
+            page = if ingredient_id.nil?
+              FancyRecipeAPI
+                .paginated_ingredients(recipe.id, max: 5)
             else
-              InvoiceAPI.last_month(max: 100, after: context.cursor)
+              FancyRecipeAPI
+                .paginated_ingredients(recipe.id, max: 5, after: ingredient_id)
             end
 
-            page.entries.each do |invoice|
-              cursor = invoice.id
-              yielder.yield [invoice, cursor]
+            page.entries.each do |ingredient|
+              ingredient_id = ingredient.id
+              cursor = "#{recipe.id}:#{ingredient.id}"
+
+              yielder.yield([ingredient, cursor])
             end
 
             break unless page.has_next?
@@ -203,25 +211,30 @@ end
 In some cases, you may have no use for a cursor (e.g. iterating over some collection until it is empty), in which case your Enumerator may yield `nil` cursors (i.e. pairs of `[item, nil]`).
 
 ```ruby
-# app/tasks/maintenance/pay_last_months_invoices_task.rb
+# app/tasks/maintenance/ingredient_purge_task.rb
 module Maintenance
-  class UnbanUsersTask < MaintenanceTasks::Task
+  class IngredientPurgeTask < MaintenanceTasks::Task
     def enumerator_builder
-      ExpiredBansEnumerator.new
+      ExpiredIngredientsEnumerator.new
     end
 
-    def process(expired_ban)
-      expired_ban.user.unban!
+    def count
+      PantryAPI.ingredients(expired: true).count +
+        FridgeAPI.ingredients(expired: true).count +
+        FreezerAPI.ingredients(expired: true).count
     end
 
-    class ExpiredBansEnumerator
-      def enumerator(context:)
-        UserManagementAPI
-          .resource(:bans)
-          .filter("expires_at <= #{Time.now}")
-          .auto_paginate
-          .lazy
-          .map { |ban| [ban, nil] }
+    def process(ingredient)
+      ingredient.compost!
+    end
+
+    class ExpiredIngredientsEnumerator
+      def enumerator(*)
+        Enumerator.chain(
+          PantryAPI.ingredients(expired: true).auto_paginate,
+          FridgeAPI.ingredients(expired: true).auto_paginate,
+          FreezerAPI.ingredients(expired: true).auto_paginate,
+        ).lazy.map { |ingredient| [ingredient, nil] }
       end
     end
   end
@@ -305,52 +318,153 @@ end
 
 As with other tasks, you should write tests for your `#process` method. It will receive the first item in each pair your custom Enumerator yields (`[item, item_cursor]`).
 
-You should also ensure your Enumerator is tested by unit testing it in isolation, testing your `#enumerator_builder` method, or both. Make sure you test how your Enumerator handles the absence or presence of a `context.cursor`, if applicable.
+You should also ensure your Enumerator is tested, by unit testing it in isolation, testing your `#enumerator_builder` method, or both. Make sure you test how your Enumerator handles the absence or presence of a `context.cursor`, if applicable.
 
 ```ruby
-# app/tasks/maintenance/shopping_list_task.rb
+# test/tasks/maintenance/shopping_list_task_test.rb
 module Maintenance
-  class ShoppingListTask < ActiveSupport::TestCase
-    test "#process adds the recipe's ingredients to the shopping list" do
-      ShoppingList.clear
-      recipe = recipes(:tacos)
-      ingredient = recipe.ingredient.first
+  class ShoppingListTaskTest < ActiveSupport::TestCase
+    test '#process adds ingredients to the shopping list' do
+      ingredient = recipes(:tacos).first
+      ShoppingList.expects(:add).with(ingredient)
 
-      Maintenance::ShoppingListTask.process(ingredient)
-
-      assert_includes ShoppingList, ingredient
+      ShoppingListTask.process(ingredient)
     end
 
-    test "#build_enumerator's enumerator yields all ingredients for all recipes, when no cursor provided" do
-      all_ingredient_pairs = ingredient_pairs
-      enumerator = Maintenance::ShoppingListTask.build_enumerator.enumerator(context: stub(cursor: nil))
+    test '#enumerator_builder.enumerator enumerates ingredients for a random recipe' do
+      FancyRecipeApi.fake_it_till_you_make_it do
+        recipe = recipes(:tacos)
+        FancyRecipeAPI.expects(:random_recipe).returns(recipe)
 
-      assert_equal all_ingredient_pairs, enumerator.to_a
+        expected_ingredient_pairs = ingredient_pairs(recipe)
+
+        context = stub('context', cursor: nil)
+        actual_ingredient_pairs = ShoppingListTask.enumerator_builder
+          .enumerator(context: context).to_a
+
+        assert_equal expected_ingredient_pairs, actual_ingredient_pairs
+      end
     end
 
-    test "#build_enumerator's enumerator yields remaining ingredients for all recipes, when cursor provided" do
-      remaining_ingredient_pairs = ingredient_pairs
-      previous_ingredient_pairs = remaining_ingredient_pairs.shift(5)
-      cursor = previous_ingredient_pairs.last.last
+    test '#enumerator_builder.enumerator enumerates remaining ingredients for the cursor recipe' do
+      FancyRecipeApi.fake_it_till_you_make_it do
+        expected_ingredient_pairs = ingredient_pairs(recipes(:vegan_tacos))
+        ingredients_so_far = expected_ingredient_pairs.shift(3)
+        cursor = ingredients_so_far.last.last
 
-      enumerator = Maintenance::ShoppingListTask.build_enumerator.enumerator(context: stub(cursor: cursor))
+        context = stub('context', cursor: cursor)
+        actual_ingredient_pairs = ShoppingListTask.enumerator_builder
+          .enumerator(context: context).to_a
 
-      assert_equal remaining_ingredient_pairs, enumerator.to_a
+        assert_equal expected_ingredient_pairs, actual_ingredient_pairs
+      end
+    end
+
+    test '#count returns nil, as we cannot guess the recipe choice' do
+      assert_nil ShoppingListTask.count
     end
 
     private
 
-    def ingredient_pairs
-      recipes.flat_map do |recipe|
-        recipe.ingredients.map do |ingredient|
-          cursor = { recipe_id: recipe.id, ingredient_id: ingredient.id }
-          [ingredient, cursor]
-        end
+    def ingredient_pairs(recipe)
+      recipe.ingredients.map do |ingredient|
+        cursor = "#{recipe.id}:#{ingredient.id}"
+        [ingredient, cursor]
       end
     end
   end
 end
 ```
+
+Dependaing on its complexity, you may choose to test your Enumerator builder in
+isolation, in which case you can simplify the tests for your Task.
+
+```ruby
+# test/tasks/maintenance/ingredient_purge_task_test.rb
+module Maintenance
+  class IngredientPurgeTaskTest < ActiveSupport::TestCase
+    test '#process composts ingredients' do
+      ingredient = ingredients(:tomato)
+      ingredient.expects(:compost!)
+
+      IngredientPurgeTask.process(ingredient)
+    end
+
+    test '#enumerator_builder returns an ExpiredIngredientsEnumerator' do
+      assert_instance_of(
+        ExpiredIngredientsEnumerator,
+        IngredientPurgeTask.enumerator_builder,
+      )
+    end
+  end
+end
+```
+
+```ruby
+# test/models/expired_ingredients_enumerator_test.rb
+class ExpiredIngredientsEnumeratorTest < ActiveSupport::TestCase
+  setup do
+    [PantryAPI, FridgeAPI, FreezerAPI].each(&:enable_test_mode!)
+  end
+
+  teardown do
+    [PantryAPI, FridgeAPI, FreezerAPI].each(&:disable_test_mode!)
+  end
+
+  test '#enumerator enumerates expired ingredients, ignoring cursor' do
+    expirees = []
+
+    PantryAPI.stock(ingredients(:fresh_tomatoes))
+
+    ingredients(:green_potatoes).tap do |ingredient|
+      PantryAPI.stock(ingredient)
+      expirees << ingredient
+    end
+
+    ingredients(:curdled_milk).tap do |ingredient|
+      FridgeAPI.stock(ingredient)
+      expirees << ingredient
+    end
+
+    FridgeAPI.stock(ingredients(:leftover_pizza))
+
+    ingredients(
+      :entire_pack_of_strawberries_ruined_by_that_single_one_that_had_mold,
+    ).tap do |ingredient|
+      FridgeAPI.stock(ingredient)
+      expirees << ingredient
+    end
+
+    ingredients(:mysterious_container).tap do |ingredient|
+      FreezerAPI.stock(ingredient)
+      expirees << ingredient
+    end
+
+    FreezerAPI.stock(ingredients(:ice_cubes))
+
+    expected_pairs = expirees.map do |ingredient|
+      cursor = nil
+      [ingredient, cursor]
+    end
+
+    context = stub('context')
+    context.expects(:cursor).never
+
+    actual_pairs =
+      ExpiredIngredientsEnumerator.enumerator(context: context).to_a
+
+    assert_equal expected_pairs, actual_pairs
+  end
+
+  test '#enumerator is empty if no expired ingredients' do
+    PantryAPI.stock(ingredients(:tortillas))
+
+    assert_empty ExpiredIngredientsEnumerator.enumerator(context: context).to_a
+  end
+end
+```
+
+</details>
 
 ### Running a Task
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ My Title,Hello World!
 
 ### Creating a custom Task
 
+TODO: Add generation instructions
+
 If you have a special use case requiring iteration over an unsupported resource, you can implement the `enumerator_builder` method instead. For example, you may need to iterate over external resources fetch from some API.
 
 This method should return an object responding to `enumerator(context:)` with an Enumerator, yielding pairs of `[item, item_cursor]`. In order for your enumerator to support resuming iteration part way through, you may use the `context.cursor`.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ A Rails engine for queuing and managing maintenance tasks.
 * [Usage](#usage)
   * [Creating a Task](#creating-a-task)
   * [Creating a CSV Task](#creating-a-csv-task)
+  * [Creating a custom Task](#creating-a-custom-task)
   * [Considerations when writing Tasks](#considerations-when-writing-tasks)
   * [Writing tests for a Task](#writing-tests-for-a-task)
   * [Writing tests for a CSV Task](#writing-tests-for-a-csv-task)
+  * [Writing tests for a custom Task](#writing-tests-for-a-custom-task)
   * [Running a Task](#running-a-task)
   * [Monitoring your Task's status](#monitoring-your-tasks-status)
   * [How Maintenance Tasks runs a Task](#how-maintenance-tasks-runs-a-task)
@@ -148,6 +150,12 @@ My Title,Hello World!
 
 ### Creating a custom Task
 
+If you have a special use case requiring iteration over an unsupported resource, you can implement the `enumerator_builder` method instead. For example, you may need to iterate over external resources fetch from some API.
+
+This method should return an object responding to `enumerator(context:)` with an Enumerator, yielding pairs of `[item, item_cursor]`. In order for your enumerator to support resuming iteration part way through, you may use the `context.cursor`.
+
+You may optionally provide an implementation for `count`, if appropriate.
+
 ```ruby
 # app/tasks/maintenance/pay_last_months_invoices_task.rb
 module Maintenance
@@ -190,6 +198,33 @@ module Maintenance
 end
 ```
 
+In some cases, you may have no use for a cursor (e.g. iterating over some collection until it is empty), in which case your Enumerator may yield `nil` cursors (i.e. pairs of `[item, nil]`).
+
+```ruby
+# app/tasks/maintenance/pay_last_months_invoices_task.rb
+module Maintenance
+  class UnbanUsersTask < MaintenanceTasks::Task
+    def enumerator_builder
+      ExpiredBansEnumerator.new
+    end
+
+    def process(expired_ban)
+      expired_ban.user.unban!
+    end
+
+    class ExpiredBansEnumerator
+      def enumerator(context:)
+        UserManagementAPI
+          .resource(:bans)
+          .filter("expires_at <= #{Time.now}")
+          .auto_paginate
+          .lazy
+          .map { |ban| [ban, nil] }
+      end
+    end
+  end
+end
+```
 
 ### Considerations when writing Tasks
 
@@ -259,6 +294,57 @@ module Maintenance
       post = Post.last
       assert_equal 'My Title', post.title
       assert_equal 'Hello World!', post.content
+    end
+  end
+end
+```
+
+### Writing test for a custom Task
+
+As with other tasks, you should write tests for your `#process` method. It will receive the first item in each pair your custom Enumerator yields (`[item, item_cursor]`).
+
+You should also ensure your Enumerator is tested by unit testing it in isolation, testing your `#enumerator_builder` method, or both. Make sure you test how your Enumerator handles the absence or presence of a `context.cursor`, if applicable.
+
+```ruby
+# app/tasks/maintenance/shopping_list_task.rb
+module Maintenance
+  class ShoppingListTask < ActiveSupport::TestCase
+    test "#process adds the recipe's ingredients to the shopping list" do
+      ShoppingList.clear
+      recipe = recipes(:tacos)
+      ingredient = recipe.ingredient.first
+
+      Maintenance::ShoppingListTask.process(ingredient)
+
+      assert_includes ShoppingList, ingredient
+    end
+
+    test "#build_enumerator's enumerator yields all ingredients for all recipes, when no cursor provided" do
+      all_ingredient_pairs = ingredient_pairs
+      enumerator = Maintenance::ShoppingListTask.build_enumerator.enumerator(context: stub(cursor: nil))
+
+      assert_equal all_ingredient_pairs, enumerator.to_a
+    end
+
+    test "#build_enumerator's enumerator yields remaining ingredients for all recipes, when cursor provided" do
+      remaining_ingredient_pairs = ingredient_pairs
+      previous_ingredient_pairs = remaining_ingredient_pairs.shift(5)
+      cursor = previous_ingredient_pairs.last.last
+
+      enumerator = Maintenance::ShoppingListTask.build_enumerator.enumerator(context: stub(cursor: cursor))
+
+      assert_equal remaining_ingredient_pairs, enumerator.to_a
+    end
+
+    private
+
+    def ingredient_pairs
+      recipes.flat_map do |recipe|
+        recipe.ingredients.map do |ingredient|
+          cursor = { recipe_id: recipe.id, ingredient_id: ingredient.id }
+          [ingredient, cursor]
+        end
+      end
     end
   end
 end

--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -32,7 +32,15 @@ module MaintenanceTasks
         cursor: cursor || @run.cursor,
       )
 
-      @task.enumerator_builder.enumerator(context: context)
+      if @task.throttle_condition
+        JobIteration::EnumeratorBuilder.new(self).build_throttle_enumerator(
+          @task.enumerator_builder.enumerator(context: context),
+          throttle_on: @task.throttle_condition,
+          backoff: @task.throttle_backoff
+        )
+      else
+        @task.enumerator_builder.enumerator(context: context)
+      end
     end
 
     # Performs task iteration logic for the current input returned by the

--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -25,21 +25,14 @@ module MaintenanceTasks
 
     private
 
-    def build_enumerator(_run, cursor:)
-      cursor ||= @run.cursor
-      collection = @task.collection
+    EnumerationContext = Struct.new(:cursor, keyword_init: true)
 
-      case collection
-      when ActiveRecord::Relation
-        enumerator_builder.active_record_on_records(collection, cursor: cursor)
-      when Array
-        enumerator_builder.build_array_enumerator(collection, cursor: cursor)
-      when CSV
-        JobIteration::CsvEnumerator.new(collection).rows(cursor: cursor)
-      else
-        raise ArgumentError, "#{@task.class.name}#collection must be either "\
-          'an Active Record Relation, Array, or CSV.'
-      end
+    def build_enumerator(_run, cursor:)
+      context = EnumerationContext.new(
+        cursor: cursor || @run.cursor,
+      )
+
+      @task.enumerator_builder.enumerator(context: context)
     end
 
     # Performs task iteration logic for the current input returned by the

--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -31,15 +31,14 @@ module MaintenanceTasks
       context = EnumerationContext.new(
         cursor: cursor || @run.cursor,
       )
+      enumerator = @task.enumerator_builder.enumerator(context: context)
 
-      if @task.throttle_condition
+      @task.throttle_specs.reduce(enumerator) do |enum, throttle_spec|
         JobIteration::EnumeratorBuilder.new(self).build_throttle_enumerator(
-          @task.enumerator_builder.enumerator(context: context),
-          throttle_on: @task.throttle_condition,
-          backoff: @task.throttle_backoff
+          enum,
+          throttle_on: throttle_spec[:condition],
+          backoff: throttle_spec[:backoff],
         )
-      else
-        @task.enumerator_builder.enumerator(context: context)
       end
     end
 

--- a/app/models/maintenance_tasks/csv_collection.rb
+++ b/app/models/maintenance_tasks/csv_collection.rb
@@ -13,6 +13,25 @@ module MaintenanceTasks
     # @return [String] the content of the CSV file to process.
     attr_accessor :csv_content
 
+    # @api private
+    CsvEnumeratorBuilder = Struct.new(:csv) do
+      # Returns an Enumerator over the (remaining) CSV rows.
+      #
+      # @param context the enumeration context providing the current cursor
+      # @return an Enumerator yielding pairs of [row, row_cursor]
+      def enumerator(context:)
+        JobIteration::CsvEnumerator.new(csv).rows(cursor: context.cursor)
+      end
+    end
+    private_constant :CsvEnumeratorBuilder
+
+    # Returns an Enumerator builder wrapping the CSV contents.
+    #
+    # @return the Enumerator builder
+    def enumerator_builder
+      CsvEnumeratorBuilder.new(collection)
+    end
+
     # Defines the collection to be iterated over, based on the provided CSV.
     #
     # @return [CSV] the CSV object constructed from the specified CSV content,

--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -105,14 +105,6 @@ module MaintenanceTasks
     end
     private_constant :ArrayEnumeratorBuilder
 
-    # @api private
-    CsvEnumeratorBuilder = Struct.new(:csv) do
-      def enumerator(context:)
-        JobIteration::CsvEnumerator.new(csv).rows(cursor: context.cursor)
-      end
-    end
-    private_constant :CsvEnumeratorBuilder
-
     def enumerator_builder
       collection = self.collection
 
@@ -121,11 +113,11 @@ module MaintenanceTasks
         ActiveRecordEnumeratorBuilder.new(collection)
       when Array
         ArrayEnumeratorBuilder.new(collection)
-      when CSV
-        CsvEnumeratorBuilder.new(collection)
       else
         raise ArgumentError, "#{self.class.name}#collection must be either "\
-          'an Active Record Relation, Array, or CSV.'
+          'an Active Record Relation, or Array.' # TODO: update
+        # If you want CSVs, do this
+        # If you want custom enum, do this
       end
     end
 

--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -105,13 +105,15 @@ module MaintenanceTasks
     end
     private_constant :ArrayEnumeratorBuilder
 
-    # Returns an Enumerator builder wrapping the collection. Supported collection types are
-    # ActiveRecord::Relations, or Arrays.
+    # Returns an Enumerator builder wrapping the collection. Supported
+    # collection types are ActiveRecord::Relations, or Arrays.
     #
-    # Tasks may override this to return a custom Enumerator builder, when requiring enumeration over an unsupported
-    # collection type. The object returned must respond to .enumerator(context:), and return an Enumerator yielding
-    # pairs of items and their cursor. The context object provided to .enumerator will respond to .cursor, returning the
-    # previous item's cursor, or nil (if this is the first iteration), to support resuming enumeration.
+    # Tasks may override this to return a custom Enumerator builder, when
+    # requiring enumeration over an unsupported collection type. The object
+    # returned must respond to .enumerator(context:), and return an Enumerator
+    # yielding pairs of items and their cursor. The context object provided to
+    # .enumerator will respond to .cursor, returning the previous item's cursor,
+    # or nil (if this is the first iteration), to support resuming enumeration.
     def enumerator_builder
       collection = self.collection
 
@@ -129,7 +131,8 @@ module MaintenanceTasks
     # Placeholder method to raise in case a subclass fails to implement the
     # expected instance method.
     #
-    # Tasks with a custom #enumerator_builder are not required to implement this method.
+    # Tasks with a custom #enumerator_builder are not required to implement this
+    # method.
     #
     # @raise [NotImplementedError] with a message advising subclasses to
     #   implement an override for this method.

--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -47,7 +47,7 @@ module MaintenanceTasks
         new.process(item)
       end
 
-      # Returns the enumerator builder for this Task.
+      # Returns the Enumerator builder for this Task.
       #
       # Especially useful for tests.
       #
@@ -105,6 +105,13 @@ module MaintenanceTasks
     end
     private_constant :ArrayEnumeratorBuilder
 
+    # Returns an Enumerator builder wrapping the collection. Supported collection types are
+    # ActiveRecord::Relations, or Arrays.
+    #
+    # Tasks may override this to return a custom Enumerator builder, when requiring enumeration over an unsupported
+    # collection type. The object returned must respond to .enumerator(context:), and return an Enumerator yielding
+    # pairs of items and their cursor. The context object provided to .enumerator will respond to .cursor, returning the
+    # previous item's cursor, or nil (if this is the first iteration), to support resuming enumeration.
     def enumerator_builder
       collection = self.collection
 
@@ -115,14 +122,14 @@ module MaintenanceTasks
         ArrayEnumeratorBuilder.new(collection)
       else
         raise ArgumentError, "#{self.class.name}#collection must be either "\
-          'an Active Record Relation, or Array.' # TODO: update
-        # If you want CSVs, do this
-        # If you want custom enum, do this
+          'an Active Record Relation, or Array.'
       end
     end
 
     # Placeholder method to raise in case a subclass fails to implement the
     # expected instance method.
+    #
+    # Tasks with a custom #enumerator_builder are not required to implement this method.
     #
     # @raise [NotImplementedError] with a message advising subclasses to
     #   implement an override for this method.

--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -8,6 +8,8 @@ module MaintenanceTasks
     class NotFoundError < NameError; end
 
     class << self
+      attr_reader :throttle_condition, :throttle_backoff
+
       # Finds a Task with the given name.
       #
       # @param name [String] the name of the Task to be found.
@@ -72,6 +74,18 @@ module MaintenanceTasks
       # @return the count of items.
       def count
         new.count
+      end
+
+      # Define throttling for this Task.
+      #
+      # @param condition [Proc] defines the condition under which the Task
+      #   should be throttled.
+      # @param backoff [ActiveSupport::Duration] optionally, a custom backoff
+      #   can be specified. This is the time to wait before retrying the Task.
+      #   If no value is specified, it defaults to 30 seconds.
+      def throttle_on(condition, backoff: 30.seconds)
+        @throttle_condition = condition
+        @throttle_backoff = backoff
       end
 
       private
@@ -159,6 +173,20 @@ module MaintenanceTasks
     #
     # @return [Integer, nil]
     def count
+    end
+
+    # Return condition under which the Task should throttle.
+    #
+    # @return [Proc, nil]
+    def throttle_condition
+      self.class.throttle_condition
+    end
+
+    # Return throttle backoff defined for the Task.
+    #
+    # @return [ActiveSupport::Duration, nil]
+    def throttle_backoff
+      self.class.throttle_backoff
     end
   end
 end

--- a/lib/generators/maintenance_tasks/task_generator.rb
+++ b/lib/generators/maintenance_tasks/task_generator.rb
@@ -12,6 +12,8 @@ module MaintenanceTasks
     class_option :csv, type: :boolean, default: false,
       desc: 'Generate a CSV Task.'
 
+    # TODO: Add generator option for custom task
+
     check_class_collision suffix: 'Task'
 
     # Creates the Task file.

--- a/lib/generators/maintenance_tasks/templates/csv_task.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/csv_task.rb.tt
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# TODO: Can we just merge this with the standard task template?
+
 module <%= tasks_module %>
 <% module_namespacing do -%>
   class <%= class_name %>Task < MaintenanceTasks::Task

--- a/lib/generators/maintenance_tasks/templates/task.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/task.rb.tt
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# Add CSV and custom task stuff
+
 module <%= tasks_module %>
 <% module_namespacing do -%>
   class <%= class_name %>Task < MaintenanceTasks::Task

--- a/lib/generators/maintenance_tasks/templates/task_spec.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/task_spec.rb.tt
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
+# TODO Add CSV and custom task stuff
+
 module <%= tasks_module %>
 <% module_namespacing do -%>
   RSpec.describe <%= class_name %>Task do

--- a/lib/generators/maintenance_tasks/templates/task_test.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/task_test.rb.tt
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 require 'test_helper'
 
+# TODO: Add CSV and custom task stuff
+
 module <%= tasks_module %>
 <% module_namespacing do -%>
   class <%= class_name %>TaskTest < ActiveSupport::TestCase

--- a/test/dummy/app/tasks/maintenance/custom_enumerating_task.rb
+++ b/test/dummy/app/tasks/maintenance/custom_enumerating_task.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+module Maintenance
+  class CustomEnumeratingTask < MaintenanceTasks::Task
+    class CustomEnumeratorBuilder
+      def enumerator(context:)
+        drop = context.cursor.nil? ? 0 : context.cursor + 1
+
+        Array.new(3) { |index| [index, index] }.lazy.drop(drop)
+      end
+    end
+
+    def enumerator_builder
+      CustomEnumeratorBuilder.new
+    end
+
+    def count
+      3
+    end
+
+    def process(_)
+    end
+  end
+end

--- a/test/dummy/app/tasks/maintenance/update_posts_throttled_task.rb
+++ b/test/dummy/app/tasks/maintenance/update_posts_throttled_task.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module Maintenance
+  class UpdatePostsThrottledTask < MaintenanceTasks::Task
+    class << self
+      attr_accessor :throttle
+    end
+
+    throttle_on -> { throttle }
+
+    def collection
+      Post.where(id: 1)
+    end
+
+    def count
+      collection.count
+    end
+
+    def process(post)
+      post.update!(content: "New content added on #{Time.now.utc}")
+    end
+  end
+end

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -219,6 +219,14 @@ module MaintenanceTasks
       assert_predicate run.reload, :succeeded?
     end
 
+    test '.perform_now accepts custom enumerated tasks' do
+      skip 'TODO: custom enumeration test to be implemented!'
+    end
+
+    test '.perform_now can resume custom enumerated tasks' do
+      skip 'TODO: custom enumeration resumption test to be implemented!'
+    end
+
     test '.perform_now sets the Run as errored when the Task collection is invalid' do
       Maintenance::TestTask.any_instance.stubs(collection: 'not a collection')
 

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -229,7 +229,7 @@ module MaintenanceTasks
       assert_equal 'ArgumentError', @run.error_class
       assert_empty @run.backtrace
       expected_message = 'Maintenance::TestTask#collection '\
-        'must be either an Active Record Relation, Array, or CSV.'
+        'must be either an Active Record Relation, or Array.'
       assert_equal expected_message, @run.error_message
     end
 

--- a/test/models/maintenance_tasks/task_data_test.rb
+++ b/test/models/maintenance_tasks/task_data_test.rb
@@ -28,6 +28,7 @@ module MaintenanceTasks
         'Maintenance::ImportPostsTask',
         'Maintenance::TestTask',
         'Maintenance::UpdatePostsTask',
+        'Maintenance::UpdatePostsThrottledTask',
       ]
       assert_equal expected, TaskData.available_tasks.map(&:name)
     end

--- a/test/models/maintenance_tasks/task_data_test.rb
+++ b/test/models/maintenance_tasks/task_data_test.rb
@@ -22,6 +22,7 @@ module MaintenanceTasks
     test '.available_tasks returns a list of Tasks as TaskData, ordered alphabetically by name' do
       expected = [
         'Maintenance::CancelledEnqueueTask',
+        'Maintenance::CustomEnumeratingTask',
         'Maintenance::EnqueueErrorTask',
         'Maintenance::ErrorTask',
         'Maintenance::ImportPostsTask',

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -19,6 +19,7 @@ module MaintenanceTasks
       expected = [
         'New Tasks',
         "Maintenance::CancelledEnqueueTask\nNew",
+        "Maintenance::CustomEnumeratingTask\nNew",
         "Maintenance::EnqueueErrorTask\nNew",
         "Maintenance::ErrorTask\nNew",
         "Maintenance::ImportPostsTask\nNew",

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -24,6 +24,7 @@ module MaintenanceTasks
         "Maintenance::ErrorTask\nNew",
         "Maintenance::ImportPostsTask\nNew",
         "Maintenance::TestTask\nNew",
+        "Maintenance::UpdatePostsThrottledTask\nNew",
         'Completed Tasks',
         "Maintenance::UpdatePostsTask\nSucceeded",
       ]

--- a/test/tasks/maintenance_tasks/task_test.rb
+++ b/test/tasks/maintenance_tasks/task_test.rb
@@ -35,6 +35,13 @@ module MaintenanceTasks
       Maintenance::TestTask.process(item)
     end
 
+    test '.enumerator_builder calls #enumerator_builder' do
+      enumerator_builder = stub('FakeEnumeratorBuilder')
+      Maintenance::TestTask.any_instance.expects(:enumerator_builder)
+        .with.returns(enumerator_builder)
+      assert_equal enumerator_builder, Maintenance::TestTask.enumerator_builder
+    end
+
     test '.collection calls #collection' do
       assert_equal [1, 2], Maintenance::TestTask.collection
     end

--- a/test/tasks/maintenance_tasks/task_test.rb
+++ b/test/tasks/maintenance_tasks/task_test.rb
@@ -68,5 +68,24 @@ module MaintenanceTasks
       message = 'MaintenanceTasks::Task must implement `process`.'
       assert_equal message, error.message
     end
+
+    test '.throttle_specs inherits specs from superclass' do
+      assert_equal [], Maintenance::TestTask.throttle_specs
+    end
+
+    test '.throttle_on registers throttle condition for Task' do
+      throttle_condition = -> { true }
+      Maintenance::TestTask.throttle_on(throttle_condition)
+
+      expected = [{ condition: throttle_condition, backoff: 30.seconds }]
+      assert_equal(expected, Maintenance::TestTask.throttle_specs)
+    ensure
+      Maintenance::TestTask.instance_variable_set(:@throttle_specs, [])
+    end
+
+    test '#throttle_specs calls .throttle_specs' do
+      Maintenance::TestTask.expects(:throttle_specs)
+      Maintenance::TestTask.new.throttle_specs
+    end
   end
 end

--- a/test/tasks/maintenance_tasks/task_test.rb
+++ b/test/tasks/maintenance_tasks/task_test.rb
@@ -6,6 +6,7 @@ module MaintenanceTasks
     test '.available_tasks returns list of tasks that inherit from the Task superclass' do
       expected = [
         'Maintenance::CancelledEnqueueTask',
+        'Maintenance::CustomEnumeratingTask',
         'Maintenance::EnqueueErrorTask',
         'Maintenance::ErrorTask',
         'Maintenance::ImportPostsTask',

--- a/test/tasks/maintenance_tasks/task_test.rb
+++ b/test/tasks/maintenance_tasks/task_test.rb
@@ -12,6 +12,7 @@ module MaintenanceTasks
         'Maintenance::ImportPostsTask',
         'Maintenance::TestTask',
         'Maintenance::UpdatePostsTask',
+        'Maintenance::UpdatePostsThrottledTask',
       ]
       assert_equal expected,
         MaintenanceTasks::Task.available_tasks.map(&:name).sort


### PR DESCRIPTION
For #298 

Here's how we could implement throttling. Users could write a Task like this:

```ruby
module Maintenance
  class MyThrottlingTask < MaintenanceTasks::Task
    throttle_on -> { DatabaseStatus.healthy? }, backoff: 5.minutes

    def collection
       User.all
    end

    def count
      collection.count
    end

    def process(user)
      # Do something
    end
  end
end
```

If we're good with this API, I'll add some docs and clean this up a bit - if not, let's discuss 😁 
I think it makes sense to specify throttling on the Task instead of on a custom Job, since users should have to think about Jobs as little as possible. I also feel like users should be able to define throttling per Task, rather than having a single throttle condition across all their Tasks (which would be the case if we required throttling to be specified on the Job instead). The downside to this is that details of the job are not available, so if users wanted to use any data from the job itself to determine whether it should throttle, this wouldn't be possible.

I've built this on top of Sam's branch, since [his PR](https://github.com/Shopify/maintenance_tasks/pull/326) extracts all our enumerator-building logic into the `Task` class instead of having it in `TaskJob`, so throttling needs to work this those two classes accordingly.