### PR TITLE
Remove redundant index on :task_name

### DIFF
--- a/db/migrate/20210225152418_remove_index_on_task_name.rb
+++ b/db/migrate/20210225152418_remove_index_on_task_name.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class RemoveIndexOnTaskName < ActiveRecord::Migration[6.1]
+  def up
+    change_table(:maintenance_tasks_runs) do |t|
+      t.remove_index(:task_name)
+    end
+  end
+
+  def down
+    change_table(:maintenance_tasks_runs) do |t|
+      t.index(:task_name)
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_12_141723) do
+ActiveRecord::Schema.define(version: 2021_02_25_152418) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -56,7 +56,6 @@ ActiveRecord::Schema.define(version: 2021_01_12_141723) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["task_name", "created_at"], name: "index_maintenance_tasks_runs_on_task_name_and_created_at", order: { created_at: :desc }
-    t.index ["task_name"], name: "index_maintenance_tasks_runs_on_task_name"
   end
 
   create_table "posts", force: :cascade do |t|


### PR DESCRIPTION
For: https://github.com/Shopify/maintenance_tasks/issues/342

Confirmed that the index on just `:task_name` is redundant given our composite index on `[:task_name, :created_at]`. We can remove it.

I think we need to remove the index from the table itself in a `change_table` block (instead of using https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-remove_index) due to LHM constraints (as mentioned [here](https://github.com/Shopify/maintenance_tasks/pull/239), modifying indexes outside of table blocks seems to pose problems for LHMs).
