### PR TITLE
Always return relation from `with_attached_csv`

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -43,7 +43,11 @@ module MaintenanceTasks
 
     # Ensure ActiveStorage is in use before preloading the attachments
     scope :with_attached_csv, -> do
-      with_attached_csv_file if ActiveStorage::Attachment.table_exists?
+      if ActiveStorage::Attachment.table_exists?
+        with_attached_csv_file
+      else
+        none
+      end
     end
 
     validates_with RunStatusValidator, on: :update


### PR DESCRIPTION
Follow up to #359.

If the attachments table exists, we return a relation, but if not, we return `nil`.

We should return an empty relation instead, so we don't have to worry about follow up calls to methods like `.order` failing.