### PR TITLE
Bump gem to v1.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    maintenance_tasks (1.1.2)
+    maintenance_tasks (1.2.0)
       actionpack (>= 6.0)
       activejob (>= 6.0)
       activerecord (>= 6.0)

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "maintenance_tasks"
-  spec.version = "1.1.2"
+  spec.version = "1.2.0"
   spec.author = "Shopify Engineering"
   spec.email = "gems@shopify.com"
   spec.homepage = "https://github.com/Shopify/maintenance_tasks"


### PR DESCRIPTION
Draft release here: https://github.com/Shopify/maintenance_tasks/releases/edit/untagged-799da69791c7b7acc355

I decided to bump us up to v1.2.0 rather than v1.1.3, since we had a couple minor changes that were not strictly bug fixes.