### PR TITLE
Show Run arguments in UI

### DIFF
--- a/app/views/maintenance_tasks/runs/_info.html.erb
+++ b/app/views/maintenance_tasks/runs/_info.html.erb
@@ -11,6 +11,16 @@
 
 <% if run.csv_file.present? %>
   <div class="block">
-    <%= link_to('Download CSV', csv_file_download_path(run)) %>
+    <%= link_to("Download CSV", csv_file_download_path(run)) %>
+  </div>
+<% end %>
+<% if run.arguments.present? %>
+  <div class="block">
+    <h5>Arguments:</h5>
+    <pre>
+      <% run.arguments.each do |key, value| %>
+        <%= "#{key}: #{value}" %>
+      <% end %>
+    </pre>
   </div>
 <% end %>

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -43,6 +43,8 @@ module MaintenanceTasks
       assert_title "Maintenance::ParamsTask"
       assert_text "Succeeded"
       assert_text "Processed 1 out of 1 item (100%)."
+      assert_text "Arguments"
+      assert_text "post_ids: #{post_id}"
     end
 
     test "errors for Task with invalid arguments shown" do


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/447

Shows the arguments a Task was run with in the UI.

🎩 
**Index page**
![Screen Shot 2021-07-19 at 2 22 52 PM](https://user-images.githubusercontent.com/22918438/126208711-dcd69cae-ef37-4c53-97b5-0db9fa9f009e.png)

**Show page (latest Run)**
![Screen Shot 2021-07-19 at 2 25 10 PM](https://user-images.githubusercontent.com/22918438/126208713-e2557f73-59cf-429a-af2e-dd1d2cac47b3.png)

**Show page (previous Runs)**
![Screen Shot 2021-07-19 at 2 25 24 PM](https://user-images.githubusercontent.com/22918438/126208667-06c75778-7234-4619-9135-3b277392f0b0.png)

Is this the best way to present this information?