### PR TITLE
Truncate the error message when message is too long

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -131,8 +131,8 @@ module MaintenanceTasks
       self.started_at ||= Time.now
       update!(
         status: :errored,
-        error_class: error.class.to_s,
-        error_message: error.message,
+        error_class: truncate(:error_class, error.class.name),
+        error_message: truncate(:error_message, error.message),
         backtrace: MaintenanceTasks.backtrace_cleaner.clean(error.backtrace),
         ended_at: Time.now,
       )
@@ -421,6 +421,12 @@ module MaintenanceTasks
         MSG
         errors.add(:base, error_message)
       end
+    end
+
+    def truncate(attribute_name, value)
+      limit = MaintenanceTasks::Run.column_for_attribute(attribute_name).limit
+      return value unless limit
+      value&.first(limit)
     end
   end
 end


### PR DESCRIPTION
Closes #493 to prevent [errors](https://app.bugsnag.com/shopify/arrive-server/errors/61fd2678bb89340008de6f8c?filters[search]=ActiveRecord%3A%3AValueTooLong) like:
```
ActiveRecord::ValueTooLongMaintenanceTaskJob@default
Mysql2::Error: Data too long for column 'error_message' at row 1
```

How I have 🎩'd it:
```
$ bundle add mysql2
$ export DATABASE_URL=mysql2://root@localhost/maintenance_tasks_development
$ brew services start mysql
$ bundle exec rails db:setup
$ bin/rails app:db:environment:set RAILS_ENV=test
$ bundle exec rails test
```

🎉