### PR TITLE
Re-enable Rubocop documentation rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,11 +15,13 @@ Layout/LineLength:
   Max: 80
 
 Style/Documentation:
+  Enabled: true
   Include:
     - app/**/*.rb
     - lib/**/*.rb
 
 Style/DocumentationMethod:
+  Enabled: true
   Include:
     - app/**/*.rb
     - lib/**/*.rb


### PR DESCRIPTION
Since rubocop-shopify was using `DisabledByDefault`, simply adding the rules in our config enabled them, like the documentation explains:

> All cops are then disabled by default. Only cops appearing in user configuration files are enabled. `Enabled: true` does not have to be set for cops in user configuration. They will be enabled anyway.

But now rubocop-shopify moved to marking the specific rules as disabled instead, which does not enable them automatically when they are used.

So when I updated to 2.1.0 in #397, we inadvertently disabled those two.