### PR TITLE
Fix schema for MySQL

### DIFF
--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -16,7 +16,7 @@ ActiveRecord::Schema.define(version: 2021_05_17_131953) do
     t.string "name", null: false
     t.string "record_type", null: false
     t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2021_05_17_131953) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end


### PR DESCRIPTION
SQLite dumps bigint columns as integer columns in the database schema, even if they should really be bigints for other adapters because they're the primary keys of other tables.

🎩 

```sh-session
$ bundle add mysql2
$ export DATABASE_URL=mysql2://root@localhost/maintenance_tasks_development
$ rails db:setup
```

This blows up on main with:
```
Created database 'maintenance_tasks_development'
rails aborted!
ActiveRecord::MismatchedForeignKey: Column `blob_id` on table `active_storage_attachments` does not match column `id` on `active_storage_blobs`, which has type `bigint`. To resolve this issue, change the type of the `blob_id` column on `active_storage_attachments` to be :bigint. (For example `t.bigint :blob_id`).
Original message: Mysql2::Error: Referencing column 'blob_id' and referenced column 'id' in foreign key constraint 'fk_rails_c3b3935057' are incompatible.
/Users/etienne/src/github.com/Shopify/maintenance_tasks/test/dummy/db/schema.rb:69:in `block in <top (required)>'
/Users/etienne/src/github.com/Shopify/maintenance_tasks/test/dummy/db/schema.rb:13:in `<top (required)>'

Caused by:
Mysql2::Error: Referencing column 'blob_id' and referenced column 'id' in foreign key constraint 'fk_rails_c3b3935057' are incompatible.
/Users/etienne/src/github.com/Shopify/maintenance_tasks/test/dummy/db/schema.rb:69:in `block in <top (required)>'
/Users/etienne/src/github.com/Shopify/maintenance_tasks/test/dummy/db/schema.rb:13:in `<top (required)>'
Tasks: TOP => db:setup => app:db:setup => app:db:schema:load
(See full trace by running task with --trace)
```

Passes on the branch!

