### PR TITLE
Release 1.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    maintenance_tasks (1.2.1)
+    maintenance_tasks (1.2.2)
       actionpack (>= 6.0)
       activejob (>= 6.0)
       activerecord (>= 6.0)

--- a/gemfiles/rails_6_0.gemfile.lock
+++ b/gemfiles/rails_6_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    maintenance_tasks (1.2.1)
+    maintenance_tasks (1.2.2)
       actionpack (>= 6.0)
       activejob (>= 6.0)
       activerecord (>= 6.0)

--- a/gemfiles/rails_edge.gemfile.lock
+++ b/gemfiles/rails_edge.gemfile.lock
@@ -86,7 +86,7 @@ GIT
 PATH
   remote: ..
   specs:
-    maintenance_tasks (1.2.1)
+    maintenance_tasks (1.2.2)
       actionpack (>= 6.0)
       activejob (>= 6.0)
       activerecord (>= 6.0)

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "maintenance_tasks"
-  spec.version = "1.2.1"
+  spec.version = "1.2.2"
   spec.author = "Shopify Engineering"
   spec.email = "gems@shopify.com"
   spec.homepage = "https://github.com/Shopify/maintenance_tasks"

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |spec|
   spec.email = "gems@shopify.com"
   spec.homepage = "https://github.com/Shopify/maintenance_tasks"
   spec.summary = "A Rails engine for queuing and managing maintenance tasks"
+  spec.license = "MIT"
 
   spec.metadata = {
     "source_code_uri" =>
@@ -14,7 +15,7 @@ Gem::Specification.new do |spec|
     "allowed_push_host" => "https://rubygems.org",
   }
 
-  spec.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
+  spec.files = Dir["{app,config,db,lib}/**/*", "LICENSE.md", "README.md"]
   spec.bindir = "exe"
   spec.executables = ["maintenance_tasks"]
 


### PR DESCRIPTION
I noticed we weren't shipping the license file which I think we are supposed to. The gem wasn't specified as MIT-licensed either.

And a bump for making Active Storage optional.