### PR TITLE
Support Tasks with custom parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,41 @@ Tasks can define multiple throttle conditions. Throttle conditions are inherited
 by descendants, and new conditions will be appended without impacting existing
 conditions.
 
+### Custom Task Parameters
+
+Tasks may need additional information, supplied via parameters, to run.
+Parameters can be defined as Active Model Attributes in a Task, and then
+become accessible to any of Task's methods: `#collection`, `#count`, or
+`#process`.
+
+```ruby
+# app/tasks/maintenance/update_posts_via_params_task.rb
+module Maintenance
+  class UpdatePostsViaParamsTask < MaintenanceTasks::Task
+    attribute :updated_content, :string
+    validates :updated_content, presence: true
+
+    def collection
+      Post.all
+    end
+
+    def count
+      collection.count
+    end
+
+    def process(post)
+      post.update!(content: updated_content)
+    end
+  end
+end
+```
+
+Tasks can leverage Active Model Validations when defining parameters. Arguments
+supplied to a Task accepting parameters will be validated before the Task starts
+to run. Since arguments are specified in the user interface via text area
+inputs, it's important to check that they conform to the format your Task
+expects, and to sanitize any inputs if necessary.
+
 ### Considerations when writing Tasks
 
 MaintenanceTasks relies on the queue adapter configured for your application to

--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -27,7 +27,8 @@ module MaintenanceTasks
     def run
       task = Runner.run(
         name: params.fetch(:id),
-        csv_file: params[:csv_file]
+        csv_file: params[:csv_file],
+        arguments: task_arguments,
       )
       redirect_to(task_path(task))
     rescue ActiveRecord::RecordInvalid => error
@@ -37,6 +38,12 @@ module MaintenanceTasks
     end
 
     private
+
+    def task_arguments
+      return {} unless params[:task_arguments].present?
+      task_attributes = Task.named(params[:id]).attribute_names
+      params.require(:task_arguments).permit(*task_attributes).to_h
+    end
 
     def set_refresh
       @refresh = 3

--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -33,6 +33,9 @@ module MaintenanceTasks
       redirect_to(task_path(task))
     rescue ActiveRecord::RecordInvalid => error
       redirect_to(task_path(error.record.task_name), alert: error.message)
+    rescue ActiveRecord::ValueTooLong => error
+      task_name = params.fetch(:id)
+      redirect_to(task_path(task_name), alert: error.message)
     rescue Runner::EnqueuingError => error
       redirect_to(task_path(error.run.task_name), alert: error.message)
     end

--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -71,7 +71,7 @@ module MaintenanceTasks
 
     def before_perform
       @run = arguments.first
-      @task = Task.named(@run.task_name).new
+      @task = @run.task
       if @task.respond_to?(:csv_content=)
         @task.csv_content = @run.csv_file.download
       end

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -38,6 +38,7 @@ module MaintenanceTasks
     attr_readonly :task_name
 
     serialize :backtrace
+    serialize :arguments, JSON
 
     scope :active, -> { where(status: ACTIVE_STATUSES) }
 

--- a/app/models/maintenance_tasks/runner.rb
+++ b/app/models/maintenance_tasks/runner.rb
@@ -45,6 +45,8 @@ module MaintenanceTasks
     # @raise [EnqueuingError] if an error occurs while enqueuing the Run.
     # @raise [ActiveRecord::RecordInvalid] if validation errors occur while
     #   creating the Run.
+    # @raise [ActiveRecord::ValueTooLong] if the creation of the Run fails due
+    #   to a value being too long for the column type.
     def run(name:, csv_file: nil, arguments: {})
       run = Run.active.find_by(task_name: name) ||
         Run.new(task_name: name, arguments: arguments)

--- a/app/models/maintenance_tasks/runner.rb
+++ b/app/models/maintenance_tasks/runner.rb
@@ -37,14 +37,17 @@ module MaintenanceTasks
     #   for the Task to iterate over when running, in the form of an attachable
     #   (see https://edgeapi.rubyonrails.org/classes/ActiveStorage/Attached/One.html#method-i-attach).
     #   Value is nil if the Task does not use CSV iteration.
+    # @param arguments [Hash] the arguments to persist to the Run and to make
+    #   accessible to the Task.
     #
     # @return [Task] the Task that was run.
     #
     # @raise [EnqueuingError] if an error occurs while enqueuing the Run.
     # @raise [ActiveRecord::RecordInvalid] if validation errors occur while
     #   creating the Run.
-    def run(name:, csv_file: nil)
-      run = Run.active.find_by(task_name: name) || Run.new(task_name: name)
+    def run(name:, csv_file: nil, arguments: {})
+      run = Run.active.find_by(task_name: name) ||
+        Run.new(task_name: name, arguments: arguments)
       run.csv_file.attach(csv_file) if csv_file
 
       run.enqueued!

--- a/app/models/maintenance_tasks/task_data.rb
+++ b/app/models/maintenance_tasks/task_data.rb
@@ -132,6 +132,15 @@ module MaintenanceTasks
       !deleted? && Task.named(name) < CsvCollection
     end
 
+    # @return [Array<String>] the names of parameters the Task accepts.
+    def parameter_names
+      if deleted?
+        []
+      else
+        Task.named(name).attribute_names
+      end
+    end
+
     private
 
     def runs

--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -3,6 +3,9 @@ module MaintenanceTasks
   # Base class that is inherited by the host application's task classes.
   class Task
     extend ActiveSupport::DescendantsTracker
+    include ActiveModel::Attributes
+    include ActiveModel::AttributeAssignment
+    include ActiveModel::Validations
 
     class NotFoundError < NameError; end
 

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -16,6 +16,16 @@
           <%= form.file_field :csv_file %>
         </div>
       <% end %>
+      <% if @task.parameter_names.any? %>
+        <div class="block">
+          <%= form.fields_for :task_arguments do |ff| %>
+            <% @task.parameter_names.each do |parameter| %>
+              <%= ff.label parameter, "#{parameter}: ", class: "label" %>
+              <%= ff.text_area parameter, class: "textarea" %>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
       <div class="block">
         <%= form.submit 'Run', class: "button is-success", disabled: @task.deleted? %>
       </div>

--- a/db/migrate/20210517131953_add_arguments_to_maintenance_tasks_runs.rb
+++ b/db/migrate/20210517131953_add_arguments_to_maintenance_tasks_runs.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddArgumentsToMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
+  def change
+    add_column(:maintenance_tasks_runs, :arguments, :text)
+  end
+end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -20,11 +20,13 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   setup do
     travel_to Time.zone.local(2020, 1, 9, 9, 41, 44)
     Maintenance::UpdatePostsTask.fast_task = false
+    Maintenance::ParamsTask.fast_task = false
   end
 
   teardown do
     assert_empty page.driver.browser.manage.logs.get(:browser)
     Maintenance::UpdatePostsTask.fast_task = true
+    Maintenance::ParamsTask.fast_task = true
     FileUtils.rm_rf("test/dummy/tmp/downloads")
   end
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -19,14 +19,10 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   setup do
     travel_to Time.zone.local(2020, 1, 9, 9, 41, 44)
-    Maintenance::UpdatePostsTask.fast_task = false
-    Maintenance::ParamsTask.fast_task = false
   end
 
   teardown do
     assert_empty page.driver.browser.manage.logs.get(:browser)
-    Maintenance::UpdatePostsTask.fast_task = true
-    Maintenance::ParamsTask.fast_task = true
     FileUtils.rm_rf("test/dummy/tmp/downloads")
   end
 end

--- a/test/dummy/app/tasks/maintenance/params_task.rb
+++ b/test/dummy/app/tasks/maintenance/params_task.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+module Maintenance
+  class ParamsTask < MaintenanceTasks::Task
+    attribute :post_ids, :string
+
+    validates :post_ids,
+      presence: true,
+      format: { with: /\A(\s?\d+(,\s?\d+\s?)*)\z/, allow_blank: true }
+
+    class << self
+      attr_accessor :fast_task
+    end
+
+    def collection
+      Post.where(id: post_ids_array)
+    end
+
+    def count
+      collection.count
+    end
+
+    def process(post)
+      sleep(1) unless self.class.fast_task
+
+      post.update!(content: "New content added on #{Time.now.utc}")
+    end
+
+    private
+
+    def post_ids_array
+      post_ids.split(",")
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_25_152418) do
+ActiveRecord::Schema.define(version: 2021_05_17_131953) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -55,7 +55,8 @@ ActiveRecord::Schema.define(version: 2021_02_25_152418) do
     t.text "backtrace"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["task_name", "created_at"], name: "index_maintenance_tasks_runs_on_task_name_and_created_at", order: { created_at: :desc }
+    t.text "arguments"
+    t.index ["task_name", "created_at"], name: "index_maintenance_tasks_runs_on_task_name_and_created_at"
   end
 
   create_table "posts", force: :cascade do |t|

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -355,5 +355,18 @@ module MaintenanceTasks
 
       assert_predicate run.reload, :succeeded?
     end
+
+    test ".perform_now makes arguments supplied for Task parameters available" do
+      post = Post.last
+      Maintenance::ParamsTask.any_instance.expects(:process).once.with(post)
+
+      run = Run.create!(
+        task_name: "Maintenance::ParamsTask",
+        arguments: { post_ids: post.id.to_s }
+      )
+      TaskJob.perform_now(run)
+
+      assert_predicate run.reload, :succeeded?
+    end
   end
 end

--- a/test/models/maintenance_tasks/runner_test.rb
+++ b/test/models/maintenance_tasks/runner_test.rb
@@ -83,6 +83,16 @@ module MaintenanceTasks
       end
     end
 
+    test "#run raises ActiveRecord::ValueTooLong error if arguments input is too long" do
+      Run.any_instance.expects(:enqueued!).raises(ActiveRecord::ValueTooLong)
+      assert_raises(ActiveRecord::ValueTooLong) do
+        @runner.run(
+          name: "Maintenance::ParamsTask",
+          arguments: { post_ids: "123" }
+        )
+      end
+    end
+
     test "#run attaches CSV file to Run if one is provided" do
       @runner.run(name: "Maintenance::ImportPostsTask", csv_file: csv_io)
 

--- a/test/models/maintenance_tasks/task_data_test.rb
+++ b/test/models/maintenance_tasks/task_data_test.rb
@@ -25,6 +25,7 @@ module MaintenanceTasks
         "Maintenance::EnqueueErrorTask",
         "Maintenance::ErrorTask",
         "Maintenance::ImportPostsTask",
+        "Maintenance::ParamsTask",
         "Maintenance::TestTask",
         "Maintenance::UpdatePostsTask",
         "Maintenance::UpdatePostsThrottledTask",
@@ -142,6 +143,15 @@ module MaintenanceTasks
 
     test "#csv_task? returns false if the Task is deleted" do
       refute_predicate TaskData.new("Maintenance::DoesNotExist"), :csv_task?
+    end
+
+    test "#parameter_names returns list of parameter names for Tasks supporting parameters" do
+      assert_equal ["post_ids"],
+        TaskData.new("Maintenance::ParamsTask").parameter_names
+    end
+
+    test "#parameter_names returns empty list for deleted Tasks" do
+      assert_empty TaskData.new("Maintenance::DoesNotExist").parameter_names
     end
   end
 end

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -29,6 +29,34 @@ module MaintenanceTasks
       assert_no_button "Run"
     end
 
+    test "run a Task that accepts parameters" do
+      visit maintenance_tasks_path
+
+      click_on("Maintenance::ParamsTask")
+      post_id = Post.first.id
+      fill_in("_task_arguments_post_ids", with: post_id.to_s)
+
+      perform_enqueued_jobs do
+        click_on "Run"
+      end
+
+      assert_title "Maintenance::ParamsTask"
+      assert_text "Succeeded"
+      assert_text "Processed 1 out of 1 item (100%)."
+    end
+
+    test "errors for Task with invalid arguments shown" do
+      visit maintenance_tasks_path
+
+      click_on("Maintenance::ParamsTask")
+      fill_in("_task_arguments_post_ids", with: "xyz")
+      click_on "Run"
+
+      alert_text = "Validation failed: Arguments are invalid: :post_ids is "\
+        "invalid"
+      assert_text alert_text
+    end
+
     test "download the CSV attached to a run for a CSV Task" do
       visit(maintenance_tasks_path)
 

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -22,6 +22,7 @@ module MaintenanceTasks
         "Maintenance::EnqueueErrorTask\nNew",
         "Maintenance::ErrorTask\nNew",
         "Maintenance::ImportPostsTask\nNew",
+        "Maintenance::ParamsTask\nNew",
         "Maintenance::TestTask\nNew",
         "Maintenance::UpdatePostsThrottledTask\nNew",
         "Completed Tasks",

--- a/test/tasks/maintenance_tasks/task_test.rb
+++ b/test/tasks/maintenance_tasks/task_test.rb
@@ -9,6 +9,7 @@ module MaintenanceTasks
         "Maintenance::EnqueueErrorTask",
         "Maintenance::ErrorTask",
         "Maintenance::ImportPostsTask",
+        "Maintenance::ParamsTask",
         "Maintenance::TestTask",
         "Maintenance::UpdatePostsTask",
         "Maintenance::UpdatePostsThrottledTask",


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/406, https://github.com/Shopify/maintenance_tasks/issues/325

This PR introduces support for custom Task parameters by leveraging `ActiveModel` attributes & validations.

Task authors use `ActiveModel::Attributes` for their parameters, and can define their own validations to ensure any parameters that are passed from the UI conform to their expectations (ie. `Maintenance::ParamsTask` uses a presence validator and a regex to ensure that post ids is a comma-delimited list of integers).

## Approach taken
- `MaintenanceTasks::Task` includes relevant `ActiveModel` modules
- In the view, we render a text field for every parameter the Task supports
- These params are passed from controller => `Runner#run`. `MaintenanceTasks::Run` has a field for `parameters` now, and we pass the parameters to the constructor
- On run creation, we assign the parameters (as attributes) to a `Task` instance for the `run`, and then validate whether the attributes are valid. If they aren't, we take the errors and add them to the `run`, which gets propagated to the UI in the form of a flash alert.
- The `run` how has parameters persisted, and we've also set the parameters on the `Task` so that any of the methods in the `Task` (`#process`, `#collection`, `#count`) now have access to these attribute

## 🎩 
![Screen Shot 2021-05-13 at 3 13 38 PM](https://user-images.githubusercontent.com/22918438/118175206-cd749700-b3fd-11eb-9dd6-c45a28451c42.png)

![Screen Shot 2021-05-13 at 4 00 18 PM](https://user-images.githubusercontent.com/22918438/118180258-52fb4580-b404-11eb-9b3d-0e87c9304ec1.png)

- Go to http://127.0.0.1:3000/maintenance_tasks/tasks/Maintenance::ParamsTask
- Run it with `1,2,3` in the `Post ids` field
- Run it with an invalid string in the `Post ids` field
- Run it with no value in the `Post ids` field

## To Do
- [x] Documentation

Let me know what you think!