### PR TITLE
Explicitly include view helpers

### DIFF
--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -7,6 +7,9 @@ module MaintenanceTasks
   class ApplicationController < ActionController::Base
     include Pagy::Backend
 
+    helper ApplicationHelper
+    helper TaskHelper
+
     BULMA_CDN = 'https://cdn.jsdelivr.net'
 
     content_security_policy do |policy|

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -25,6 +25,8 @@ module Dummy
       MaintenanceTasks.job = 'CustomTaskJob'
     end
 
+    config.action_controller.include_all_helpers = false
+
     # Settings in config/environments/* take precedence over those specified
     # here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
Problem:

When `config.action_controller.include_all_helpers = false`, helpers are
not available by default which leads to `undefined method 'status_tag'`.

Solution:

Include view helpers explicitly.