### PR TITLE
Revert "Drop support for classic autoloading"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,6 @@ take a look at the [Active Job documentation][active-job-docs].
 [async-adapter]: https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/AsyncAdapter.html
 [active-job-docs]: https://guides.rubyonrails.org/active_job_basics.html#setting-the-backend
 
-
-### Autoloading
-
-The Maintenance Tasks framework does not support autoloading in `:classic` mode.
-Please ensure your application is using [Zeitwerk](https://github.com/fxn/zeitwerk) to load your code.
-For more information, please consult the [Rails guides on autoloading and reloading constants](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html).
-
 ## Usage
 
 ### Creating a Task

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -17,6 +17,11 @@ module Dummy
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults("#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}")
 
+    if ENV["CLASSIC_AUTOLOADER"].present?
+      puts "=> Using classic autoloader"
+      config.autoloader = :classic
+    end
+
     config.to_prepare do
       MaintenanceTasks.job = "CustomTaskJob"
     end


### PR DESCRIPTION
Reverts Shopify/maintenance_tasks#529

We can revert this revert once we've properly deprecated classic autoloading.