### PR TITLE
Support Sorbet-annotated task code display in task UI

### DIFF
--- a/app/models/maintenance_tasks/task_data.rb
+++ b/app/models/maintenance_tasks/task_data.rb
@@ -74,7 +74,11 @@ module MaintenanceTasks
     def code
       return if deleted?
       task = Task.named(name)
-      file = task.instance_method(:process).source_location.first
+      file = if Object.respond_to?(:const_source_location)
+        Object.const_source_location(task.name).first
+      else
+        task.instance_method(:process).source_location.first
+      end
       File.read(file)
     end
 

--- a/test/dummy/app/tasks/maintenance/update_posts_module_prepended_task.rb
+++ b/test/dummy/app/tasks/maintenance/update_posts_module_prepended_task.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_module"
+
+module Maintenance
+  class UpdatePostsModulePrependedTask < MaintenanceTasks::Task
+    prepend TestModule
+
+    class << self
+      attr_accessor :fast_task
+    end
+
+    def collection
+      Post.all
+    end
+
+    def count
+      collection.count
+    end
+
+    def process(post)
+      sleep(1) unless self.class.fast_task
+
+      post.update!(content: "New content added on #{Time.now.utc}")
+    end
+  end
+end

--- a/test/dummy/lib/test_module.rb
+++ b/test/dummy/lib/test_module.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module TestModule
+  def process(_post)
+    super
+  end
+end

--- a/test/models/maintenance_tasks/task_data_test.rb
+++ b/test/models/maintenance_tasks/task_data_test.rb
@@ -30,6 +30,7 @@ module MaintenanceTasks
         "Maintenance::ParamsTask",
         "Maintenance::TestTask",
         "Maintenance::UpdatePostsInBatchesTask",
+        "Maintenance::UpdatePostsModulePrependedTask",
         "Maintenance::UpdatePostsTask",
         "Maintenance::UpdatePostsThrottledTask",
       ]
@@ -46,8 +47,15 @@ module MaintenanceTasks
     test "#code returns the code source of the Task" do
       task_data = TaskData.new("Maintenance::UpdatePostsTask")
 
-      assert_equal "class UpdatePostsTask < MaintenanceTasks::Task",
-        task_data.code.each_line.grep(/UpdatePostsTask/).first.squish
+      assert_includes task_data.code,
+        "class UpdatePostsTask < MaintenanceTasks::Task"
+    end
+
+    test "#code returns the code source of a Task with a prepended module" do
+      task_data = TaskData.new("Maintenance::UpdatePostsModulePrependedTask")
+
+      assert_includes task_data.code,
+        "class UpdatePostsModulePrependedTask < MaintenanceTasks::Task"
     end
 
     test "#code returns nil if the Task does not exist" do

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -14,6 +14,7 @@ module MaintenanceTasks
         "Maintenance::ParamsTask",
         "Maintenance::TestTask",
         "Maintenance::UpdatePostsInBatchesTask",
+        "Maintenance::UpdatePostsModulePrependedTask",
         "Maintenance::UpdatePostsTask",
         "Maintenance::UpdatePostsThrottledTask",
       ]

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -26,6 +26,7 @@ module MaintenanceTasks
         "Maintenance::ParamsTask\nNew",
         "Maintenance::TestTask\nNew",
         "Maintenance::UpdatePostsInBatchesTask\nNew",
+        "Maintenance::UpdatePostsModulePrependedTask\nNew",
         "Maintenance::UpdatePostsThrottledTask\nNew",
         "Completed Tasks",
         "Maintenance::UpdatePostsTask\nSucceeded",


### PR DESCRIPTION
Preamble: I'm not sure this is something that you all would like to support (especially since it adds Sorbet as a development/test dependency just to support the test). I figured I'd open the pull request and if it should be closed right away, that's fine from my side! 🎉 

Please let me know if I've missed any steps or if this is the wrong approach. If there are additional changes you'd like, I'm more than happy to make them as well. Thank you!

### Issue

Gem versions: `1.5.0`, `1.6.0`
Ruby versions: `2.7.2`, `3.0.2p107`
Rails versions: `6.0.4`, `6.1.4.1`

After creating a new task recently (and with `sorbet-runtime` enabled), I noticed that the source code display in the UI returns source for [Sorbet's `T::Private::Methods` module](https://github.com/sorbet/sorbet/blob/master/gems/sorbet-runtime/lib/types/private/methods/_methods.rb) instead of the maintenance task itself. This makes sense based on what I see in the current `MaintenanceTasks::TaskData#code` implementation. I realize that this might not be a common enough problem though depending on how often `sorbet-runtime` is enabled/disabled in production and further, how often developers are adding type annotations to tasks.

#### Expected (and fixed) behavior:

Task source code is visible when viewed in the UI.

<img width="1571" alt="Screen Shot 2021-11-09 at 10 36 11 AM" src="https://user-images.githubusercontent.com/88166822/140984318-5804f28b-c514-4539-ab71-5a8035804d3b.png">

#### Current behavior:

Sorbet source code is visible when viewed in the UI.

<img width="1579" alt="Screen Shot 2021-11-09 at 10 36 36 AM" src="https://user-images.githubusercontent.com/88166822/140984338-ba2f827c-08e8-4b70-ba29-1f59242960d7.png">

### Approach

[`Module::const_source_location` added in Ruby 2.7](https://ruby-doc.org/core-2.7.0/Module.html#method-i-const_source_location) appears to meet this need and returns the correct source whether using Sorbet or not. I've guarded against the method presence to allow backward compatibility with older Ruby versions. However, I see the target Ruby version might be 2.7+ so if I should remove the conditional, please let me know.

### Release Notes (Patch)

##### Fixes
- `MaintenanceTasks::Task`s with prepended modules (e.g. Sorbet-annotated tasks) will correctly display the source code of the task when viewed in the UI.