### PR TITLE
Ignore Selenium warning we don't control

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -6,6 +6,15 @@ require "action_dispatch/system_testing/server"
 
 ActionDispatch::SystemTesting::Server.silence_puma = true
 
+if Rails::VERSION::MAJOR < 7
+  # Necessary so that Capybara::Selenium::DeprecationSuppressor is prepended in
+  # Selenium::WebDriver::Logger before it is instantiated in
+  # Selenium::WebDriver.logger to prevent an uninitialized instance variable
+  # warning.
+  Capybara::Selenium::Driver.load_selenium
+  Selenium::WebDriver.logger.ignore(:browser_options)
+end
+
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include ActiveJob::TestHelper
 


### PR DESCRIPTION
Since it's due to Rails' system tests and fixed there for Rails 7, we can ignore the warning for previous versions.