### PR TITLE
Add note on handling rolled-up migrations to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,16 @@ $ bin/rails generate maintenance_tasks:install
 
 This ensures that new migrations are installed and run as well.
 
+**What if I've deleted my previous Maintenance Task migrations?**
+
+The install command will attempt to reinstall these old migrations and migrating
+the database will cause problems. Use `bin/rails generate maintenance_tasks:install:migrations`
+to copy the gem's migrations to your `db/migrate` folder. Check the release
+notes to see if any new migrations were added since your last gem upgrade.
+Ensure that these are kept, but remove any migrations that already ran.
+
+Run the migrations using `bin/rails db:migrate`.
+
 ## Contributing
 
 Would you like to report an issue or contribute with code? We accept issues and

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -33,5 +33,9 @@ module Dummy
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    if Rails::VERSION::STRING.match?(/^7.0/)
+      config.active_record.destroy_all_in_batches = true
+    end
   end
 end


### PR DESCRIPTION
This comes up a fair amount at Shopify, since many large Rails apps roll up their db migrations. It's reasonable to assume that external applications using this gem may be doing a similar thing.

We discussed trying to be smarter about figuring out which migrations an app already ran and only copying over necessary ones, which spawned [this issue](https://github.com/Shopify/maintenance_tasks/issues/441), but it's a pretty involved solution for the size of the problem.

A quick fix that makes the user experience better is laid out in this PR. If an app has rolled up past MT migrations, they are advised to run the migration copying subcommand, remove any unnecessary migrations (by checking the release notes to see which ones have been added since the last upgrade) and then manually running `bin/rails db:migrate`.