### PR TITLE
Change CSV collection implementation to use a strategy pattern.

### DIFF
--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -90,7 +90,7 @@ module MaintenanceTasks
     def before_perform
       @run = arguments.first
       @task = @run.task
-      if @task.respond_to?(:csv_content=)
+      if @task.has_csv_content?
         @task.csv_content = @run.csv_file.download
       end
 

--- a/app/models/maintenance_tasks/csv_collection_builder.rb
+++ b/app/models/maintenance_tasks/csv_collection_builder.rb
@@ -3,8 +3,7 @@
 require "csv"
 
 module MaintenanceTasks
-  # Module that is included into Task classes by Task.csv_collection for
-  # processing CSV files.
+  # Strategy for building a Task that processes CSV files.
   #
   # @api private
   class CsvCollectionBuilder
@@ -25,6 +24,7 @@ module MaintenanceTasks
       task.csv_content.count("\n") - 1
     end
 
+    # Return that the Task processes CSV content.
     def has_csv_content?
       true
     end

--- a/app/models/maintenance_tasks/csv_collection_builder.rb
+++ b/app/models/maintenance_tasks/csv_collection_builder.rb
@@ -7,18 +7,13 @@ module MaintenanceTasks
   # processing CSV files.
   #
   # @api private
-  module CsvCollection
-    # The contents of a CSV file to be processed by a Task.
-    #
-    # @return [String] the content of the CSV file to process.
-    attr_accessor :csv_content
-
+  class CsvCollectionBuilder
     # Defines the collection to be iterated over, based on the provided CSV.
     #
     # @return [CSV] the CSV object constructed from the specified CSV content,
     #   with headers.
-    def collection
-      CSV.new(csv_content, headers: true)
+    def collection(task)
+      CSV.new(task.csv_content, headers: true)
     end
 
     # The number of rows to be processed. Excludes the header row from the count
@@ -26,8 +21,12 @@ module MaintenanceTasks
     # an approximation based on the number of new lines.
     #
     # @return [Integer] the approximate number of rows to process.
-    def count
-      csv_content.count("\n") - 1
+    def count(task)
+      task.csv_content.count("\n") - 1
+    end
+
+    def has_csv_content?
+      true
     end
   end
 end

--- a/app/models/maintenance_tasks/null_collection_builder.rb
+++ b/app/models/maintenance_tasks/null_collection_builder.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module MaintenanceTasks
+  # Base strategy for building a collection-based Task to be performed.
+  class NullCollectionBuilder
+    # Placeholder method to raise in case a subclass fails to implement the
+    # expected instance method.
+    #
+    # @raise [NotImplementedError] with a message advising subclasses to
+    #   implement an override for this method.
+    def collection(task)
+      raise NoMethodError, "#{task.class.name} must implement `collection`."
+    end
+
+    # Total count of iterations to be performed.
+    #
+    # Tasks override this method to define the total amount of iterations
+    # expected at the start of the run. Return +nil+ if the amount is
+    # undefined, or counting would be prohibitive for your database.
+    #
+    # @return [Integer, nil]
+    def count(task)
+      :no_count
+    end
+
+    # Return that the Task does not process CSV content.
+    def has_csv_content?
+      false
+    end
+  end
+end

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -202,7 +202,7 @@ module MaintenanceTasks
     def csv_attachment_presence
       if Task.named(task_name).has_csv_content? && !csv_file.attached?
         errors.add(:csv_file, "must be attached to CSV Task.")
-      elsif !(Task.named(task_name).has_csv_content?) && csv_file.present?
+      elsif !Task.named(task_name).has_csv_content? && csv_file.present?
         errors.add(:csv_file, "should not be attached to non-CSV Task.")
       end
     rescue Task::NotFoundError

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -200,9 +200,9 @@ module MaintenanceTasks
     # should not have an attachment to be valid. The appropriate error is added
     # if the Run does not meet the above criteria.
     def csv_attachment_presence
-      if Task.named(task_name) < CsvCollection && !csv_file.attached?
+      if Task.named(task_name).has_csv_content? && !csv_file.attached?
         errors.add(:csv_file, "must be attached to CSV Task.")
-      elsif !(Task.named(task_name) < CsvCollection) && csv_file.present?
+      elsif !(Task.named(task_name).has_csv_content?) && csv_file.present?
         errors.add(:csv_file, "should not be attached to non-CSV Task.")
       end
     rescue Task::NotFoundError

--- a/app/models/maintenance_tasks/task_data.rb
+++ b/app/models/maintenance_tasks/task_data.rb
@@ -129,7 +129,7 @@ module MaintenanceTasks
 
     # @return [Boolean] whether the Task inherits from CsvTask.
     def csv_task?
-      !deleted? && Task.named(name) < CsvCollection
+      !deleted? && Task.named(name).has_csv_content?
     end
 
     # @return [Array<String>] the names of parameters the Task accepts.

--- a/app/tasks/maintenance_tasks/task.rb
+++ b/app/tasks/maintenance_tasks/task.rb
@@ -7,34 +7,6 @@ module MaintenanceTasks
     include ActiveModel::AttributeAssignment
     include ActiveModel::Validations
 
-    # Base strategy for building a collection-based Task to be performed.
-    class NullCollectionBuilder
-      # Placeholder method to raise in case a subclass fails to implement the
-      # expected instance method.
-      #
-      # @raise [NotImplementedError] with a message advising subclasses to
-      #   implement an override for this method.
-      def collection(task)
-        raise NoMethodError, "#{task.class.name} must implement `collection`."
-      end
-
-      # Total count of iterations to be performed.
-      #
-      # Tasks override this method to define the total amount of iterations
-      # expected at the start of the run. Return +nil+ if the amount is
-      # undefined, or counting would be prohibitive for your database.
-      #
-      # @return [Integer, nil]
-      def count(task)
-        :no_count
-      end
-
-      # Return that the Task does not process CSV content.
-      def has_csv_content?
-        false
-      end
-    end
-
     class NotFoundError < NameError; end
 
     # The throttle conditions for a given Task. This is provided as an array of

--- a/test/models/maintenance_tasks/csv_collection_builder_test.rb
+++ b/test/models/maintenance_tasks/csv_collection_builder_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module MaintenanceTasks
+  class CsvCollectionBuilderTest < ActiveSupport::TestCase
+    setup do
+      @task = Maintenance::ImportPostsTask.new
+      @builder = CsvCollectionBuilder.new
+    end
+
+    test "#collection" do
+      @task.csv_content = <<~CSV
+        header
+        1
+      CSV
+
+      assert_instance_of(CSV, @builder.collection(@task))
+    end
+
+    test "count" do
+      @task.csv_content = <<~CSV
+        header
+        1
+        2
+        3
+      CSV
+
+      assert_equal(3, @builder.count(@task))
+    end
+
+    test "#has_csv_content?" do
+      assert_predicate(@builder, :has_csv_content?)
+    end
+  end
+end

--- a/test/models/maintenance_tasks/null_collection_builder_test.rb
+++ b/test/models/maintenance_tasks/null_collection_builder_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module MaintenanceTasks
+  class NullCollectionBuilderTest < ActiveSupport::TestCase
+    setup do
+      @task = Maintenance::TestTask.new
+      @builder = NullCollectionBuilder.new
+    end
+
+    test "#collection" do
+      assert_raises(NoMethodError) do
+        @builder.collection(@task)
+      end
+    end
+
+    test "count" do
+      assert_equal(:no_count, @builder.count(@task))
+    end
+
+    test "#has_csv_content?" do
+      assert_not_predicate(@builder, :has_csv_content?)
+    end
+  end
+end


### PR DESCRIPTION
We want to add more ways to build collection, so using a strategy
pattern makes sense since we don't need to be including different
modules with different API and we can just swap the strategy at
runtime.