### PR TITLE
Introduce callbacks for Task lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,48 @@ to run. Since arguments are specified in the user interface via text area
 inputs, it's important to check that they conform to the format your Task
 expects, and to sanitize any inputs if necessary.
 
+### Using Task Callbacks
+
+The Task provides callbacks that hook into its life cycle.
+
+Available callbacks are:
+
+`after_start`
+`after_pause`
+`after_interrupt`
+`after_cancel`
+`after_complete`
+`after_error`
+
+```ruby
+module Maintenance
+  class UpdatePostsTask < MaintenanceTasks::Task
+    after_start :notify
+
+    def notify
+      NotifyJob.perform_later(self.class.name)
+    end
+
+    # ...
+  end
+end
+```
+
+Callback behaviour can be shared across all tasks using an initializer.
+
+```ruby
+# config/initializer/maintenance_tasks.rb
+Rails.autoloaders.main.on_load("MaintenanceTasks::Task") do
+  MaintenanceTasks::Task.class_eval do
+    after_start(:notify)
+
+    private
+
+    def notify; end
+  end
+end
+```
+
 ### Considerations when writing Tasks
 
 MaintenanceTasks relies on the queue adapter configured for your application to

--- a/README.md
+++ b/README.md
@@ -262,6 +262,31 @@ module Maintenance
 end
 ```
 
+Note: The `after_error` callback is guaranteed to complete,
+so any exceptions raised in your callback code are ignored.
+If your `after_error` callback code can raise an exception,
+you'll need to rescue it and handle it appropriately
+within the callback.
+
+```ruby
+module Maintenance
+  class UpdatePostsTask < MaintenanceTasks::Task
+    after_error :dangerous_notify
+
+    def dangerous_notify
+      # This error is rescued in favour of the original error causing the error flow.
+      raise NotDeliveredError
+    end
+
+    # ...
+  end
+end
+```
+
+If any of the other callbacks cause an exception,
+it will be handled by the error handler,
+and will cause the task to stop running.
+
 Callback behaviour can be shared across all tasks using an initializer.
 
 ```ruby

--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -170,7 +170,15 @@ module MaintenanceTasks
         task_context = {}
       end
       errored_element = @errored_element if defined?(@errored_element)
+      run_error_callback
+    ensure
       MaintenanceTasks.error_handler.call(error, task_context, errored_element)
+    end
+
+    def run_error_callback
+      @task.run_callbacks(:error) if defined?(@task)
+    rescue
+      nil
     end
   end
 end

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -3,6 +3,7 @@ module MaintenanceTasks
   # Base class that is inherited by the host application's task classes.
   class Task
     extend ActiveSupport::DescendantsTracker
+    include ActiveSupport::Callbacks
     include ActiveModel::Attributes
     include ActiveModel::AttributeAssignment
     include ActiveModel::Validations
@@ -18,6 +19,8 @@ module MaintenanceTasks
 
     class_attribute :collection_builder_strategy,
       default: NullCollectionBuilder.new
+
+    define_callbacks :start, :complete, :error, :cancel, :pause, :interrupt
 
     class << self
       # Finds a Task with the given name.
@@ -102,6 +105,54 @@ module MaintenanceTasks
         self.throttle_conditions += [
           { throttle_on: condition, backoff: backoff },
         ]
+      end
+
+      # Initialize a callback to run after the task starts.
+      #
+      # @param filter_list apply filters to the callback
+      #   (see https://api.rubyonrails.org/classes/ActiveSupport/Callbacks/ClassMethods.html#method-i-set_callback)
+      def after_start(*filter_list, &block)
+        set_callback(:start, :after, *filter_list, &block)
+      end
+
+      # Initialize a callback to run after the task completes.
+      #
+      # @param filter_list apply filters to the callback
+      #   (see https://api.rubyonrails.org/classes/ActiveSupport/Callbacks/ClassMethods.html#method-i-set_callback)
+      def after_complete(*filter_list, &block)
+        set_callback(:complete, :after, *filter_list, &block)
+      end
+
+      # Initialize a callback to run after the task pauses.
+      #
+      # @param filter_list apply filters to the callback
+      #   (see https://api.rubyonrails.org/classes/ActiveSupport/Callbacks/ClassMethods.html#method-i-set_callback)
+      def after_pause(*filter_list, &block)
+        set_callback(:pause, :after, *filter_list, &block)
+      end
+
+      # Initialize a callback to run after the task is interrupted.
+      #
+      # @param filter_list apply filters to the callback
+      #   (see https://api.rubyonrails.org/classes/ActiveSupport/Callbacks/ClassMethods.html#method-i-set_callback)
+      def after_interrupt(*filter_list, &block)
+        set_callback(:interrupt, :after, *filter_list, &block)
+      end
+
+      # Initialize a callback to run after the task is cancelled.
+      #
+      # @param filter_list apply filters to the callback
+      #   (see https://api.rubyonrails.org/classes/ActiveSupport/Callbacks/ClassMethods.html#method-i-set_callback)
+      def after_cancel(*filter_list, &block)
+        set_callback(:cancel, :after, *filter_list, &block)
+      end
+
+      # Initialize a callback to run after the task produces an error.
+      #
+      # @param filter_list apply filters to the callback
+      #   (see https://api.rubyonrails.org/classes/ActiveSupport/Callbacks/ClassMethods.html#method-i-set_callback)
+      def after_error(*filter_list, &block)
+        set_callback(:error, :after, *filter_list, &block)
       end
 
       private

--- a/test/dummy/app/tasks/maintenance/callback_test_task.rb
+++ b/test/dummy/app/tasks/maintenance/callback_test_task.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+module Maintenance
+  class CallbackTestTask < MaintenanceTasks::Task
+    after_start :after_start_callback
+    after_complete :after_complete_callback
+    after_pause :after_pause_callback
+    after_interrupt :after_interrupt_callback
+    after_cancel :after_cancel_callback
+    after_error :after_error_callback
+
+    def collection
+      [1, 2]
+    end
+
+    def count
+      collection.count
+    end
+
+    def process(number)
+      Rails.logger.debug("number: #{number}")
+    end
+
+    def after_start_callback; end
+
+    def after_complete_callback; end
+
+    def after_pause_callback; end
+
+    def after_interrupt_callback; end
+
+    def after_cancel_callback; end
+
+    def after_error_callback; end
+  end
+end

--- a/test/models/maintenance_tasks/task_data_test.rb
+++ b/test/models/maintenance_tasks/task_data_test.rb
@@ -21,6 +21,7 @@ module MaintenanceTasks
 
     test ".available_tasks returns a list of Tasks as TaskData, ordered alphabetically by name" do
       expected = [
+        "Maintenance::CallbackTestTask",
         "Maintenance::CancelledEnqueueTask",
         "Maintenance::EnqueueErrorTask",
         "Maintenance::ErrorTask",

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -5,6 +5,7 @@ module MaintenanceTasks
   class TaskTest < ActiveSupport::TestCase
     test ".available_tasks returns list of tasks that inherit from the Task superclass" do
       expected = [
+        "Maintenance::CallbackTestTask",
         "Maintenance::CancelledEnqueueTask",
         "Maintenance::EnqueueErrorTask",
         "Maintenance::ErrorTask",

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -18,6 +18,7 @@ module MaintenanceTasks
 
       expected = [
         "New Tasks",
+        "Maintenance::CallbackTestTask\nNew",
         "Maintenance::CancelledEnqueueTask\nNew",
         "Maintenance::EnqueueErrorTask\nNew",
         "Maintenance::ErrorTask\nNew",


### PR DESCRIPTION
Closes #334 

#### Motivation

Having callbacks provides the client the opportunity to integrate with the task lifecycle. As cited in the original issue, a Slack notification (or any other message dispatch) seems to be a common use case when running tasks such as these.

#### What was introduced?

This PR adds an interface for supporting callbacks in `MaintenanceTasks::Task`. 

It provides the following public class methods: 

- `after_start`
- `after_pause`
- `after_interrupt`
- `after_error`
- `after_cancel`
- `after_complete`

One important behaviour is that errors that are raised during the custom error callback code are **ignored / swallowed**, to guarantee that our `error_handler` proceeds as expected.

Internally, the events added to the object lifecycle are: `start`, `complete`, `pause,` `interrupt`, `cancel`, `error`.

The `TaskJobConcern` is responsible for running the task's callbacks and they correspond with the lifecycle of the `TaskJob` itself.

The PR updates documentation for the new feature. I've made sure to add a note about how a client might share callback behaviour across Tasks inspired by [this comment](https://github.com/Shopify/maintenance_tasks/pull/484#issuecomment-918313190) and this [discussion](https://github.com/Shopify/maintenance_tasks/pull/77#discussion_r508941116).

#### Testing

I've introduced a new maintenance task in the dummy app called `CallbackTestTask`. This task uses the new callback hooks. 

In the test, I assert that these methods are called appropriate by the `TaskJobConcern` using Mocha expectations.