### PR TITLE
Fixes upgrading docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ This ensures that new migrations are installed and run as well.
 **What if I've deleted my previous Maintenance Task migrations?**
 
 The install command will attempt to reinstall these old migrations and migrating
-the database will cause problems. Use `bin/rails generate
+the database will cause problems. Use `bin/rake
 maintenance_tasks:install:migrations` to copy the gem's migrations to your
 `db/migrate` folder. Check the release notes to see if any new migrations were
 added since your last gem upgrade.  Ensure that these are kept, but remove any


### PR DESCRIPTION
In the `README.md` we have:

>  Use `bin/rails generate maintenance_tasks:install:migrations` to copy the gem's migrations to your `db/migrate` folder.

However, Rails tells me this command does not exist (using 1.5.0):

```console
$ bin/rails generate maintenance_tasks:migrations
Could not find generator 'maintenance_tasks:migrations'. Maybe you meant "maintenance_tasks:task"?
Run `rails generate --help` for more options.
```

Looking at [the code](https://github.com/Shopify/maintenance_tasks/blob/d406b0c6ff0e8cc05b128739e5c288f0982c3e44/lib/generators/maintenance_tasks/install_generator.rb#L17) there's no generate command for that, but a `rake` call. 

Thus I think it should be `rake` (not `rails generate`). Tested locally and it works. Is that the case?