### PR TITLE
Persist `job_id` to Run before job is enqueued

### DIFF
--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -8,6 +8,7 @@ module MaintenanceTasks
     include JobIteration::Iteration
 
     included do
+      before_enqueue(:before_enqueue)
       before_perform(:before_perform)
 
       on_start(:on_start)
@@ -87,13 +88,17 @@ module MaintenanceTasks
       raise error
     end
 
+    def before_enqueue
+      @run = arguments.first
+      @run.update!(job_id: job_id)
+    end
+
     def before_perform
       @run = arguments.first
       @task = @run.task
       if @task.respond_to?(:csv_content=)
         @task.csv_content = @run.csv_file.download
       end
-      @run.job_id = job_id
 
       @run.running! unless @run.stopping?
 


### PR DESCRIPTION
Compatibility with the blackhole system in Shopify/shopify requires us to have the `job_id` available on the `MaintenanceTasks::Run` as soon as it's enqueued, not once it's about to start performing.

This PR simply changes the deserialization of the `MaintenanceTasks::Run` + the setting of `job_id` on the run to happen in a `before_enqueue` block rather than in the `before_perform` block.