### PR TITLE
Remove X-Frame-Options header from dummy application

### DIFF
--- a/test/dummy/config/initializers/content_security_policy.rb
+++ b/test/dummy/config/initializers/content_security_policy.rb
@@ -18,6 +18,10 @@ Rails.application.config.content_security_policy do |policy|
   # policy.report_uri "/csp-violation-report-endpoint"
 end
 
+# Remove this header since Chrome warns
+Rails.application.config.action_dispatch.default_headers
+  .delete("X-Frame-Options")
+
 # Report CSP violations to a specified URI
 # For further information see the following documentation:
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only


### PR DESCRIPTION
It has been superseded by Content-Security-Policy: frame-ancestors, which is widely supported:

https://caniuse.com/mdn-http_headers_csp_content-security-policy_frame-ancestors

Now Chrome has added a warning:

	The page delivered both an 'X-Frame-Options' header and a
	'Content-Security-Policy' header with a 'frame-ancestors'
	directive.  Although the 'X-Frame-Options' header alone would
	have blocked embedding, it has been ignored.

The warning is confusing because the X-Frame-Options header alone would not have blocked embedding, because Rails defaults to SAMEORIGIN which allows embedding in the same site like we do here.

This only removes the header from the dummy app for tests.