### PR TITLE
Allow Run model to be injected

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -105,8 +105,8 @@ module MaintenanceTasks
     #
     # @return [MaintenanceTasks::Run] the Run record with its updated status.
     def reload_status
-      updated_status = Run.uncached do
-        Run.where(id: id).pluck(:status).first
+      updated_status = self.class.uncached do
+        self.class.where(id: id).pluck(:status).first
       end
       self.status = updated_status
       clear_attribute_changes([:status])

--- a/app/models/maintenance_tasks/runner.rb
+++ b/app/models/maintenance_tasks/runner.rb
@@ -39,8 +39,6 @@ module MaintenanceTasks
     #   Value is nil if the Task does not use CSV iteration.
     # @param arguments [Hash] the arguments to persist to the Run and to make
     #   accessible to the Task.
-    # @param run_model [ActiveRecord] the Active Record Run class to use for
-    #   persisting information related to the Task.
     #
     # @return [Task] the Task that was run.
     #


### PR DESCRIPTION
Step 1 of shardm support in Shopify/shopify.

Allow the `Run` model to be injected into the Runner so that we can back maintenance tasks with different models in Shopify/shopify for shardm support.