### PR TITLE
Introduce Mechanism for Throttling

### DIFF
--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -33,7 +33,7 @@ module MaintenanceTasks
       cursor ||= @run.cursor
       collection = @task.collection
 
-      case collection
+      collection_enum = case collection
       when ActiveRecord::Relation
         enumerator_builder.active_record_on_records(collection, cursor: cursor)
       when Array
@@ -43,6 +43,10 @@ module MaintenanceTasks
       else
         raise ArgumentError, "#{@task.class.name}#collection must be either "\
           "an Active Record Relation, Array, or CSV."
+      end
+
+      @task.throttle_conditions.reduce(collection_enum) do |enum, condition|
+        enumerator_builder.build_throttle_enumerator(enum, **condition)
       end
     end
 

--- a/test/dummy/app/tasks/maintenance/update_posts_throttled_task.rb
+++ b/test/dummy/app/tasks/maintenance/update_posts_throttled_task.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module Maintenance
+  class UpdatePostsThrottledTask < MaintenanceTasks::Task
+    class << self
+      attr_accessor :throttle
+    end
+
+    throttle_on { throttle }
+
+    def collection
+      Post.all
+    end
+
+    def count
+      collection.count
+    end
+
+    def process(post)
+      post.update!(content: "New content added on #{Time.now.utc}")
+    end
+  end
+end

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -337,5 +337,23 @@ module MaintenanceTasks
     ensure
       MaintenanceTasks.error_handler = error_handler_before
     end
+
+    test ".perform_now throttles when running Task that uses throttle_on" do
+      Maintenance::UpdatePostsThrottledTask.throttle = true
+      run = Run.create!(task_name: "Maintenance::UpdatePostsThrottledTask")
+      TaskJob.perform_now(run)
+
+      assert_predicate run.reload, :interrupted?
+
+      Maintenance::UpdatePostsThrottledTask.throttle = false
+      Maintenance::UpdatePostsThrottledTask
+        .any_instance
+        .expects(:process)
+        .times(Post.count)
+
+      perform_enqueued_jobs
+
+      assert_predicate run.reload, :succeeded?
+    end
   end
 end

--- a/test/models/maintenance_tasks/task_data_test.rb
+++ b/test/models/maintenance_tasks/task_data_test.rb
@@ -27,6 +27,7 @@ module MaintenanceTasks
         "Maintenance::ImportPostsTask",
         "Maintenance::TestTask",
         "Maintenance::UpdatePostsTask",
+        "Maintenance::UpdatePostsThrottledTask",
       ]
       assert_equal expected, TaskData.available_tasks.map(&:name)
     end

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -23,6 +23,7 @@ module MaintenanceTasks
         "Maintenance::ErrorTask\nNew",
         "Maintenance::ImportPostsTask\nNew",
         "Maintenance::TestTask\nNew",
+        "Maintenance::UpdatePostsThrottledTask\nNew",
         "Completed Tasks",
         "Maintenance::UpdatePostsTask\nSucceeded",
       ]


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/298

I revisited adding throttling! I think adding a simple DSL like this optimizes for ease of use from a user's perspective:

```ruby
throttle_on -> { <condition> }, backoff: <backoff>
```

The PR is pretty simple - JobIteration's [Throttle Enumerator](https://github.com/Shopify/job-iteration/blob/4e4ed66c0c325d6e28ecddf84399f1b291ae8ae4/lib/job-iteration/throttle_enumerator.rb) does most of the work for us, so we just need to wrap the enumerator we build using the collection in a throttle enumerator Job Iteration constructs via [`#build_throttle_enumerator`](https://github.com/Shopify/job-iteration/blob/4e4ed66c0c325d6e28ecddf84399f1b291ae8ae4/lib/job-iteration/enumerator_builder.rb#L113)

As discussed in https://github.com/Shopify/maintenance_tasks/pull/330, storing `throttle_specs` as an array allows Tasks to define multiple throttle conditions, and to inherit throttle specs from superclasses / mixins without clobbering those conditions if the Task defines new ones. Does this approach still make sense?
