### PR TITLE
Make Job class configurable per Task

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,29 @@ The Job class **must inherit** from `MaintenanceTasks::TaskJob`.
 Note that `retry_on` is not supported for custom Job classes, so failed jobs
 cannot be retried.
 
+#### Customizing the Job for a single Task
+
+A Job class can also be specified on an individual Task, overriding the global
+configuration, using `with_job_class`:
+
+```ruby
+# app/jobs/high_priority_job.rb
+
+class HighPriorityJob < MaintenanceTasks::TaskJob
+  queue_as :high_priority
+end
+
+# app/tasks/maintenance/really_important_task.rb
+
+module Maintenance
+  class ReallyImportantTask < MaintenanceTasks::Task
+    with_job_class "HighPriorityJob"
+    ...
+  end
+end
+```
+
+Again, the Job class must inherit from `MaintenanceTasks::TaskJob`.
 #### Customizing the rate at which task progress gets updated
 
 `MaintenanceTasks.ticker_delay` can be configured to customize how frequently

--- a/app/models/maintenance_tasks/runner.rb
+++ b/app/models/maintenance_tasks/runner.rb
@@ -80,13 +80,18 @@ module MaintenanceTasks
     end
 
     def instantiate_job(run)
-      job_class = begin
-        Task.named(run.task_name).job_class&.constantize ||
-          MaintenanceTasks.job.constantize
+      klass = begin
+        Task.named(run.task_name).job_class
       rescue Task::NotFoundError
-        MaintenanceTasks.job.constantize
+        MaintenanceTasks.job
       end
-      job_class.new(run)
+
+      case klass
+      when Proc
+        klass.call
+      when String
+        klass.constantize
+      end.new(run)
     end
   end
 end

--- a/app/models/maintenance_tasks/runner.rb
+++ b/app/models/maintenance_tasks/runner.rb
@@ -54,7 +54,7 @@ module MaintenanceTasks
         run.csv_file.attach(csv_file)
         run.csv_file.filename = filename(name)
       end
-      job = MaintenanceTasks.job.constantize.new(run)
+      job = instantiate_job(run)
       run.job_id = job.job_id
       yield run if block_given?
       run.enqueued!
@@ -77,6 +77,16 @@ module MaintenanceTasks
     def filename(task_name)
       formatted_task_name = task_name.underscore.gsub("/", "_")
       "#{Time.now.utc.strftime("%Y%m%dT%H%M%SZ")}_#{formatted_task_name}.csv"
+    end
+
+    def instantiate_job(run)
+      job_class = begin
+        Task.named(run.task_name).job_class&.constantize ||
+          MaintenanceTasks.job.constantize
+      rescue Task::NotFoundError
+        MaintenanceTasks.job.constantize
+      end
+      job_class.new(run)
     end
   end
 end

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -23,6 +23,8 @@ module MaintenanceTasks
     define_callbacks :start, :complete, :error, :cancel, :pause, :interrupt
 
     class << self
+      attr_reader :job_class
+
       # Finds a Task with the given name.
       #
       # @param name [String] the name of the Task to be found.
@@ -106,6 +108,13 @@ module MaintenanceTasks
         self.throttle_conditions += [
           { throttle_on: condition, backoff: backoff },
         ]
+      end
+
+      # Specify the Job class to use for this Task.
+      #
+      # @param job_class [String] the Job class to be used.
+      def with_job_class(job_class)
+        @job_class = job_class
       end
 
       # Initialize a callback to run after the task starts.

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -20,11 +20,11 @@ module MaintenanceTasks
     class_attribute :collection_builder_strategy,
       default: NullCollectionBuilder.new
 
+    class_attribute :job_class, default: -> { MaintenanceTasks.job.constantize }
+
     define_callbacks :start, :complete, :error, :cancel, :pause, :interrupt
 
     class << self
-      attr_reader :job_class
-
       # Finds a Task with the given name.
       #
       # @param name [String] the name of the Task to be found.
@@ -114,7 +114,7 @@ module MaintenanceTasks
       #
       # @param job_class [String] the Job class to be used.
       def with_job_class(job_class)
-        @job_class = job_class
+        self.job_class = job_class
       end
 
       # Initialize a callback to run after the task starts.

--- a/test/dummy/app/jobs/another_custom_task_job.rb
+++ b/test/dummy/app/jobs/another_custom_task_job.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AnotherCustomTaskJob < MaintenanceTasks::TaskJob
+  queue_as :custom_queue
+end

--- a/test/dummy/app/tasks/maintenance/custom_job_task.rb
+++ b/test/dummy/app/tasks/maintenance/custom_job_task.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module Maintenance
+  class CustomJobTask < MaintenanceTasks::Task
+    with_job_class "CustomTaskJob"
+
+    def collection
+      [1, 2]
+    end
+
+    def count
+      collection.count
+    end
+
+    def process(number)
+      Rails.logger.debug("number: #{number}")
+    end
+  end
+end

--- a/test/models/maintenance_tasks/runner_test.rb
+++ b/test/models/maintenance_tasks/runner_test.rb
@@ -162,6 +162,14 @@ module MaintenanceTasks
         run.csv_file.filename.to_s
     end
 
+    test "#run instantiates custom job if one is set on the task" do
+      expected_job_class = Maintenance::CustomJobTask.job_class.constantize
+
+      assert_enqueued_with(job: expected_job_class) do
+        @runner.run(name: "Maintenance::CustomJobTask")
+      end
+    end
+
     private
 
     def csv_io

--- a/test/models/maintenance_tasks/task_data_test.rb
+++ b/test/models/maintenance_tasks/task_data_test.rb
@@ -23,6 +23,7 @@ module MaintenanceTasks
       expected = [
         "Maintenance::CallbackTestTask",
         "Maintenance::CancelledEnqueueTask",
+        "Maintenance::CustomJobTask",
         "Maintenance::EnqueueErrorTask",
         "Maintenance::ErrorTask",
         "Maintenance::ImportPostsTask",

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -7,6 +7,7 @@ module MaintenanceTasks
       expected = [
         "Maintenance::CallbackTestTask",
         "Maintenance::CancelledEnqueueTask",
+        "Maintenance::CustomJobTask",
         "Maintenance::EnqueueErrorTask",
         "Maintenance::ErrorTask",
         "Maintenance::ImportPostsTask",
@@ -85,6 +86,11 @@ module MaintenanceTasks
       assert_equal(expected, Maintenance::TestTask.throttle_conditions)
     ensure
       Maintenance::TestTask.throttle_conditions = []
+    end
+
+    test ".with_job_class sets job class on Task" do
+      Maintenance::TestTask.with_job_class("AnotherCustomTaskJob")
+      assert_equal("AnotherCustomTaskJob", Maintenance::TestTask.job_class)
     end
   end
 end

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -20,6 +20,7 @@ module MaintenanceTasks
         "New Tasks",
         "Maintenance::CallbackTestTask\nNew",
         "Maintenance::CancelledEnqueueTask\nNew",
+        "Maintenance::CustomJobTask\nNew",
         "Maintenance::EnqueueErrorTask\nNew",
         "Maintenance::ErrorTask\nNew",
         "Maintenance::ImportPostsTask\nNew",


### PR DESCRIPTION
## Motivation

To support tasks in the global ("master") context in Shopify/shopify, we need to use a separate job class that disables all of the automatic pod selection logic. This is done at load time, so I don't think there's a way to handle this other than using distinct job classes to handle non-podded vs podded tasks.

One possible way to accomplish this is to inject the job class into the runner, just as we're doing with the `run_model`. See https://github.com/Shopify/maintenance_tasks/pull/498/commits/1cce03d2cac084dd2a7a7c8342d5007b495bcb50

However, we'd [previously discussed](https://github.com/Shopify/maintenance_tasks/pull/96#pullrequestreview-517821649) allowing job classes to be configured on a per-task basis, so I figured I'd put this up and see how we felt about it. IMO, while allowing the job to be injected into the Runner serves us for Core, it isn't that useful for generic gem users. A class-level method on `Task` seems to be a more appropriate solution in terms of bringing value to _all_ users of the gem (not just for our own use case in Core), and as much as possible I think we should try to keep code out of the gem that's _just_ for Core.

The counter-argument is that this gives users too much flexibility. But I think if we keep the app-level config it's okay.

## Solution

Offer a `with_job_class` (needs a better name?) macro that can be set on a Task class, in order to configure the job class to use for that Task. We can keep the app-level config -- this value will only take precedence if it's set.

Thoughts?

## To Do
- [ ] Add docs