### PR TITLE
Enhance usability of task_spec generator

### DIFF
--- a/lib/generators/maintenance_tasks/templates/task_spec.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/task_spec.rb.tt
@@ -4,11 +4,13 @@ require 'rails_helper'
 module <%= tasks_module %>
 <% module_namespacing do -%>
   RSpec.describe <%= class_name %>Task do
-    # describe '#process' do
-      # it 'performs a task iteration' do
-        # <%= tasks_module %>::<%= class_name %>Task.process(element)
-      # end
-    # end
+    describe "#process" do
+      subject(:process) { described_class.process(element) }
+      let(:element) { 
+        # Object to be processed in a single iteration of this task
+      }
+      pending "add some examples to (or delete) #{__FILE__}"
+    end
   end
 <% end -%>
 end


### PR DESCRIPTION
Just a quick fix, we use the task_spec generator a lot and it is handy that it generates a few lines to get you started, so I thought we might as well be able to use those lines in our code rather than needing to delete them.

#### Problem
The current generator generates something like
```ruby
# frozen_string_literal: true
require 'rails_helper'

module Maintenance
  RSpec.describe SomeMaintenanceTask do
    # describe '#process' do
      # it 'performs a task iteration' do
        # Maintenance::SomeMaintenanceTask.process(element)
      # end
    # end
  end
end
```
If we're generating this starter code, I think we might as well generate it in a somewhat usable manner, rather than generating it for it to be deleted later 

#### Changes
This is a minor change but I just rearranged the .process and cleaned it up a bit so it matches up with the [RSpec/DescribedClass convention](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribedClass). The generator will now generate something like this
```ruby
# frozen_string_literal: true
require 'rails_helper'

module Maintenance
  RSpec.describe SomeMaintenanceTask do
    # describe '#process' do
      # subject(:process) { described_class.process(element) }
      # it 'performs a task iteration' do
        # expect something here
      # end
    # end
  end
end
```
This makes the generated code somewhat more usable and I believe it is more helpful. Let me know what you guys think! maybe this is all unnecessary..
