### PR TITLE
Remove n+1 for Active Storage attachments

### DIFF
--- a/app/models/maintenance_tasks/task_data.rb
+++ b/app/models/maintenance_tasks/task_data.rb
@@ -40,7 +40,7 @@ module MaintenanceTasks
       def available_tasks
         task_names = Task.available_tasks.map(&:name)
         available_task_runs = Run.where(task_name: task_names)
-        last_runs = Run.where(
+        last_runs = Run.with_attached_csv.where(
           id: available_task_runs.select("MAX(id) as id").group(:task_name)
         )
 


### PR DESCRIPTION
On the index page, for each available task we run one query to get the ActiveStorage::Attachment of the last run of that Task, then if there's one, another query to get the ActiveStorage::Blob. So more like:
* 1 query for Run records
* n queries for ActiveStorage::Attachment records
* m queries for ActiveStorage::Blob records (where m < n)

This reduces to 3 queries, one for each table.