### PR TITLE
Use min accepted version for ActiveRecord::Migration classes

### DIFF
--- a/db/migrate/20210225152418_remove_index_on_task_name.rb
+++ b/db/migrate/20210225152418_remove_index_on_task_name.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class RemoveIndexOnTaskName < ActiveRecord::Migration[6.1]
+class RemoveIndexOnTaskName < ActiveRecord::Migration[6.0]
   def up
     change_table(:maintenance_tasks_runs) do |t|
       t.remove_index(:task_name)


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/368

We have `">= 6.0"` set as the version requirement for `activerecord` in our gemspec, but since we've upgraded Rails to `6.1`, any migrations we generate are now versioned as `[6.1]`. This leads to incompatibilities with apps that are using `6.0`. 

Any migrations we generate moving forward should not exceed the minimum accepted ActiveRecord version as set by our gem specification.