### PR TITLE
Eager-load the engine before the app code for the classic autoloader

### DIFF
--- a/lib/maintenance_tasks/engine.rb
+++ b/lib/maintenance_tasks/engine.rb
@@ -7,6 +7,10 @@ module MaintenanceTasks
   class Engine < ::Rails::Engine
     isolate_namespace MaintenanceTasks
 
+    initializer 'eager_load_for_classic_autoloader' do
+      eager_load! unless Rails.autoloaders.zeitwerk_enabled?
+    end
+
     config.to_prepare do
       unless Rails.autoloaders.zeitwerk_enabled?
         tasks_module = MaintenanceTasks.tasks_module.underscore
@@ -17,7 +21,6 @@ module MaintenanceTasks
     end
 
     config.after_initialize do
-      eager_load! unless Rails.autoloaders.zeitwerk_enabled?
       JobIteration.max_job_runtime ||= 5.minutes
     end
 


### PR DESCRIPTION
When using the classic autoloader, simply by using a CSV Task, we got in the situation where we try to refer to CsvCollection but it hasn't yet been loaded.

Fixes #347.