### PR TITLE
Add constant for stuck task timeouts

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -27,6 +27,7 @@ module MaintenanceTasks
     ]
     COMPLETED_STATUSES = [:succeeded, :errored, :cancelled]
     COMPLETED_RUNS_LIMIT = 10
+    STUCK_TASK_TIMEOUT = 5.minutes
 
     enum status: STATUSES.to_h { |status| [status, status.to_s] }
 
@@ -190,7 +191,7 @@ module MaintenanceTasks
     #
     # @return [Boolean] whether the Run is stuck.
     def stuck?
-      cancelling? && updated_at <= 5.minutes.ago
+      cancelling? && updated_at <= STUCK_TASK_TIMEOUT.ago
     end
 
     # Performs validation on the presence of a :csv_file attachment.

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -252,7 +252,7 @@ module MaintenanceTasks
       )
       refute_predicate run, :stuck?
 
-      travel 5.minutes
+      travel Run::STUCK_TASK_TIMEOUT
       assert_predicate run, :stuck?
     end
 
@@ -263,7 +263,7 @@ module MaintenanceTasks
           task_name: "Maintenance::UpdatePostsTask",
           status: status,
         )
-        travel 5.minutes
+        travel Run::STUCK_TASK_TIMEOUT
         refute_predicate run, :stuck?
       end
     end
@@ -279,7 +279,7 @@ module MaintenanceTasks
       assert_predicate run, :cancelling?
       assert_nil run.ended_at
 
-      travel 5.minutes
+      travel Run::STUCK_TASK_TIMEOUT
       run.cancel
       assert_predicate run, :cancelled?
       assert_equal Time.now, run.ended_at

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -135,7 +135,7 @@ module MaintenanceTasks
       assert_text "Cancelling…"
       refute_button "Cancel"
 
-      travel 5.minutes
+      travel Run::STUCK_TASK_TIMEOUT
 
       refresh
       click_on "Cancel"


### PR DESCRIPTION
Closes: #448 
We need a way to synchronize changes to the stuck task timer if an application decides to extend the gem. At the moment if both applications are using 5 minutes for a stuck timeout but there could be consequences if these changed. (I.e in the gem but not the application based off it.

I.e if we changed the timer to one min and another application has the old timeout (5 minutes).
