### PR TITLE
Set `started_at` on `MaintenanceTasks::Run` if error occurs before `#on_start`

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -87,6 +87,7 @@ module MaintenanceTasks
     #
     # @param error [StandardError] the Error being persisted.
     def persist_error(error)
+      self.started_at ||= Time.now
       update!(
         status: :errored,
         error_class: error.class.to_s,

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -236,6 +236,7 @@ module MaintenanceTasks
     end
 
     test ".perform_now sets the Run as errored when the Task collection is invalid" do
+      freeze_time
       Maintenance::TestTask.any_instance.stubs(collection: "not a collection")
 
       TaskJob.perform_now(@run)
@@ -250,6 +251,7 @@ module MaintenanceTasks
         Array, or CSV.
       MSG
       assert_equal expected_message, @run.error_message
+      assert_equal Time.now, @run.started_at
     end
 
     test ".perform_now sets the Run as errored when the Task collection is not defined" do

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -62,7 +62,7 @@ module MaintenanceTasks
       assert_equal 12.2, run.time_running
     end
 
-    test "#persist_error updates Run to errored and sets ended_at" do
+    test "#persist_error updates Run to errored, sets ended_at, and sets started_at if not yet set" do
       freeze_time
       run = Run.create!(task_name: "Maintenance::ErrorTask")
 
@@ -74,6 +74,7 @@ module MaintenanceTasks
       assert_equal "ArgumentError", run.error_class
       assert_equal "Something went wrong", run.error_message
       assert_equal ["lib/foo.rb:42:in `bar'"], run.backtrace
+      assert_equal Time.now, run.started_at
       assert_equal Time.now, run.ended_at
     end
 


### PR DESCRIPTION
Currently, if a Task raises prior to the `#on_start` callback running (for example, if there is a problem with `#collection` and it raises), no `started_at` timestamp gets set on the `Run`. 

 I think it's kind of weird to have an `ended_at` timestamp on a complete `Run`, but no `started_at` timestamp. IMO if a `Run` is `completed?` we should be able to assume that both those timestamps are present.