### PR TITLE
Avoid iteration for stopping race condition

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -177,6 +177,7 @@ module MaintenanceTasks
     #
     # If the run is stopping already, it will not transition to running.
     def running
+      return if stopping?
       updated = self.class.where(id: id).where.not(status: STOPPING_STATUSES)
         .update_all(status: :running, updated_at: Time.now) > 0
       if updated

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -183,6 +183,8 @@ module MaintenanceTasks
       if updated
         self.status = :running
         clear_attribute_changes([:status])
+      else
+        reload_status
       end
     end
 

--- a/test/dummy/app/jobs/custom_task_job.rb
+++ b/test/dummy/app/jobs/custom_task_job.rb
@@ -6,4 +6,10 @@ class CustomTaskJob < MaintenanceTasks::TaskJob
     raise "Error enqueuing" if run.task_name == "Maintenance::EnqueueErrorTask"
     throw :abort if run.task_name == "Maintenance::CancelledEnqueueTask"
   end
+
+  class_attribute :race_condition_hook, instance_accessor: false
+
+  before_perform(prepend: true) do
+    CustomTaskJob.race_condition_hook&.call
+  end
 end

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -247,6 +247,18 @@ module MaintenanceTasks
       end
     end
 
+    test "#running doesn't set a stopping run to running and reloads the status" do
+      [:cancelling, :pausing].each do |status|
+        run = Run.create!(
+          task_name: "Maintenance::UpdatePostsTask",
+        )
+        Run.find(run.id).update(status: status) # race condition
+        run.running
+
+        assert_equal status.to_s, run.status
+      end
+    end
+
     test "#cancel transitions the Run to cancelling if not paused" do
       [:enqueued, :running, :pausing, :interrupted].each do |status|
         run = Run.create!(

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -235,13 +235,13 @@ module MaintenanceTasks
       end
     end
 
-    test "#running doesn't set a stopping run to running" do
+    test "#running doesn't set a stopping run to running without a query" do
       [:cancelling, :pausing].each do |status|
         run = Run.create!(
           task_name: "Maintenance::UpdatePostsTask",
           status: status,
         )
-        run.running
+        assert_equal 0, count_uncached_queries { run.running }
 
         refute_predicate run, :running?
       end


### PR DESCRIPTION
Follow-up to #515

First, we can entirely avoid the "optimistic update" if the run is already stopping, like we were doing before in the non-race-condition case.
Also, since we know whether or not the record was updated, we know it was indeed stopping (but not its actual status), so we can prevent even a single iteration from happening (but we have to reload to get the actual status to either moved to paused or cancelled).

I tested the first point by re-using `count_uncached_queries`.
For the second point, I tested it by simulating a race condition for the model, but I also added a test at the job level for good measure. It also causes the race condition by running in a `before_perform` callback. This runs after Active Job deserializing the Run, but since it's prepended, before `TaskJobConcern#before_perform`, when we do the optimistic update.