### PR TITLE
Fix duplicated timestamps for previous runs on show page

### DIFF
--- a/app/views/maintenance_tasks/runs/_info.html.erb
+++ b/app/views/maintenance_tasks/runs/_info.html.erb
@@ -1,5 +1,6 @@
 <h5 class="title is-5">
   <%= time_tag run.created_at, title: run.created_at %>
+  <%= status_tag run.status if with_status %>
 </h5>
 
 <%= progress run %>

--- a/app/views/maintenance_tasks/runs/_run.html.erb
+++ b/app/views/maintenance_tasks/runs/_run.html.erb
@@ -1,8 +1,3 @@
 <div class="box">
-  <h5 class="title is-5">
-    <%= time_tag run.created_at, title: run.created_at %>
-    <%= status_tag run.status %>
-  </h5>
-
-  <%= render 'maintenance_tasks/runs/info', run: run %>
+  <%= render 'maintenance_tasks/runs/info', run: run, with_status: true %>
 </div>


### PR DESCRIPTION
Duplicated timestamps are showing up for previous runs on the show page, since: https://github.com/Shopify/maintenance_tasks/pull/288.

We need to bring back conditionally showing `run.status` in the `_info` partial based on the value of `with_status`, and then have `_run` render the `_info` partial without duplicating the heading.

## Currently on main

### Index
<img width="1117" alt="Screen Shot 2021-02-19 at 2 06 37 PM" src="https://user-images.githubusercontent.com/22918438/108549808-afded800-72bb-11eb-97f0-f1d0a0b3b4aa.png">

### Show
<img width="1112" alt="Screen Shot 2021-02-19 at 2 06 52 PM" src="https://user-images.githubusercontent.com/22918438/108549834-b8371300-72bb-11eb-88d3-e85ef39e2d3b.png">


## With fix

### Index
<img width="1108" alt="Screen Shot 2021-02-19 at 2 08 21 PM" src="https://user-images.githubusercontent.com/22918438/108549999-eddbfc00-72bb-11eb-88b5-675a09ff49eb.png">

### Show
<img width="1099" alt="Screen Shot 2021-02-19 at 2 06 10 PM" src="https://user-images.githubusercontent.com/22918438/108549763-9f2e6200-72bb-11eb-8ec9-6051a432a688.png">
