### PR TITLE
Deprecate Runner.new.run in favour of Runner.run

### DIFF
--- a/app/models/maintenance_tasks/runner.rb
+++ b/app/models/maintenance_tasks/runner.rb
@@ -5,6 +5,14 @@ module MaintenanceTasks
   module Runner
     extend self
 
+    # @deprecated Use {Runner} directly instead.
+    def new
+      ActiveSupport::Deprecation.warn(
+        'Use Runner.run instead of Runner.new.run'
+      )
+      self
+    end
+
     # Exception raised when a Task Job couldn't be enqueued.
     class EnqueuingError < StandardError
       # Initializes a Enqueuing Error.

--- a/test/models/maintenance_tasks/runner_test.rb
+++ b/test/models/maintenance_tasks/runner_test.rb
@@ -91,5 +91,12 @@ module MaintenanceTasks
       assert_predicate run.csv_file, :attached?
       assert_equal File.read(csv_file), run.csv_file.download
     end
+
+    test '#new raises deprecation warning and returns self' do
+      dep_msg = 'Use Runner.run instead of Runner.new.run'
+      assert_deprecated(dep_msg) do
+        assert_equal Runner, Runner.new
+      end
+    end
   end
 end


### PR DESCRIPTION
#296 removed `Runner.new` to instead support `Runner.run` directly, but this creates an incompatibility for existing users who were using that API. This brings it back and uses `ActiveSupport::Deprecation.warn` to indicate that users should start using `Runner.run` directly.