### PR TITLE
Include idempotency hint in generated task template.

### DIFF
--- a/lib/generators/maintenance_tasks/templates/task.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/task.rb.tt
@@ -9,7 +9,8 @@ module <%= tasks_module %>
     end
 
     def process(element)
-      # The work to be done in a single iteration of the task
+      # The work to be done in a single iteration of the task.
+      # This should be idempotent, as the same element may be processed more than once if the task interrupted and resumed.
     end
 
     def count


### PR DESCRIPTION
The README makes it clear that `#process` needs to be idempotent. There are potentially major consequences of not adhering to this recommendation. We should remind developers inline while they are writing the `#process` method. 

The generated task file includes help comments already. I've extended them to include the idempotency hint.