### PR TITLE
Follow the rails naming convention

### DIFF
--- a/app/helpers/maintenance_tasks/tasks_helper.rb
+++ b/app/helpers/maintenance_tasks/tasks_helper.rb
@@ -6,7 +6,7 @@ module MaintenanceTasks
   # Helpers for formatting data in the maintenance_tasks views.
   #
   # @api private
-  module TaskHelper
+  module TasksHelper
     STATUS_COLOURS = {
       'new' => ['is-primary'],
       'enqueued' => ['is-primary is-light'],
@@ -114,5 +114,5 @@ module MaintenanceTasks
       )
     end
   end
-  private_constant :TaskHelper
+  private_constant :TasksHelper
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -25,6 +25,9 @@ module Dummy
       MaintenanceTasks.job = 'CustomTaskJob'
     end
 
+    # Only include the helper module which match the name of the controller.
+    config.action_controller.include_all_helpers = false
+
     # Settings in config/environments/* take precedence over those specified
     # here.
     # Application configuration can go into files in config/initializers

--- a/test/helpers/maintenance_tasks/tasks_helper_test.rb
+++ b/test/helpers/maintenance_tasks/tasks_helper_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 module MaintenanceTasks
-  class TaskHelperTest < ActionView::TestCase
+  class TasksHelperTest < ActionView::TestCase
     setup do
       @run = Run.new
     end


### PR DESCRIPTION
Problem:

When `config.action_controller.include_all_helpers = false`, helpers are
not available by default which leads to `undefined method 'status_tag'`.

Solution:

By following the rails naming convention, necessary helpers are
automatically included by rails.