### PR TITLE
Change generator `--csv` to `--type=csv`

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ is specified in your application's Gemfile, and that you've followed the
 Generate a CSV Task by running:
 
 ```bash
-$ rails generate maintenance_tasks:task import_posts --csv
+$ rails generate maintenance_tasks:task import_posts --type=csv
 ```
 
 The generated task is a subclass of `MaintenanceTasks::Task` that implements:

--- a/lib/generators/maintenance_tasks/task_generator.rb
+++ b/lib/generators/maintenance_tasks/task_generator.rb
@@ -9,23 +9,28 @@ module MaintenanceTasks
     desc 'This generator creates a task file at app/tasks and a corresponding '\
       'test.'
 
-    class_option :csv, type: :boolean, default: false,
-      desc: 'Generate a CSV Task.'
+    TASK_TYPES = ['generic', 'csv']
+    class_option :type, type: :string, default: 'generic',
+      desc: "Specify the type of Task to generate (#{TASK_TYPES.join(', ')})"
 
     check_class_collision suffix: 'Task'
 
+    # Ensure a valid task type has been provided
+    def validate_task_type
+      return if TASK_TYPES.include?(task_type)
+
+      raise(Thor::Error, "Unknown task type #{task_type.inspect}. " \
+            "Must be one of: #{TASK_TYPES.join(', ')}")
+    end
+
     # Creates the Task file.
     def create_task_file
-      template_file = File.join(
+      task_file = File.join(
         "app/tasks/#{tasks_module_file_path}",
         class_path,
         "#{file_name}_task.rb"
       )
-      if options[:csv]
-        template('csv_task.rb', template_file)
-      else
-        template('task.rb', template_file)
-      end
+      template(task_template_file, task_file)
     end
 
     # Creates the Task test file, according to the app's test framework.
@@ -44,25 +49,52 @@ module MaintenanceTasks
     private
 
     def create_task_test_file
-      template_file = File.join(
+      test_file = File.join(
         "test/tasks/#{tasks_module_file_path}",
         class_path,
         "#{file_name}_task_test.rb"
       )
-      template('task_test.rb', template_file)
+      template(test_template_file, test_file)
     end
 
     def create_task_spec_file
-      template_file = File.join(
+      spec_file = File.join(
         "spec/tasks/#{tasks_module_file_path}",
         class_path,
         "#{file_name}_task_spec.rb"
       )
-      template('task_spec.rb', template_file)
+      template(spec_template_file, spec_file)
+    end
+
+    def task_template_file
+      case task_type
+      when 'generic'
+        'task.rb'
+      when 'csv'
+        'csv_task.rb'
+      end
+    end
+
+    def test_template_file
+      case task_type
+      when 'generic', 'csv'
+        'task_test.rb'
+      end
+    end
+
+    def spec_template_file
+      case task_type
+      when 'generic', 'csv'
+        'task_spec.rb'
+      end
     end
 
     def file_name
       super.sub(/_task\z/i, '')
+    end
+
+    def task_type
+      options[:type]
     end
 
     def tasks_module

--- a/lib/generators/maintenance_tasks/templates/task_spec.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/task_spec.rb.tt
@@ -5,9 +5,9 @@ module <%= tasks_module %>
 <% module_namespacing do -%>
   RSpec.describe <%= class_name %>Task do
     # describe '#process' do
-      # it 'performs a task iteration' do
-        # <%= tasks_module %>::<%= class_name %>Task.process(element)
-      # end
+    #   it 'performs a task iteration' do
+    #     <%= tasks_module %>::<%= class_name %>Task.process(element)
+    #   end
     # end
   end
 <% end -%>

--- a/test/lib/generators/maintenance_tasks/task_generator_test.rb
+++ b/test/lib/generators/maintenance_tasks/task_generator_test.rb
@@ -72,13 +72,29 @@ module MaintenanceTasks
       assert_file 'app/tasks/maintenance/sleepy_task.rb'
     end
 
-    test 'generator creates a CSV Task if the --csv option is supplied' do
-      run_generator ['sleepy', '--csv']
+    test 'generator creates a CSV Task if the --type=csv option is supplied' do
+      run_generator ['sleepy', '--type=csv']
       assert_file 'app/tasks/maintenance/sleepy_task.rb' do |task|
         assert_match(/class SleepyTask < MaintenanceTasks::Task/, task)
         assert_match(/csv_collection/, task)
         assert_match(/def process\(row\)/, task)
       end
+    end
+
+    test 'generator creates a generic collection task if the --type=generic option is supplied' do
+      run_generator ['sleepy', '--type=generic']
+      assert_file 'app/tasks/maintenance/sleepy_task.rb' do |task|
+        assert_match(/def collection/, task)
+        assert_match(/def process\(element\)/, task)
+      end
+    end
+
+    test 'generator aborts if the --type option is supplied with an unknown value' do
+      stderr = capture(:stderr) do
+        run_generator(['sleepy', '--type=unknown'])
+      end
+      assert_no_file 'app/tasks/maintenance/sleepy_task.rb'
+      assert_match(/Unknown task type "unknown"\. Must be one of:/, stderr)
     end
   end
 end

--- a/test/lib/generators/maintenance_tasks/task_generator_test.rb
+++ b/test/lib/generators/maintenance_tasks/task_generator_test.rb
@@ -32,18 +32,14 @@ module MaintenanceTasks
     end
 
     test 'generator creates a task spec if the application is using RSpec' do
-      generators_config = Rails.application.config.generators
-      old_test_framework = generators_config.options[:rails][:test_framework]
-      generators_config.options[:rails][:test_framework] = :rspec
+      with_rspec do
+        run_generator(['sleepy'])
 
-      run_generator(['sleepy'])
-
-      assert_file('spec/tasks/maintenance/sleepy_task_spec.rb') do |task_spec|
-        assert_match(/module Maintenance/, task_spec)
-        assert_match(/RSpec.describe SleepyTask/, task_spec)
+        assert_file('spec/tasks/maintenance/sleepy_task_spec.rb') do |task_spec|
+          assert_match(/module Maintenance/, task_spec)
+          assert_match(/RSpec.describe SleepyTask/, task_spec)
+        end
       end
-    ensure
-      generators_config.options[:rails][:test_framework] = old_test_framework
     end
 
     test 'generator uses configured tasks module' do
@@ -95,6 +91,18 @@ module MaintenanceTasks
       end
       assert_no_file 'app/tasks/maintenance/sleepy_task.rb'
       assert_match(/Unknown task type "unknown"\. Must be one of:/, stderr)
+    end
+
+    private
+
+    def with_rspec
+      generators_config = Rails.application.config.generators
+      old_test_framework = generators_config.options[:rails][:test_framework]
+      generators_config.options[:rails][:test_framework] = :rspec
+
+      yield
+    ensure
+      generators_config.options[:rails][:test_framework] = old_test_framework
     end
   end
 end


### PR DESCRIPTION
## TL;DR

```diff
-$ rails generate maintenance_tasks:task NAME --csv
+$ rails generate maintenance_tasks:task NAME --type=csv # or --type csv
```

## Details

Working on #326 and wanting to include a generator for tasks with a custom enumerator builder, @adrianna-chang-shopify and I decided it might be best to change the `--csv` generator option to `--type=csv`, rather than have a bunch of mutually exclusive options (e.g. `--csv` & `--custom`).

IF we decide to provide additional built-in enumerators in the future, this would also provide a natural extension point.

Included in this PR are various refactorings to the generator code.

This is technically a breaking change to the developer API, but not to the actual task/application code. As such, it doesn't feel like it warrants a major version bump.

### ⚠️ Before Merging
- [x] Get feedback on task type names (`--type=generic` & `--type=csv`)
- [x] Update README and any other documentation mentioning `--csv`