### PR TITLE
Support batch record collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,41 @@ end
 title,content
 My Title,Hello World!
 ```
+### Processing Batch Collections
+
+The Maintenance Tasks gem supports processing Active Records in batches. This
+can reduce the number of calls your Task makes to the database. Use `in_batches`
+to specify that your Task should process records in batches. The default batch
+size is 100, but a custom size can be specified.
+
+```ruby
+# app/tasks/maintenance/update_posts_in_batches_task.rb
+module Maintenance
+  class UpdatePostsInBatchesTask < MaintenanceTasks::Task
+    in_batches 50
+
+    def collection
+      Post.all
+    end
+
+    def count
+      collection.count
+    end
+
+    def process(batch_of_posts)
+      Post.where(id: batch_of_posts.map(&:id)).update_all(
+        content: "New content added on #{Time.now.utc}"
+      )    
+    end
+  end
+end
+```
+
+Ensure that you've implemented the following methods:
+* `collection`: return an Active Record Relation to be iterated over.
+* `process`: do the work of your Task on a _batch_ of records.
+* `count`: return the number of rows that will be iterated over (this should
+still be the number of records to be processed, not the number of batches).
 
 ### Considerations when writing Tasks
 

--- a/app/models/maintenance_tasks/ticker.rb
+++ b/app/models/maintenance_tasks/ticker.rb
@@ -28,11 +28,11 @@ module MaintenanceTasks
       @ticks_recorded = 0
     end
 
-    # Increments the tick count by one, and may persist the new value if the
-    # threshold duration has passed since initialization or the tick count was
-    # last persisted.
-    def tick
-      @ticks_recorded += 1
+    # Increments the tick count, which defaults to one. It may persist the new
+    # value if the threshold duration has passed since initialization or the
+    # tick count was last persisted.
+    def tick(increment = 1)
+      @ticks_recorded += increment
       persist if persist?
     end
 

--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -8,6 +8,8 @@ module MaintenanceTasks
     class NotFoundError < NameError; end
 
     class << self
+      attr_reader :batch_size
+
       # Finds a Task with the given name.
       #
       # @param name [String] the name of the Task to be found.
@@ -72,6 +74,14 @@ module MaintenanceTasks
         new.count
       end
 
+      # Make this a Task that processes batches.
+      #
+      # @param batch_size [Integer] optionally, a custom batch size can be
+      #   specified. Defaults to 100 if one is not provided.
+      def in_batches(batch_size = 100)
+        @batch_size = batch_size
+      end
+
       private
 
       def load_constants
@@ -109,6 +119,21 @@ module MaintenanceTasks
     #
     # @return [Integer, nil]
     def count
+    end
+
+    # The batch size for this Task instance, if any.
+    #
+    # @return [Integer, nil] the batch size for this Task instance, or nil if
+    #   the Task does not process batches.
+    def batch_size
+      self.class.batch_size
+    end
+
+    # Whether this Task instance processes batches.
+    #
+    # @return [Boolean] whether this Task instance processes batches.
+    def in_batches?
+      batch_size.present?
     end
   end
 end

--- a/test/dummy/app/tasks/maintenance/update_posts_in_batches_task.rb
+++ b/test/dummy/app/tasks/maintenance/update_posts_in_batches_task.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+module Maintenance
+  class UpdatePostsInBatchesTask < MaintenanceTasks::Task
+    in_batches 5
+
+    def collection
+      Post.all
+    end
+
+    def count
+      collection.count
+    end
+
+    def process(batch_of_posts)
+      Post.where(id: batch_of_posts.map(&:id)).update_all(
+        content: "New content added on #{Time.now.utc}"
+      )
+    end
+  end
+end

--- a/test/models/maintenance_tasks/task_data_test.rb
+++ b/test/models/maintenance_tasks/task_data_test.rb
@@ -26,6 +26,7 @@ module MaintenanceTasks
         "Maintenance::ErrorTask",
         "Maintenance::ImportPostsTask",
         "Maintenance::TestTask",
+        "Maintenance::UpdatePostsInBatchesTask",
         "Maintenance::UpdatePostsTask",
       ]
       assert_equal expected, TaskData.available_tasks.map(&:name)

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -23,6 +23,7 @@ module MaintenanceTasks
         "Maintenance::ErrorTask\nNew",
         "Maintenance::ImportPostsTask\nNew",
         "Maintenance::TestTask\nNew",
+        "Maintenance::UpdatePostsInBatchesTask\nNew",
         "Completed Tasks",
         "Maintenance::UpdatePostsTask\nSucceeded",
       ]

--- a/test/tasks/maintenance_tasks/task_test.rb
+++ b/test/tasks/maintenance_tasks/task_test.rb
@@ -10,6 +10,7 @@ module MaintenanceTasks
         "Maintenance::ErrorTask",
         "Maintenance::ImportPostsTask",
         "Maintenance::TestTask",
+        "Maintenance::UpdatePostsInBatchesTask",
         "Maintenance::UpdatePostsTask",
       ]
       assert_equal expected,


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/401

This PR allows users to specify batch collections via the following API:
```ruby
# app/tasks/maintenance/update_posts_in_batches_task.rb
module Maintenance
  class UpdatePostsInBatchesTask < MaintenanceTasks::Task
    in_batches 50

    def collection
      Post.all
    end

    def count
      collection.count
    end

    def process(batch_of_posts)
      Post.where(id: batch_of_posts.map(&:id)).update_all(content: "New content added on #{Time.now.utc}")    
    end
  end
end
```

## What are you trying to accomplish?
- Batch support has been requested by numerous users because it can make Tasks that need to do batch operations much more efficient
- I'm proposing a simple API that allows users to specify that their Task should process batches
- Batch size is 100 by default (to match [JobIteration's default batch_size](https://github.com/Shopify/job-iteration/blob/75657194442c9ebde3873d5702029fd3a7743b8a/lib/job-iteration/enumerator_builder.rb#L101)), but can be customized
- `#process` will accept a batch of records instead of a single record

## Approach Taken
- Users will call `in_batches` when defining their batch Task in order to denote it as a batch task
- This sets a class variable `@batch_size`, defining the batch size for the Task
- Define methods so we can retrieve whether a Task is `#in_batches?` and it's `#batch_size` at the instance level
- If a Task is in batches, use [Job Iteration's `#active_record_on_batches`](https://github.com/Shopify/job-iteration/blob/75657194442c9ebde3873d5702029fd3a7743b8a/lib/job-iteration/enumerator_builder.rb#L104-L111) method with the Task's batch size when building the enumerator in `TaskJob#build_enumerator`
- Tweaker `Ticker#tick` to take an increment, defaulting to 1.
- In `TaskJob#each_iteration`, I've tweaked the call to `#tick` to use `input.size`. **This makes it so that tick count is still based on the number of records, rather than the number of batches. I felt that having progress in terms of records processed made more sense than the number of batches processed. Does this make sense?**

## What about using `ActiveRecord::Batches::BatchEnumerator`?
- This is unfortunately not compatible with Job Iteration's [`EnumeratorBuilder#build_active_record_enumerator_on_records`](https://github.com/Shopify/job-iteration/blob/75657194442c9ebde3873d5702029fd3a7743b8a/lib/job-iteration/enumerator_builder.rb#L89-L96) because it explicitly [requires an `ActiveRecord::Relation`](https://github.com/Shopify/job-iteration/blob/75657194442c9ebde3873d5702029fd3a7743b8a/lib/job-iteration/enumerator_builder.rb#L131-L134)
- We should use the mechanism Job Iteration _actually_ provides for batch enumeration, which is `#active_record_on_batches`