### PR TITLE
Postpone reenqueuing the iteration job until after callbacks are done

### DIFF
--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -97,8 +97,16 @@ module MaintenanceTasks
       @ticker.persist
     end
 
+    def reenqueue_iteration_job(should_ignore: true)
+      super() unless should_ignore
+      @reenqueue_iteration_job = true
+    end
+
     def after_perform
       @run.save!
+      if defined?(@reenqueue_iteration_job) && @reenqueue_iteration_job
+        reenqueue_iteration_job(should_ignore: false)
+      end
     end
 
     def on_error(error)

--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -97,6 +97,17 @@ module MaintenanceTasks
       @ticker.persist
     end
 
+    # We are reopening a private part of Job Iteration's API here, so we should
+    # ensure the method is still defined upstream. This way, in the case where
+    # the method changes upstream, we catch it at load time instead of at
+    # runtime while calling `super`.
+    unless private_method_defined?(:reenqueue_iteration_job)
+      error_message = <<~HEREDOC
+        JobIteration::Iteration#reenqueue_iteration_job is expected to be
+        defined. Upgrading the maintenance_tasks gem should solve this problem.
+      HEREDOC
+      raise error_message
+    end
     def reenqueue_iteration_job(should_ignore: true)
       super() unless should_ignore
       @reenqueue_iteration_job = true

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -9,6 +9,10 @@ require 'maintenance_tasks/engine'
 require 'pagy'
 require 'pagy/extras/bulma'
 
+# Force the TaskJob class to load so we can verify upstream compatibility with
+# the JobIteration gem
+require_relative '../app/jobs/maintenance_tasks/task_job'
+
 # The engine's namespace module. It provides isolation between the host
 # application's code and the engine-specific code. Top-level engine constants
 # and variables are defined under this module.


### PR DESCRIPTION
For: https://github.com/Shopify/maintenance_tasks/issues/335

This PR fixes a bug that occurs when a job gets interrupted and is reenqueued faster than the original job takes to shut down. This results in race conditions with the `@run` and results in errors due to invalid status transitions (and notably results in a run showing up as interrupted when it is actually running).

To solve this, we should delay reenqueuing the job until after all callbacks have completed, which can be done by calling `#reenqueue_iteration_job` in a prepended after_perform callback in TaskJob, and skipping the call that JobIteration performs in [`#iterate_with_enumerator`](https://github.com/Shopify/job-iteration/blob/ae9f11e316c99eaf0c5a478c1fa0a659fcd7730a/lib/job-iteration/iteration.rb#L131).


## Considerations
Arguably callback ordering and ensuring that a job shuts down and runs its callbacks successfully before the new one starts up is something that should be upstreamed to `JobIteration`. I experimented with [a PR](https://github.com/Shopify/job-iteration/pull/66) for this, but the issue is that a number of jobs relying on JobIteration in Core are also dependent on the point at which the job is reenqueued in order to resume batch processing jobs where an error has occurred. (These jobs are currently able to resume from the last cursor when something goes wrong, but changing the order results in the [new job not being pushed back to the queue](https://buildkite.com/shopify/shopify-selective-tests/builds/337355), and things simply failing).

I think this is worth reinvestigating upstream at a later point, but I think we should get this patch out in the meantime, given it's affecting a number of users at the moment.

## Tophatting
Try without the changes and then with to see the difference.
Steps to reproduce:
- `bundle add sidekiq`
```ruby
+++ test/dummy/config/application.rb
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.active_job.queue_adapter = :sidekiq
   end
 end
```
```ruby
+++ app/jobs/maintenance_tasks/task_job.rb
    def on_shutdown
       if @run.cancelling?
         @run.status = :cancelled
         @run.ended_at = Time.now
       else
+        sleep(3)
         @run.status = @run.pausing? ? :paused : :interrupted
```

```ruby
+++ test/dummy/config/initializers/maintenance_tasks.rb
+JobIteration.max_job_runtime = 4.seconds
```

And then run `Maintenance::UpdatePostsTask` from the UI