### PR TITLE
Maintain backwards compatibility when using #has_one_attached

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -48,7 +48,12 @@ module MaintenanceTasks
 
     validates_with RunStatusValidator, on: :update
 
-    has_one_attached :csv_file, service: MaintenanceTasks.active_storage_service
+    if MaintenanceTasks.active_storage_service.present?
+      has_one_attached :csv_file,
+        service: MaintenanceTasks.active_storage_service
+    else
+      has_one_attached :csv_file
+    end
 
     # Sets the run status to enqueued, making sure the transition is validated
     # in case it's already enqueued.


### PR DESCRIPTION
`v1.2.0` is broken for all Rails versions < 6.1.0 due to `has_one_attached: unknown keyword: service (ArgumentError)`, introduced [in this PR](https://github.com/Shopify/maintenance_tasks/pull/372).

~~Couldn't think of a better way to patch this and preserve functionality for Rails < 6.1.0 while allowing service configuration for Rails 6.1+ apps than checking the kwargs on the method and either passing in a service or not 😅  Let me know if you can think of a better way!~~

Opting instead to check for the presence of the `MaintenanceTasks.active_storage_service` config instead to check if we should specify the `service` kwarg, rather than doing parameter introspection.

I think we may also want to expand our test suite to test against a dummy app that use Rails 6.0, and then Rails 6.1 to make sure we catch things like this moving forward.

# 🎩 
- Change the dummy to use Rails 6.0
- Without these changes, `has_one_attached: unknown keyword: service (ArgumentError)` should be raised
- With these changes, ActiveStorage should be fine
- Moving back to Rails 6.1, these changes should be fine