### PR TITLE
Bump version to 1.5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    maintenance_tasks (1.4.0)
+    maintenance_tasks (1.5.0)
       actionpack (>= 6.0)
       activejob (>= 6.0)
       activerecord (>= 6.0)

--- a/README.md
+++ b/README.md
@@ -591,6 +591,7 @@ are merged.
 Once a release is ready, follow these steps:
 
 * Update `spec.version` in `maintenance_tasks.gemspec`.
+* Run `bundle install` to bump the `Gemfile.lock` version of the gem.
 * Open a PR and merge on approval.
 * Deploy via [Shipit][shipit] and see the new version on
   <https://rubygems.org/gems/maintenance_tasks>.

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "maintenance_tasks"
-  spec.version = "1.4.0"
+  spec.version = "1.5.0"
   spec.author = "Shopify Engineering"
   spec.email = "gems@shopify.com"
   spec.homepage = "https://github.com/Shopify/maintenance_tasks"


### PR DESCRIPTION
I'm proposing we release a new version now so we can start tackling some of the changes in Shopify/shopify 😄 

We can cut a `v.1.5.1` later to address fixing `job_id` to be set on insert instead of update, as well as to allow collections that support objects responding to `to_enum` to finish up CSV support.

Drafted release notes: https://github.com/Shopify/maintenance_tasks/releases/edit/untagged-a14428f6d5f7d26e76bc