### PR TITLE
Tweak workflow labelling and triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Ruby
+name: CI
 
 on: [push, pull_request]
 
@@ -6,7 +6,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
+    name: Ruby ${{ matrix.ruby }} / ${{ matrix.gemfile }}
     strategy:
       matrix:
         gemfile: [Gemfile, gemfiles/rails_6_0.gemfile, gemfiles/rails_edge.gemfile]


### PR DESCRIPTION
This is almost identical to the change I made in https://github.com/Shopify/job-iteration/pull/74.

- Only run on push. Running on Pull Request seems redundant, since all PRs would include a push.
- Rename the workflow from "Ruby" to "CI" to avoid redundant prefix
- Append Gemfile from matrix to job name, so they are distinguishable

#### :warning: Before Merging

- [x] Squash commits and update commit messages