### PR TITLE
Make progress information visible in the info card

### DIFF
--- a/app/helpers/maintenance_tasks/tasks_helper.rb
+++ b/app/helpers/maintenance_tasks/tasks_helper.rb
@@ -49,8 +49,8 @@ module MaintenanceTasks
         max: progress.max,
         class: ["progress"] + STATUS_COLOURS.fetch(run.status)
       )
-      progress_text = tag.i(progress.text)
-      tag.div(progress_bar.concat(progress_text), class: "block")
+      progress_text = tag.p(tag.i(progress.text))
+      tag.div(progress_bar + progress_text, class: "block")
     end
 
     # Renders a span with a Run's status, with the corresponding tag class

--- a/app/helpers/maintenance_tasks/tasks_helper.rb
+++ b/app/helpers/maintenance_tasks/tasks_helper.rb
@@ -44,12 +44,13 @@ module MaintenanceTasks
 
       progress = Progress.new(run)
 
-      tag.progress(
+      progress_bar = tag.progress(
         value: progress.value,
         max: progress.max,
-        title: progress.title,
         class: ["progress"] + STATUS_COLOURS.fetch(run.status)
       )
+      progress_text = tag.i(progress.text)
+      tag.div(progress_bar.concat(progress_text), class: "block")
     end
 
     # Renders a span with a Run's status, with the corresponding tag class

--- a/app/models/maintenance_tasks/progress.rb
+++ b/app/models/maintenance_tasks/progress.rb
@@ -4,6 +4,7 @@ module MaintenanceTasks
   # This class generates progress information about a Run.
   class Progress
     include ActiveSupport::NumberHelper
+    include ActionView::Helpers::TextHelper
 
     # Sets the Progress initial state with a Run.
     #
@@ -50,13 +51,13 @@ module MaintenanceTasks
       count = @run.tick_count
       total = @run.tick_total
       if !total?
-        "Processed #{ticks_in_words(count)}."
+        "Processed #{pluralize(count, 'item')}."
       elsif over_total?
-        "Processed #{ticks_in_words(count)} (expected #{total})."
+        "Processed #{pluralize(count, 'item')} (expected #{total})."
       else
         percentage = 100.0 * count / total
 
-        "Processed #{count} out of #{ticks_in_words(total)} "\
+        "Processed #{count} out of #{pluralize(total, 'item')} "\
           "(#{number_to_percentage(percentage, precision: 0)})."
       end
     end
@@ -73,10 +74,6 @@ module MaintenanceTasks
 
     def over_total?
       @run.tick_count > @run.tick_total
-    end
-
-    def ticks_in_words(amount, unit = 'item')
-      "#{amount} #{unit.pluralize(amount)}"
     end
   end
 end

--- a/app/models/maintenance_tasks/progress.rb
+++ b/app/models/maintenance_tasks/progress.rb
@@ -41,22 +41,23 @@ module MaintenanceTasks
       estimatable? ? @run.tick_total : @run.tick_count
     end
 
-    # The title for the progress information. This is a text that describes the
-    # progress of the Run so far. It includes the percentage that is done out of
-    # the maximum, if an estimate is possible.
+    # The text containing progress information. This describes the progress of
+    # the Run so far. It includes the percentage done out of the maximum, if an
+    # estimate is possible.
     #
-    # @return [String] the title for the Run progress.
-    def title
+    # @return [String] the text for the Run progress.
+    def text
+      count = @run.tick_count
+      total = @run.tick_total
       if !total?
-        "Processed #{@run.tick_count} #{'item'.pluralize(@run.tick_count)}."
+        "Processed #{ticks_in_words(count)}."
       elsif over_total?
-        "Processed #{@run.tick_count} #{'item'.pluralize(@run.tick_count)} " \
-          "(expected #{@run.tick_total})."
+        "Processed #{ticks_in_words(count)} (expected #{total})."
       else
-        percentage = 100.0 * @run.tick_count / @run.tick_total
+        percentage = 100.0 * count / total
 
-        "Processed #{@run.tick_count} out of #{@run.tick_total} "\
-          "(#{number_to_percentage(percentage, precision: 0)})"
+        "Processed #{count} out of #{ticks_in_words(total)} "\
+          "(#{number_to_percentage(percentage, precision: 0)})."
       end
     end
 
@@ -72,6 +73,10 @@ module MaintenanceTasks
 
     def over_total?
       @run.tick_count > @run.tick_total
+    end
+
+    def ticks_in_words(amount, unit = 'item')
+      "#{amount} #{unit.pluralize(amount)}"
     end
   end
 end

--- a/app/views/maintenance_tasks/runs/info/_running.html.erb
+++ b/app/views/maintenance_tasks/runs/info/_running.html.erb
@@ -1,7 +1,5 @@
 <p>
   <% if run.estimated_completion_time %>
     <%= estimated_time_to_completion(run).capitalize %> remaining.
-  <% else %>
-    Processed <%= pluralize run.tick_count, 'item' %> so far.
   <% end %>
 </p>

--- a/test/helpers/maintenance_tasks/tasks_helper_test.rb
+++ b/test/helpers/maintenance_tasks/tasks_helper_test.rb
@@ -20,15 +20,15 @@ module MaintenanceTasks
       assert_equal expected_trace, format_backtrace(backtrace)
     end
 
-    test "#progress renders a <progress> when Run has started" do
+    test "#progress returns a <div> with a <progress> and progress text when Run has started" do
       @run.started_at = Time.now
 
       Progress.expects(:new).with(@run).returns(
-        mock(value: 42, max: 84, title: "Almost there!")
+        mock(value: 42, max: 84, text: "Almost there!")
       )
 
-      expected = '<progress value="42" max="84" title="Almost there!" '\
-        'class="progress is-primary is-light"></progress>'
+      expected = '<div class="block"><progress value="42" max="84" class='\
+        '"progress is-primary is-light"></progress><i>Almost there!</i></div>'
       assert_equal expected, progress(@run)
     end
 
@@ -36,13 +36,14 @@ module MaintenanceTasks
       assert_nil progress(@run)
     end
 
-    test "#progress returns a <progress> with no value when the Progress value is nil" do
+    test "#progress returns a a <div> with a <progress> with no value when the Progress value is nil" do
       @run.started_at = Time.now
       Progress.expects(:new).with(@run).returns(
-        mock(value: nil, max: 84, title: "Almost there!")
+        mock(value: nil, max: 84, text: "Almost there!")
       )
-      expected = '<progress max="84" title="Almost there!" '\
-        'class="progress is-primary is-light"></progress>'
+
+      expected = '<div class="block"><progress max="84" class='\
+        '"progress is-primary is-light"></progress><i>Almost there!</i></div>'
       assert_equal expected, progress(@run)
     end
 

--- a/test/helpers/maintenance_tasks/tasks_helper_test.rb
+++ b/test/helpers/maintenance_tasks/tasks_helper_test.rb
@@ -27,8 +27,9 @@ module MaintenanceTasks
         mock(value: 42, max: 84, text: "Almost there!")
       )
 
-      expected = '<div class="block"><progress value="42" max="84" class='\
-        '"progress is-primary is-light"></progress><i>Almost there!</i></div>'
+      expected = '<div class="block"><progress value="42" max="84" '\
+        'class="progress is-primary is-light"></progress>'\
+        "<p><i>Almost there!</i></p></div>"
       assert_equal expected, progress(@run)
     end
 
@@ -42,8 +43,9 @@ module MaintenanceTasks
         mock(value: nil, max: 84, text: "Almost there!")
       )
 
-      expected = '<div class="block"><progress max="84" class='\
-        '"progress is-primary is-light"></progress><i>Almost there!</i></div>'
+      expected = '<div class="block"><progress max="84" '\
+        'class="progress is-primary is-light"></progress>'\
+        "<p><i>Almost there!</i></p></div>"
       assert_equal expected, progress(@run)
     end
 

--- a/test/models/maintenance_tasks/progress_test.rb
+++ b/test/models/maintenance_tasks/progress_test.rb
@@ -47,24 +47,24 @@ module MaintenanceTasks
       assert_equal 8, @progress.max
     end
 
-    test "#title returns a description with tick count, tick total, and percentage" do
-      assert_equal "Processed 4 out of 7 (57%)", @progress.title
+    test "#text returns a description with tick count, tick total, and percentage" do
+      assert_equal "Processed 4 out of 7 items (57%).", @progress.text
     end
 
-    test "#title returns a description with tick count when tick total is not present" do
+    test "#text returns a description with tick count when tick total is not present" do
       @run.tick_total = nil
-      assert_equal "Processed 4 items.", @progress.title
+      assert_equal "Processed 4 items.", @progress.text
     end
 
-    test "#title returns a description with tick count and tick total when tick count is greater than its tick total" do
+    test "#text returns a description with tick count and tick total when tick count is greater than its tick total" do
       @run.tick_count = 8
-      assert_equal "Processed 8 items (expected 7).", @progress.title
+      assert_equal "Processed 8 items (expected 7).", @progress.text
     end
 
-    test "#title pluralizes the description according to the tick count" do
+    test "#text pluralizes the description according to the tick count" do
       @run.tick_count = 1
       @run.tick_total = nil
-      assert_equal "Processed 1 item.", @progress.title
+      assert_equal "Processed 1 item.", @progress.text
     end
   end
 end


### PR DESCRIPTION
Having the elapsed ticks / total ticks hidden away in the title attribute of the progress bar is not very discoverable for users. For long-running tasks where progress is slow and not very obvious by the progress bar, it helps to see the tick count to have confidence that the Task is still progressing.

I've moved the progress info out of the `title` attribute of the `progress` element, and into a span underneath the progress bar. Changes are as follows:
- Renamed `Progress#title` to `Progress#text` since it's no longer really a title
- Cleaned up `Progress#text` a bit, and made the returned string more consistent (notably `Processed 10 out of 10 (100%)` => `Processed 10 out of 10 items (100%).`
- Changed `TasksHelper#progress` to return a div wrapping both the progress element and a span containing the progress text. Open to styling options on this if we're not happy with it, I went with having the text in italics for now.

Samples from Tophat:

![Screen Shot 2021-03-19 at 8 56 21 AM](https://user-images.githubusercontent.com/22918438/111788349-5e177680-8896-11eb-8534-0e11b1338bdb.png)
![Screen Shot 2021-03-19 at 8 56 35 AM](https://user-images.githubusercontent.com/22918438/111788353-5eb00d00-8896-11eb-85c5-c34927738936.png)
![Screen Shot 2021-03-19 at 8 56 49 AM](https://user-images.githubusercontent.com/22918438/111788356-5eb00d00-8896-11eb-9e59-d919d319bd84.png)
![Screen Shot 2021-03-19 at 8 57 01 AM](https://user-images.githubusercontent.com/22918438/111788359-5f48a380-8896-11eb-8a9c-9160e9b1149e.png)
![Screen Shot 2021-03-19 at 8 58 52 AM](https://user-images.githubusercontent.com/22918438/111788361-5f48a380-8896-11eb-93cd-3e9170605b1d.png)
