### PR TITLE
Yield run before persistence in `Runner.run`

### DIFF
--- a/app/models/maintenance_tasks/runner.rb
+++ b/app/models/maintenance_tasks/runner.rb
@@ -51,10 +51,10 @@ module MaintenanceTasks
       run = Run.active.find_by(task_name: name) ||
         Run.new(task_name: name, arguments: arguments)
       run.csv_file.attach(csv_file) if csv_file
+      yield run if block_given?
 
       run.enqueued!
       enqueue(run)
-      yield run if block_given?
       Task.named(name)
     end
 


### PR DESCRIPTION
This change shouldn't have any visible repercussions because this is an undocumented feature - however, it does allow us to save a write in Shopify/shopify because we can set attributes on the yielded run _before_ it's persisted and then rely on the write happening in `Runner.run`. (The current behaviour is to call `Runner.run`, which inserts to the db, yields the persisted run, and then we perform an update to set additional attributes on the run).