### PR TITLE
Style Task arguments section better

### DIFF
--- a/app/views/maintenance_tasks/runs/_arguments.html.erb
+++ b/app/views/maintenance_tasks/runs/_arguments.html.erb
@@ -1,23 +1,6 @@
-<h5 class="title is-5">
-  <%= time_tag run.created_at, title: run.created_at %>
-  <%= status_tag run.status if with_status %>
-</h5>
-
-<%= progress run %>
-
-<div class="content">
-  <%= render "maintenance_tasks/runs/info/#{run.status}", run: run %>
-</div>
-
-<% if run.csv_file.present? %>
-  <div class="block">
-    <%= link_to("Download CSV", csv_file_download_path(run)) %>
-  </div>
-  <hr/>
-<% end %>
 <% if run.arguments.present? %>
-<div class="table-container">
-  <h6 class="title is-6">Arguments:</h6>
+  <div class="table-container">
+    <h6 class="title is-6">Arguments:</h6>
     <table class="table">
       <tbody>
         <% run.arguments.each do |key, value| %>
@@ -36,5 +19,4 @@
       </tbody>
     </table>
   </div>
-  <hr/>
 <% end %>

--- a/app/views/maintenance_tasks/runs/_csv.html.erb
+++ b/app/views/maintenance_tasks/runs/_csv.html.erb
@@ -1,0 +1,5 @@
+<% if run.csv_file.present? %>
+  <div class="block">
+    <%= link_to("Download CSV", csv_file_download_path(run)) %>
+  </div>
+<% end %>

--- a/app/views/maintenance_tasks/runs/_info.html.erb
+++ b/app/views/maintenance_tasks/runs/_info.html.erb
@@ -13,6 +13,7 @@
   <div class="block">
     <%= link_to("Download CSV", csv_file_download_path(run)) %>
   </div>
+  <hr/>
 <% end %>
 <% if run.arguments.present? %>
   <div class="block">
@@ -23,4 +24,5 @@
       <% end %>
     </pre>
   </div>
+  <hr/>
 <% end %>

--- a/app/views/maintenance_tasks/runs/_info.html.erb
+++ b/app/views/maintenance_tasks/runs/_info.html.erb
@@ -24,6 +24,7 @@
           <tr>
             <td class="is-family-monospace"><%= key %></td>
             <td>
+              <% next if value.nil? || value.empty? %>
               <% if value.include?("\n") %>
                 <pre><%= value %><pre>
               <% else %>

--- a/app/views/maintenance_tasks/runs/_info.html.erb
+++ b/app/views/maintenance_tasks/runs/_info.html.erb
@@ -22,7 +22,7 @@
       <tbody>
         <% run.arguments.each do |key, value| %>
           <tr>
-            <td><var><%= key %></var></td>
+            <td class="is-family-monospace"><%= key %></td>
             <td>
               <% if value.include?("\n") %>
                 <pre><%= value %><pre>

--- a/app/views/maintenance_tasks/runs/_info.html.erb
+++ b/app/views/maintenance_tasks/runs/_info.html.erb
@@ -16,13 +16,24 @@
   <hr/>
 <% end %>
 <% if run.arguments.present? %>
-  <div class="block">
-    <h5>Arguments:</h5>
-    <pre>
-      <% run.arguments.each do |key, value| %>
-        <%= "#{key}: #{value}" %>
-      <% end %>
-    </pre>
+<div class="table-container">
+  <h6 class="title is-6">Arguments:</h6>
+    <table class="table">
+      <tbody>
+        <% run.arguments.each do |key, value| %>
+          <tr>
+            <td><var><%= key %></var></td>
+            <td>
+              <% if value.include?("\n") %>
+                <pre><%= value %><pre>
+              <% else %>
+                <code><%= value %><code>
+              <% end %>
+            </td>
+          </tr>
+          <% end %>
+      </tbody>
+    </table>
   </div>
   <hr/>
 <% end %>

--- a/app/views/maintenance_tasks/runs/_run.html.erb
+++ b/app/views/maintenance_tasks/runs/_run.html.erb
@@ -1,3 +1,16 @@
 <div class="box">
-  <%= render 'maintenance_tasks/runs/info', run: run, with_status: true %>
+  <h5 class="title is-5">
+    <%= time_tag run.created_at, title: run.created_at %>
+    <%= status_tag run.status %>
+  </h5>
+
+  <%= progress run %>
+
+  <div class="content">
+    <%= render "maintenance_tasks/runs/info/#{run.status}", run: run %>
+  </div>
+
+  <%= render "maintenance_tasks/runs/csv", run: run %>
+  <%= tag.hr if run.csv_file.present? && run.arguments.present? %>
+  <%= render "maintenance_tasks/runs/arguments", run: run %>
 </div>

--- a/app/views/maintenance_tasks/runs/info/_errored.html.erb
+++ b/app/views/maintenance_tasks/runs/info/_errored.html.erb
@@ -3,8 +3,6 @@
   <%= time_ago run.ended_at %>.
 </p>
 
-</p>
-
 <div class="card">
   <header class="card-header">
     <p class="card-header-title">

--- a/app/views/maintenance_tasks/tasks/_task.html.erb
+++ b/app/views/maintenance_tasks/tasks/_task.html.erb
@@ -4,5 +4,19 @@
     <%= status_tag(task.status) %>
   </h3>
 
-  <%= render 'maintenance_tasks/runs/info', run: task.last_run, with_status: false if task.last_run %>
+  <% if (run = task.last_run) %>
+    <h5 class="title is-5">
+      <%= time_tag run.created_at, title: run.created_at %>
+    </h5>
+
+    <%= progress run %>
+
+    <div class="content">
+      <%= render "maintenance_tasks/runs/info/#{run.status}", run: run %>
+    </div>
+
+    <%= render "maintenance_tasks/runs/csv", run: run %>
+    <%= tag.hr if run.csv_file.present? && run.arguments.present? %>
+    <%= render "maintenance_tasks/runs/arguments", run: run %>
+  <% end %>
 </div>

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -20,8 +20,12 @@
         <div class="block">
           <%= form.fields_for :task_arguments do |ff| %>
             <% @task.parameter_names.each do |parameter| %>
-              <%= ff.label parameter, "#{parameter}: ", class: "label" %>
-              <%= ff.text_area parameter, class: "textarea" %>
+              <div class="field">
+                <%= ff.label parameter, tag.var(parameter), class: "label" %>
+                <div class="control">
+                  <%= ff.text_area parameter, class: "textarea" %>
+                </div>
+              </div>
             <% end %>
           <% end %>
         </div>

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -4,10 +4,25 @@
   <%= @task %> <%= status_tag(@task.status) %>
 </h1>
 
-<%= render 'maintenance_tasks/runs/info', run: @task.last_run, with_status: false if @task.last_run %>
+<% last_run = @task.last_run %>
+<% if last_run %>
+  <h5 class="title is-5">
+    <%= time_tag last_run.created_at, title: last_run.created_at %>
+  </h5>
+
+  <%= progress last_run %>
+
+  <div class="content">
+    <%= render "maintenance_tasks/runs/info/#{last_run.status}", run: last_run %>
+  </div>
+
+  <%= render "maintenance_tasks/runs/csv", run: last_run %>
+  <%= tag.hr if last_run.csv_file.present? %>
+  <%= render "maintenance_tasks/runs/arguments", run: last_run %>
+  <%= tag.hr if last_run.arguments.present? %>
+<% end %>
 
 <div class="buttons">
-  <% last_run = @task.last_run %>
   <% if last_run.nil? || last_run.completed? %>
     <%= form_with url: run_task_path(@task), method: :put do |form| %>
       <% if @task.csv_task? %>

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -21,7 +21,7 @@
           <%= form.fields_for :task_arguments do |ff| %>
             <% @task.parameter_names.each do |parameter| %>
               <div class="field">
-                <%= ff.label parameter, tag.var(parameter), class: "label" %>
+                <%= ff.label parameter, parameter, class: "label is-family-monospace" %>
                 <div class="control">
                   <%= ff.text_area parameter, class: "textarea" %>
                 </div>

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -44,7 +44,10 @@ module MaintenanceTasks
       assert_text "Succeeded"
       assert_text "Processed 1 out of 1 item (100%)."
       assert_text "Arguments"
-      assert_text "post_ids: #{post_id}"
+      assert_table do |table|
+        table.assert_text("post_ids")
+        table.assert_text(post_id.to_s)
+      end
     end
 
     test "errors for Task with invalid arguments shown" do


### PR DESCRIPTION
Some slight improvements to the Task show page for Tasks with arguments / CSVs:
### Added horizontal rules to split Task arguments / CSV download section for the latest run from the "Run" section of the page:

**Before**
![Screen Shot 2021-07-27 at 4 13 20 PM](https://user-images.githubusercontent.com/22918438/127221067-2a9b7e52-1612-47ec-8fb9-8d237a42db80.png)
**After**
![Screen Shot 2021-07-27 at 4 12 58 PM](https://user-images.githubusercontent.com/22918438/127221027-c1c8c95b-76c7-4468-b1c2-9da8d49b593e.png)

### Wrapped argument form labels in `<var>` tags:

**Before**
![Screen Shot 2021-07-27 at 4 16 37 PM](https://user-images.githubusercontent.com/22918438/127221490-ee7b8f26-6425-4539-96c5-5f7c119c5564.png)

**After**
![Screen Shot 2021-07-27 at 4 21 00 PM](https://user-images.githubusercontent.com/22918438/127222024-0b082861-5704-477e-af54-86770ea169c7.png)

### Changed args to be displayed in a table instead of a single `<pre>` tag. If the arg is a single line, we wrap it in `<code>`, if the argument spans multiple lines we wrap it in `<pre>`:

**Before**
![Screen Shot 2021-07-27 at 4 18 16 PM](https://user-images.githubusercontent.com/22918438/127221675-bf3fd93b-56c4-4823-a46f-4178786767dd.png)

**After**
![Screen Shot 2021-07-27 at 4 19 09 PM](https://user-images.githubusercontent.com/22918438/127221787-37e2ba55-1f6c-4e40-b278-43c8cacf53bf.png)
----------------------
![Screen Shot 2021-07-27 at 4 19 44 PM](https://user-images.githubusercontent.com/22918438/127221850-a254c422-1c02-4d6b-b06e-251f6e3ef08b.png)
----------------------
![Screen Shot 2021-07-27 at 4 20 34 PM](https://user-images.githubusercontent.com/22918438/127221959-d392a922-b3dd-42b1-8b3e-13f78132048d.png)
(Long content is scrollable)