### PR TITLE
Bump version to 1.6.0 so we can put out a release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    maintenance_tasks (1.5.0)
+    maintenance_tasks (1.6.0)
       actionpack (>= 6.0)
       activejob (>= 6.0)
       activerecord (>= 6.0)

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "maintenance_tasks"
-  spec.version = "1.5.0"
+  spec.version = "1.6.0"
   spec.author = "Shopify Engineering"
   spec.email = "gems@shopify.com"
   spec.homepage = "https://github.com/Shopify/maintenance_tasks"


### PR DESCRIPTION
We're hoping to use commit https://github.com/Shopify/maintenance_tasks/commit/de3a0b990430b32a0a892b32d5f5af18dc976466, but would prefer not to tag to a specific commit in our repository. It looks like the last version bump was in July, so I figured it's worth putting out a new version. Let me know if I missed anything!