### PR TITLE
Don't show indefinite progress bar when finishing a task

### DIFF
--- a/app/models/maintenance_tasks/progress.rb
+++ b/app/models/maintenance_tasks/progress.rb
@@ -49,7 +49,7 @@ module MaintenanceTasks
     def title
       if !total?
         "Processed #{@run.tick_count} #{'item'.pluralize(@run.tick_count)}."
-      elsif @run.tick_count > @run.tick_total
+      elsif over_total?
         "Processed #{@run.tick_count} #{'item'.pluralize(@run.tick_count)} " \
           "(expected #{@run.tick_total})."
       else
@@ -67,7 +67,11 @@ module MaintenanceTasks
     end
 
     def estimatable?
-      total? && @run.tick_total > @run.tick_count
+      total? && !over_total?
+    end
+
+    def over_total?
+      @run.tick_count > @run.tick_total
     end
   end
   private_constant :Progress

--- a/test/models/maintenance_tasks/progress_test.rb
+++ b/test/models/maintenance_tasks/progress_test.rb
@@ -25,9 +25,11 @@ module MaintenanceTasks
       assert_equal 4, @progress.value
     end
 
-    test '#value is nil if the Run tick count is greater than its tick total' do
-      @run.tick_count = 8
+    test '#value is nil if the Run tick count is strictly greater than its tick total' do
+      @run.tick_count = 7
+      refute_nil @progress.value
 
+      @run.tick_count = 8
       assert_nil @progress.value
     end
 


### PR DESCRIPTION
When a Task is finished processing, but the `JobIteration.max_job_runtime` has been reached, the Task gets interrupted, then when it starts it finally gets marked as succeeded, because there's no additional element to process.

When that happens, the tick count is equal to the tick total and the progress bar appears as indefinite. We were missing a test at the boundary.