### PR TITLE
Handle no run when rescuing errors in TaskJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,12 +339,15 @@ end
 
 The error handler should be a lambda that accepts three arguments:
 
-* `error`: The object containing the exception that was raised.
+* `error`: The exception that was raised.
 * `task_context`: A hash with additional information about the Task and the
   error:
   * `task_name`: The name of the Task that errored
   * `started_at`: The time the Task started
   * `ended_at`: The time the Task errored
+  Note that `task_context` may be empty if the Task produced an error before any
+  context could be gathered (for example, if deserializing the job to process
+  your Task failed).
 * `errored_element`: The element, if any, that was being processed when the
   Task raised an exception. If you would like to pass this object to your
   exception monitoring service, make sure you **sanitize the object** to avoid

--- a/app/jobs/maintenance_tasks/task_job.rb
+++ b/app/jobs/maintenance_tasks/task_job.rb
@@ -122,13 +122,18 @@ module MaintenanceTasks
 
     def on_error(error)
       @ticker.persist if defined?(@ticker)
-      @run.persist_error(error)
 
-      task_context = {
-        task_name: @run.task_name,
-        started_at: @run.started_at,
-        ended_at: @run.ended_at,
-      }
+      if defined?(@run)
+        @run.persist_error(error)
+
+        task_context = {
+          task_name: @run.task_name,
+          started_at: @run.started_at,
+          ended_at: @run.ended_at,
+        }
+      else
+        task_context = {}
+      end
       errored_element = @errored_element if defined?(@errored_element)
       MaintenanceTasks.error_handler.call(error, task_context, errored_element)
     end


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/374

Errors in a Task can occur _before_ the `before_perform` callback runs (ie. before `@run`) is set. The main scenario to be concerned about here is if deserializing the run fails (in the Partners app, this happened because the connection to the MySQL server was lost when attempting to deserialize). Another case to consider is that users might have a custom Job with a callback that raises for some reason, prior to our `TaskJob#before_perform` callback happening.

Right now, `on_error` blows up when `@run` is not defined. This leads to unintended consequences - namely, job retries happening that we are not in control of. The upside is that it makes the framework somewhat "resilient" (ie. the job might retry and succeed, leading the Task to continue running successfully), but this actually ends up being problematic because we can't determine exactly what will happen, and it might lead to the `run` getting into a state that messes up the whole system.

We should solve this by only calling methods on `@run` if it's defined. Otherwise, we can still call the error handler, but do so with an empty `task_context` hash.

I thought about checking `if defined?(@run) && @run`, but I'm pretty sure `@run` has to be present if it's defined since we control enqueuing `TaskJob` in the `Runner`. (So either we fail to deserialize properly and that blows up, or we set `@run` to a valid object. Since we're the only ones who enqueue this job via `Runner#enqueue`, I don't think this could ever get set to nil, it can only be undefined)
