### PR TITLE
Ensure cursor is converted into integer as needed

### DIFF
--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -33,9 +33,12 @@ module MaintenanceTasks
       when ActiveRecord::Relation
         enumerator_builder.active_record_on_records(collection, cursor: cursor)
       when Array
-        enumerator_builder.build_array_enumerator(collection, cursor: cursor)
+        enumerator_builder.build_array_enumerator(
+          collection,
+          cursor: cursor&.to_i,
+        )
       when CSV
-        JobIteration::CsvEnumerator.new(collection).rows(cursor: cursor)
+        JobIteration::CsvEnumerator.new(collection).rows(cursor: cursor&.to_i)
       else
         raise ArgumentError, "#{@task.class.name}#collection must be either "\
           'an Active Record Relation, Array, or CSV.'


### PR DESCRIPTION
To ensure #339's change to string cursors can occur smoothly, we ensure we always convert the cursor into an integer when needed.

Specifically, the `Array` and `CSV` cursors **must** be integers when forwarded to JobIteration's enumerator builders, or things break. The ActiveRecord enumerator builder handles the conversion gracefully.

This should allow consumers to perform the cursor schema change from `bigint` to `string` without worrying about stale code blowing up.

## ⚠️ After Merging
- [ ] Ensure this is released before #339, so consumers can update to the transition version