### PR TITLE
Don't run rubocop in parallel with the Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,9 @@ load("rails/tasks/statistics.rake")
 require "bundler/gem_tasks"
 
 require "rubocop/rake_task"
-RuboCop::RakeTask.new
+RuboCop::RakeTask.new.tap do |rubocop|
+  rubocop.options += ["--no-parallel"]
+end
 
 task(test: "app:test")
 task("test:system" => "app:test:system")


### PR DESCRIPTION
When I run `bundle exec rake` the tests fail, and it has been happening since #470.
It comes from https://github.com/rubocop/rubocop/pull/10000.
Parallelization causes issues with the way Rails runs tests see https://github.com/rails/rails/pull/41132, since Rails uses `at_exit`, and Rubocop creates multiple forks, all of them start running the tests, and database locking occurs.

We could also fix that by moving the Rubocop task first, since the `at_exit` hooks wouldn't have been defined at this point, but I like to keep it at the end, and it's not that slow anyway. It could also be fixed by Rubocop not running its code directly from the Rake task, but in a subprocess, which would not bring along the `at_exit` hooks.