### PR TITLE
Yield the run in `Runner.run`

### DIFF
--- a/app/models/maintenance_tasks/runner.rb
+++ b/app/models/maintenance_tasks/runner.rb
@@ -54,6 +54,7 @@ module MaintenanceTasks
 
       run.enqueued!
       enqueue(run)
+      yield run if block_given?
       Task.named(name)
     end
 

--- a/test/models/maintenance_tasks/runner_test.rb
+++ b/test/models/maintenance_tasks/runner_test.rb
@@ -32,6 +32,20 @@ module MaintenanceTasks
       end
     end
 
+    # Yielding the run is undocumented and not supported in the Runner's API
+    test "#run yields the newly created Run when there is no active Run" do
+      run = Run.create!(task_name: @name, status: :paused)
+
+      @runner.run(name: @name) { |yielded| @run = yielded }
+      assert_equal run, @run
+    end
+
+    # Yielding the run is undocumented and not supported in the Runner's API
+    test "#run yields the existing active Run" do
+      @runner.run(name: @name) { |run| @run = run }
+      assert_equal Run.last, @run
+    end
+
     test "#run raises validation error if no Task for given name" do
       assert_no_difference -> { Run.where(task_name: "Invalid").count } do
         assert_no_enqueued_jobs do


### PR DESCRIPTION
When wrapping this gem for Shopify/shopify, we want to get the newly created or resumed `Run` from `Runner.run`.

This yields the current run only if a block is passed to `Runner.run`, without documenting that feature since `Run` is a private API that most apps shouldn't tinker with.

Fixes #405 