### PR TITLE
Change the name of the CSV file before uploading

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,7 @@ My Title,Hello World!
 ```
 
 The files uploaded to your Active Storage service provider will be renamed first
-to include a timestamp (ISO8601 without dashes or colons) and the Task name
-(with colons changed into dashes).
+to include an ISO8601 timestamp and the Task name in snake case format.
 
 ### Processing Batch Collections
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ title,content
 My Title,Hello World!
 ```
 
+The files uploaded to your Active Storage service provider will be renamed first
+to include a timestamp (ISO8601 without dashes or colons) and the Task name
+(with colons changed into dashes).
+
 ### Processing Batch Collections
 
 The Maintenance Tasks gem supports processing Active Records in batches. This

--- a/app/models/maintenance_tasks/runner.rb
+++ b/app/models/maintenance_tasks/runner.rb
@@ -75,7 +75,8 @@ module MaintenanceTasks
     end
 
     def filename(task_name)
-      "#{Time.now.utc.strftime("%Y%m%dT%H%M%SZ")} #{task_name}.csv"
+      formatted_task_name = task_name.underscore.gsub("/", "_")
+      "#{Time.now.utc.strftime("%Y%m%dT%H%M%SZ")}_#{formatted_task_name}.csv"
     end
   end
 end

--- a/test/models/maintenance_tasks/runner_test.rb
+++ b/test/models/maintenance_tasks/runner_test.rb
@@ -158,7 +158,7 @@ module MaintenanceTasks
       @runner.run(name: "Maintenance::ImportPostsTask", csv_file: csv_io)
 
       run = Run.last
-      assert_equal "20210805T120542Z Maintenance--ImportPostsTask.csv",
+      assert_equal "20210805T120542Z_maintenance_import_posts_task.csv",
         run.csv_file.filename.to_s
     end
 

--- a/test/models/maintenance_tasks/runner_test.rb
+++ b/test/models/maintenance_tasks/runner_test.rb
@@ -153,6 +153,15 @@ module MaintenanceTasks
       end
     end
 
+    test "#run overrides the file name" do
+      travel_to "2021-08-05T12:05:42Z"
+      @runner.run(name: "Maintenance::ImportPostsTask", csv_file: csv_io)
+
+      run = Run.last
+      assert_equal "20210805T120542Z Maintenance--ImportPostsTask.csv",
+        run.csv_file.filename.to_s
+    end
+
     private
 
     def csv_io

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -75,7 +75,7 @@ module MaintenanceTasks
       click_on("Download CSV")
 
       downloaded_csv = "test/dummy/tmp/downloads/"\
-        "20200109T094144Z Maintenance--ImportPostsTask.csv"
+        "20200109T094144Z_maintenance_import_posts_task.csv"
 
       Timeout.timeout(1) do
         sleep(0.1) until File.exist?(downloaded_csv)

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -74,7 +74,8 @@ module MaintenanceTasks
 
       click_on("Download CSV")
 
-      downloaded_csv = "test/dummy/tmp/downloads/sample.csv"
+      downloaded_csv = "test/dummy/tmp/downloads/"\
+        "20200109T094144Z Maintenance--ImportPostsTask.csv"
 
       Timeout.timeout(1) do
         sleep(0.1) until File.exist?(downloaded_csv)


### PR DESCRIPTION
In #318 we wanted to change the name of CSV files, but the added complexity wasn't worth it because we were adding a controller to provide the file name.

This changes the name before uploading, that way files also have useful names in the Active Storage service, not only when downloading them with the UI.