### PR TITLE
Check if ActiveStorage used before fetching Run's csv_file

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -188,11 +188,21 @@ module MaintenanceTasks
     def csv_attachment_presence
       if Task.named(task_name) < CsvCollection && !csv_file.attached?
         errors.add(:csv_file, 'must be attached to CSV Task.')
-      elsif !(Task.named(task_name) < CsvCollection) && csv_file.attached?
+      elsif !(Task.named(task_name) < CsvCollection) && csv_file.present?
         errors.add(:csv_file, 'should not be attached to non-CSV Task.')
       end
     rescue Task::NotFoundError
       nil
+    end
+
+    # Fetches the attached ActiveStorage CSV file for the run. Checks first
+    # whether the ActiveStorage::Attachment table exists so that we are
+    # compatible with apps that are not using ActiveStorage.
+    #
+    # @return [ActiveStorage::Attached::One] the attached CSV file
+    def csv_file
+      return unless ActiveStorage::Attachment.table_exists?
+      super
     end
   end
 end

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -41,6 +41,11 @@ module MaintenanceTasks
 
     scope :active, -> { where(status: ACTIVE_STATUSES) }
 
+    # Ensure ActiveStorage is in use before preloading the attachments
+    scope :with_attached_csv, -> do
+      with_attached_csv_file if ActiveStorage::Attachment.table_exists?
+    end
+
     validates_with RunStatusValidator, on: :update
 
     has_one_attached :csv_file

--- a/app/models/maintenance_tasks/task_data.rb
+++ b/app/models/maintenance_tasks/task_data.rb
@@ -135,7 +135,7 @@ module MaintenanceTasks
     private
 
     def runs
-      Run.where(task_name: name).with_attached_csv_file.order(created_at: :desc)
+      Run.where(task_name: name).with_attached_csv.order(created_at: :desc)
     end
   end
 end

--- a/app/views/maintenance_tasks/runs/_info.html.erb
+++ b/app/views/maintenance_tasks/runs/_info.html.erb
@@ -9,7 +9,7 @@
   <%= render "maintenance_tasks/runs/info/#{run.status}", run: run %>
 </div>
 
-<% if run.csv_file.attached? %>
+<% if run.csv_file.present? %>
   <div class="block">
     <%= link_to('Download CSV', csv_file_download_path(run)) %>
   </div>


### PR DESCRIPTION
Right now, both:
https://github.com/Shopify/maintenance_tasks/blob/0c5813cd2d5acd8a4457d9ddfe6072dd9bd48ed6/app/views/maintenance_tasks/runs/_info.html.erb#L12
and
https://github.com/Shopify/maintenance_tasks/blob/0c5813cd2d5acd8a4457d9ddfe6072dd9bd48ed6/app/models/maintenance_tasks/run.rb#L191
will blow up when called in an app that does not have ActiveStorage set up.

Arguably 
https://github.com/Shopify/maintenance_tasks/blob/0c5813cd2d5acd8a4457d9ddfe6072dd9bd48ed6/app/models/maintenance_tasks/run.rb#L189
and
https://github.com/Shopify/maintenance_tasks/blob/0c5813cd2d5acd8a4457d9ddfe6072dd9bd48ed6/app/models/maintenance_tasks/runner.rb#L48
also blow up, but these are scenarios where the app is attempting to use CSV functionality, so I think it's okay that these result in the missing table error.

IMHO the way to solve this is to just return early from `Run#csv_file` if the `ActiveStorage::Attachment` table doesn't exist, and to then use the safe access operator for the first two lines above.

I figured we wouldn't want to use the safe access operator for the second two scenarios (L189 in `Run` and L48 in `Runner`), since ActiveStorage should be configured here if the user wants to write CSV Tasks, so it makes sense for this to 💥 .

EDIT: The preloading query in `TaskData` also fails if the table doesn't exist, so I've tweaked that to not preload unless it's the table exists there too.