### PR TITLE
[WIP] Value-based pagination

### DIFF
--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -20,7 +20,11 @@ module MaintenanceTasks
     def show
       @task = TaskData.find(params.fetch(:id))
       set_refresh if @task.last_run&.active?
-      @pagy, @previous_runs = pagy(@task.previous_runs)
+
+      cursor = params[:cursor].to_i if params[:cursor].present?
+      @page = Page.new( relation: @task.previous_runs, cursor: cursor)
+      # @previous_runs = @task.previous_runs.where('id < ?', @cursor).limit(20)
+      # @pagy, @previous_runs = pagy(@task.previous_runs)
     end
 
     # Runs a given Task and redirects to the Task page.

--- a/app/models/maintenance_tasks/page.rb
+++ b/app/models/maintenance_tasks/page.rb
@@ -1,0 +1,30 @@
+module MaintenanceTasks
+  class Page
+    RECORD_LIMIT = 20
+
+    def initialize(relation:, cursor:)
+      @relation = relation
+      @cursor = cursor || relation.first.id
+    end
+
+    def records
+      @records ||= @relation.where('id < ?', @cursor).limit(RECORD_LIMIT)
+    end
+
+    def next_cursor
+      @cursor - RECORD_LIMIT
+    end
+
+    def previous_cursor
+      @cursor + RECORD_LIMIT
+    end
+
+    def first_page?
+      @cursor == @relation.first.id
+    end
+
+    def last_page?
+      @relation.last == records.last
+    end
+  end
+end

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -41,12 +41,12 @@
   <pre><code><%= highlight_code(code) %></code></pre>
 <% end %>
 
-<% if @previous_runs.present? %>
+<% if @page.records.any? %>
   <hr/>
 
   <h4 class="title is-4">Previous Runs</h4>
 
-  <%= render @previous_runs %>
-
-  <%= pagination(@pagy) %>
+  <%= render @page.records %>
+  <%= link_to "Previous page", task_path(@task, cursor: @page.previous_cursor) unless @page.first_page? %>
+  <%= link_to "Next page", task_path(@task, cursor: @page.next_cursor) unless @page.last_page? %>
 <% end %>


### PR DESCRIPTION
Here's a proof of concept for doing value-based pagination ourselves. Not sure how general we want it to be. Right now it assumes that:
- `id` is used for the cursor
- the relation is ordered by `id: :desc` (our `runs` are actually ordered by `created_at: :desc`, we'll have to think about what to do here... Since id is auto-incrementing these mean essentially the same thing, but using `created_at` as our cursor is tricky since there is no uniqueness clause on this column right now)
- the relation is already ordered when it is passed to the `Page` initializer

We could make this customizable by allowing the column / columns for the cursor to be specified, and the direction of the relation to be specified, but not sure if this will be reused beyond showing runs. I feel like at that point we also have to start validating whether the column has a unique order, ensuring the relation is not already ordered before it is passed in OR checking that the order matches what is specified, etc... Not sure it's worth the effort.

Let me know what you think.