### PR TITLE
Switch to cursor-based pagination with geared_pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,5 @@ gem 'selenium-webdriver'
 gem 'sqlite3'
 gem 'webdrivers', require: false
 gem 'yard'
+
+gem 'geared_pagination', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ PATH
       activejob (>= 6.0)
       activerecord (>= 6.0)
       job-iteration (~> 1.1)
-      pagy (~> 3.9)
       railties (>= 6.0)
 
 GEM
@@ -115,7 +114,6 @@ GEM
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    pagy (3.11.0)
     parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,9 @@ GEM
     concurrent-ruby (1.1.8)
     crass (1.0.6)
     erubi (1.10.0)
+    geared_pagination (1.1.0)
+      activesupport (>= 5.0)
+      addressable (>= 2.5.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.8.9)
@@ -206,6 +209,7 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
+  geared_pagination (~> 1.1)
   maintenance_tasks!
   mocha
   pry-byebug

--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -5,8 +5,6 @@ module MaintenanceTasks
   #
   # Can be extended to add different authentication and authorization code.
   class ApplicationController < ActionController::Base
-    include Pagy::Backend
-
     BULMA_CDN = 'https://cdn.jsdelivr.net'
 
     content_security_policy do |policy|

--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -20,7 +20,9 @@ module MaintenanceTasks
     def show
       @task = TaskData.find(params.fetch(:id))
       set_refresh if @task.last_run&.active?
-      @pagy, @previous_runs = pagy(@task.previous_runs)
+      set_page_and_extract_portion_from(@task.previous_runs,
+        ordered_by: { created_at: :desc })
+      set_paginated_headers
     end
 
     # Runs a given Task and redirects to the Task page.

--- a/app/helpers/maintenance_tasks/application_helper.rb
+++ b/app/helpers/maintenance_tasks/application_helper.rb
@@ -4,17 +4,6 @@ module MaintenanceTasks
   #
   # @api private
   module ApplicationHelper
-    include Pagy::Frontend
-
-    # Renders pagination for the page, if there is more than one page present.
-    #
-    # @param pagy [Pagy] the pagy instance containing pagination details,
-    #   including the number of pages the results are spread across.
-    # @return [String] the HTML to render for pagination.
-    def pagination(pagy)
-      raw(pagy_bulma_nav(pagy)) if pagy.pages > 1
-    end
-
     # Renders pagination-related text showing the current page, total pages,
     # and total number of records, if there is more than one page present.
     # @param page [GearedPagination::Page] the page instance containing

--- a/app/helpers/maintenance_tasks/application_helper.rb
+++ b/app/helpers/maintenance_tasks/application_helper.rb
@@ -15,6 +15,21 @@ module MaintenanceTasks
       raw(pagy_bulma_nav(pagy)) if pagy.pages > 1
     end
 
+    # Renders pagination-related text showing the current page, total pages,
+    # and total number of records, if there is more than one page present.
+    # @param page [GearedPagination::Page] the page instance containing
+    #   pagination details.
+    # @param record_type [String] the type of the recordset.
+    # @return [String] the HTML to render with the helpful pagination text.
+    def pagination_text(page, record_type)
+      page_count = page.recordset.page_count
+      if page_count > 1
+        record_count = page.recordset.records_count
+        tag.span("Showing page #{page.number} of #{page_count} " \
+        "(#{record_count} total #{record_type.pluralize(record_count)})")
+      end
+    end
+
     # Renders a time element with the given datetime, worded as relative to the
     # current time.
     #

--- a/app/models/maintenance_tasks/task_data.rb
+++ b/app/models/maintenance_tasks/task_data.rb
@@ -83,7 +83,7 @@ module MaintenanceTasks
     # @return [nil] if there are no Runs associated with the Task.
     def last_run
       return @last_run if defined?(@last_run)
-      @last_run = runs.first
+      @last_run = runs.last
     end
 
     # Returns the set of Run records associated with the Task previous to the
@@ -135,7 +135,7 @@ module MaintenanceTasks
     private
 
     def runs
-      Run.where(task_name: name).with_attached_csv.order(created_at: :desc)
+      Run.where(task_name: name).with_attached_csv
     end
   end
 end

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -41,12 +41,11 @@
   <pre><code><%= highlight_code(code) %></code></pre>
 <% end %>
 
-<% if @previous_runs.present? %>
+<% if @task.previous_runs.any? %>
   <hr/>
 
   <h4 class="title is-4">Previous Runs</h4>
-
-  <%= render @previous_runs %>
-
-  <%= pagination(@pagy) %>
+  <%= render @page.records %>
+  <%= pagination_text(@page, 'run')%>
+  <%= link_to "Next page", task_path(@task, page: @page.next_param) unless @page.last? %>
 <% end %>

--- a/config/initializers/geared_pagination.rb
+++ b/config/initializers/geared_pagination.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+GearedPagination::Engine.config.after_initialize do
+  ActiveSupport.on_load(:action_controller) do
+    ActionController::Base.skip_after_action(:set_paginated_headers)
+  end
+end

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -6,8 +6,6 @@ require 'active_record'
 
 require 'job-iteration'
 require 'maintenance_tasks/engine'
-require 'pagy'
-require 'pagy/extras/bulma'
 
 # Force the TaskJob class to load so we can verify upstream compatibility with
 # the JobIteration gem

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -26,6 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency('activejob', '>= 6.0')
   spec.add_dependency('activerecord', '>= 6.0')
   spec.add_dependency('job-iteration', '~> 1.1')
-  spec.add_dependency('pagy', '~> 3.9')
   spec.add_dependency('railties', '>= 6.0')
 end

--- a/test/helpers/maintenance_tasks/application_helper_test.rb
+++ b/test/helpers/maintenance_tasks/application_helper_test.rb
@@ -3,22 +3,7 @@ require 'test_helper'
 
 module MaintenanceTasks
   class ApplicationHelperTest < ActionView::TestCase
-    setup do
-      @pagy = mock
-      @page = mock
-    end
-
-    test '#pagination returns nil if pages is less than or equal to 1' do
-      @pagy.expects(pages: 1)
-      expects(:pagy_bulma_nav).never
-      assert_nil pagination(@pagy)
-    end
-
-    test '#pagination returns pagination element if pages is greater than 1' do
-      @pagy.expects(pages: 2)
-      expects(:pagy_bulma_nav).with(@pagy).returns('pagination')
-      assert_equal 'pagination', pagination(@pagy)
-    end
+    setup { @page = mock }
 
     test '#pagination_text returns nil if pages is less than or equal to 1' do
       @page.stubs(recordset: mock(page_count: 1))

--- a/test/helpers/maintenance_tasks/application_helper_test.rb
+++ b/test/helpers/maintenance_tasks/application_helper_test.rb
@@ -3,7 +3,10 @@ require 'test_helper'
 
 module MaintenanceTasks
   class ApplicationHelperTest < ActionView::TestCase
-    setup { @pagy = mock }
+    setup do
+      @pagy = mock
+      @page = mock
+    end
 
     test '#pagination returns nil if pages is less than or equal to 1' do
       @pagy.expects(pages: 1)
@@ -15,6 +18,23 @@ module MaintenanceTasks
       @pagy.expects(pages: 2)
       expects(:pagy_bulma_nav).with(@pagy).returns('pagination')
       assert_equal 'pagination', pagination(@pagy)
+    end
+
+    test '#pagination_text returns nil if pages is less than or equal to 1' do
+      @page.stubs(recordset: mock(page_count: 1))
+      assert_nil pagination_text(@page, 'run')
+    end
+
+    test '#pagination_text returns text with pagination info if pages is greater than 1' do
+      page_number = 1
+      total_pages = 2
+      records_count = 12
+      @page.stubs(
+        number: page_number,
+        recordset: mock(page_count: total_pages, records_count: records_count)
+      )
+      assert_equal '<span>Showing page 1 of 2 (12 total runs)</span>',
+        pagination_text(@page, 'run')
     end
 
     test '#time_ago returns a time element with the given datetime worded as relative to now and ISO 8601 UTC time in title attribute' do

--- a/test/models/maintenance_tasks/task_data_test.rb
+++ b/test/models/maintenance_tasks/task_data_test.rb
@@ -80,8 +80,8 @@ module MaintenanceTasks
       task_data = TaskData.find('Maintenance::UpdatePostsTask')
 
       assert_equal 2, task_data.previous_runs.count
-      assert_equal run_2, task_data.previous_runs.first
-      assert_equal run_1, task_data.previous_runs.last
+      assert_equal run_1, task_data.previous_runs.first
+      assert_equal run_2, task_data.previous_runs.last
     end
 
     test '#previous_runs is empty when there are no Runs for the Task' do


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/362

As mentioned in the issue, Pagy uses offset-based pagination, which decreases in performance as the collection of elements being paginated grows. It doesn't scale very well, and queries that use `OFFSET` are outright banned in Core for performance reasons. A cursor based pagination strategy queries based on a specific point in the dataset (the cursor), and works well for 
sequential datasets / datasets with ordered attributes (`maintenance_tasks_runs` table is guaranteed to be sortable by `created_at` ).

Basecamp has actually written a gem that supports [cursor-based pagination](https://github.com/basecamp/geared_pagination#cursor-based-pagination), which I think is a really good candidate for us to use, replacing Pagy.

### Implementation
- As the gem's README notes, we use `set_page_and_extract_portion_from` with the `ordered_by`  option to perform cursor-based pagination
- Using this form of pagination requires the original relation to be unordered, so I've dropped the ordering on `#previous_runs`, since the pagination will handle this for us now
- This provides us with an instance var `@page`, which contains the recordset of paginated elements which we can render in the view (similar to what was happening with Pagy)
- **What is config/initializers/geared_pagination.rb all about?**
     - The gem works by [including `GearedPagination::Controller` in `ActionController::Base`](https://github.com/basecamp/geared_pagination/blob/140de067b283dfc6d564fa91b8860b2badc57286/lib/geared_pagination/engine.rb#L7) when the gem is initialized
      -  `GearedPagination::Controller` sets an `after_action` filter, `set_paginated_headers`
      - This currently breaks our test suite, because `set_paginated_headers` checks an ivar that doesn't exist (`@page`) which warns and thus raises in our test suite. I also don't really like that this filter runs before every single controller action in the engine _and_ the host app. 
      - So, I've added an initializer that removes this filter and puts the onus on us to call `set_paginated_headers` when we need to (for now, this is only in `TasksController#show`)
      - Arguably this is a little brittle. We could write a wrapper to isolate the call to `set_paginated_headers` in case we want to reuse pagination elsewhere, but I thought maybe that was premature

### To 🎩 
- Create a bunch of `runs` in the dummy (ie. `rails db:seed` a couple times)
- Check out http://localhost:3000/maintenance_tasks/tasks/Maintenance::TestTask and verify no pagination
- Check out http://localhost:3000/maintenance_tasks/tasks/Maintenance::UpdatePostsTask and test the pagination

![Screen Shot 2021-03-05 at 10 33 13 AM](https://user-images.githubusercontent.com/22918438/110136976-52a85380-7d9e-11eb-8f12-9d0c702eb83a.png)


### Tradeoffs
- We lose the ability to show individual "pages" and to go back to a previous page. However, I think it will be pretty rare that a ton of pages will be needed
- We also gain the ability to provide a URL to a given page based on a cursor now which is kind of nice