### PR TITLE
Avoid usage of private_constant

### DIFF
--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -3,7 +3,7 @@
 module MaintenanceTasks
   # Base class for all controllers used by this engine.
   #
-  # @api private
+  # Can be extended to add different authentication and authorization code.
   class ApplicationController < ActionController::Base
     include Pagy::Backend
 

--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -22,5 +22,4 @@ module MaintenanceTasks
 
     protect_from_forgery with: :exception
   end
-  private_constant :ApplicationController
 end

--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -30,5 +30,4 @@ module MaintenanceTasks
       @run = Run.find(params.fetch(:id))
     end
   end
-  private_constant :RunsController
 end

--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -42,5 +42,4 @@ module MaintenanceTasks
       @refresh = 3
     end
   end
-  private_constant :TasksController
 end

--- a/app/helpers/maintenance_tasks/application_helper.rb
+++ b/app/helpers/maintenance_tasks/application_helper.rb
@@ -29,5 +29,4 @@ module MaintenanceTasks
       end
     end
   end
-  private_constant :ApplicationHelper
 end

--- a/app/helpers/maintenance_tasks/tasks_helper.rb
+++ b/app/helpers/maintenance_tasks/tasks_helper.rb
@@ -114,5 +114,4 @@ module MaintenanceTasks
       )
     end
   end
-  private_constant :TasksHelper
 end

--- a/app/models/maintenance_tasks/application_record.rb
+++ b/app/models/maintenance_tasks/application_record.rb
@@ -6,5 +6,4 @@ module MaintenanceTasks
   class ApplicationRecord < ActiveRecord::Base
     self.abstract_class = true
   end
-  private_constant :ApplicationRecord
 end

--- a/app/models/maintenance_tasks/application_record.rb
+++ b/app/models/maintenance_tasks/application_record.rb
@@ -2,7 +2,8 @@
 module MaintenanceTasks
   # Base class for all records used by this engine.
   #
-  # @api private
+  # Can be extended to setup different database where all tables related to
+  # maintenance tasks will live.
   class ApplicationRecord < ActiveRecord::Base
     self.abstract_class = true
   end

--- a/app/models/maintenance_tasks/csv_collection.rb
+++ b/app/models/maintenance_tasks/csv_collection.rb
@@ -30,5 +30,4 @@ module MaintenanceTasks
       csv_content.count("\n") - 1
     end
   end
-  private_constant :CsvCollection
 end

--- a/app/models/maintenance_tasks/progress.rb
+++ b/app/models/maintenance_tasks/progress.rb
@@ -70,5 +70,4 @@ module MaintenanceTasks
       total? && @run.tick_total > @run.tick_count
     end
   end
-  private_constant :Progress
 end

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -195,5 +195,4 @@ module MaintenanceTasks
       nil
     end
   end
-  private_constant :Run
 end

--- a/app/models/maintenance_tasks/task_data.rb
+++ b/app/models/maintenance_tasks/task_data.rb
@@ -138,5 +138,4 @@ module MaintenanceTasks
       Run.where(task_name: name).with_attached_csv_file.order(created_at: :desc)
     end
   end
-  private_constant :TaskData
 end

--- a/app/models/maintenance_tasks/ticker.rb
+++ b/app/models/maintenance_tasks/ticker.rb
@@ -54,5 +54,4 @@ module MaintenanceTasks
       Time.now - @last_persisted >= @throttle_duration
     end
   end
-  private_constant :Ticker
 end

--- a/app/validators/maintenance_tasks/run_status_validator.rb
+++ b/app/validators/maintenance_tasks/run_status_validator.rb
@@ -85,5 +85,4 @@ module MaintenanceTasks
       )
     end
   end
-  private_constant :RunStatusValidator
 end

--- a/lib/generators/maintenance_tasks/install_generator.rb
+++ b/lib/generators/maintenance_tasks/install_generator.rb
@@ -18,5 +18,4 @@ module MaintenanceTasks
       rake('db:migrate')
     end
   end
-  private_constant :InstallGenerator
 end

--- a/lib/generators/maintenance_tasks/task_generator.rb
+++ b/lib/generators/maintenance_tasks/task_generator.rb
@@ -77,5 +77,4 @@ module MaintenanceTasks
       Rails.application.config.generators.options[:rails][:test_framework]
     end
   end
-  private_constant :TaskGenerator
 end

--- a/lib/maintenance_tasks/cli.rb
+++ b/lib/maintenance_tasks/cli.rb
@@ -51,5 +51,4 @@ module MaintenanceTasks
       end
     end
   end
-  private_constant :CLI
 end

--- a/test/lib/maintenance_tasks_test.rb
+++ b/test/lib/maintenance_tasks_test.rb
@@ -2,24 +2,6 @@
 require 'test_helper'
 
 class MaintenanceTasksTest < ActiveSupport::TestCase
-  test "doesn't leak its internals" do
-    expected_public_constants = [
-      :Engine,  # to mount
-      :Runner,  # to run a Task
-      :Task,    # to define Tasks
-      :TaskJob, # to customize the job
-    ]
-    public_constants = MaintenanceTasks.constants.select do |constant|
-      constant =
-        eval("MaintenanceTasks::#{constant}") # rubocop:disable Security/Eval
-      next if constant.is_a?(Class) && constant < Minitest::Test
-      true
-    rescue NameError
-      false
-    end
-    assert_equal expected_public_constants.sort, public_constants.sort
-  end
-
   test 'deprecation warning raised when error_handler does not accept three arguments' do
     error_handler_before = MaintenanceTasks.error_handler
 


### PR DESCRIPTION
This just make hard to use reflection on Ruby classes breaking tools like tapioca. The value we want to provide with this call is telling people to not use this class, but that is already achieved by `@api private`.

If people really want to use this constant even if we told them to not do it, isn't `private_constant` that will stop them.