### PR TITLE
Make Active Storage optional

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -43,6 +43,7 @@ module MaintenanceTasks
 
     # Ensure ActiveStorage is in use before preloading the attachments
     scope :with_attached_csv, -> do
+      return unless defined?(ActiveStorage)
       with_attached_csv_file if ActiveStorage::Attachment.table_exists?
     end
 
@@ -51,7 +52,7 @@ module MaintenanceTasks
     if MaintenanceTasks.active_storage_service.present?
       has_one_attached :csv_file,
         service: MaintenanceTasks.active_storage_service
-    else
+    elsif respond_to?(:has_one_attached)
       has_one_attached :csv_file
     end
 
@@ -211,6 +212,7 @@ module MaintenanceTasks
     #
     # @return [ActiveStorage::Attached::One] the attached CSV file
     def csv_file
+      return unless defined?(ActiveStorage)
       return unless ActiveStorage::Attachment.table_exists?
       super
     end


### PR DESCRIPTION
This allows loading the gem and running regular Tasks when `active_storage/engine` is not required in `config/application.rb`.

Not having required `active_storage/engine` will have the same result as having it required but not configured. An error is raised when a CSV file is uploaded, but no earlier.

This is handled in the README so I'm not sure we want to do more about this.