### PR TITLE
Raise early when Active Storage is not setup

### DIFF
--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -38,6 +38,10 @@ module MaintenanceTasks
       # An input to upload a CSV will be added in the form to start a Run. The
       # collection and count method are implemented.
       def csv_collection
+        if !defined?(ActiveStorage) || !ActiveStorage::Attachment.table_exists?
+          raise NotImplementedError, "Active Storage needs to be installed\n"\
+            "To resolve this issue run: bin/rails active_storage:install"
+        end
         include(CsvCollection)
       end
 


### PR DESCRIPTION
Instead of waiting until a CSV file is uploaded, this raises an exception early when a CSV Task is defined by calling `csv_collection` and Active Storage is not loaded or its tables created.

I reused part of the message that Rails emits when a file is attached and one of the Active Storage tables does not exist.

<img width="1006" alt="image" src="https://user-images.githubusercontent.com/3535/114732957-f1668f00-9d10-11eb-82fd-daae65280ae8.png">

No tests because we load Active Storage in the dummy app, and I'm not sure it's worth adding a very slow test creating an app.

🎩 To tophat:

```sh-session
$ cd
$ rails new my_app --skip-active-storage && cd my_app
$ echo "gem 'maintenance_tasks', path: '../src/github.com/Shopify/maintenance_tasks'" >> Gemfile
$ bundle
$ rails g maintenance_tasks:install
$ rails g maintenance_tasks:task my_csv_task --csv
$ rails s
# visit http://127.0.0.1:3000/maintenance_tasks/
```