### PR TITLE
Remove a Selenium warning

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -22,7 +22,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   end
 
   teardown do
-    assert_empty page.driver.browser.manage.logs.get(:browser)
+    assert_empty page.driver.browser.logs.get(:browser)
     FileUtils.rm_rf("test/dummy/tmp/downloads")
   end
 end


### PR DESCRIPTION
Remove one warning introduced in #511.

There's still one but we can't really do anything about it, it's fixed in Rails in https://github.com/rails/rails/commit/7f2b89faef4d4fcf186e7ff940f395ae9ba7a0b5