### PR TITLE
Render task default attributes on the form

### DIFF
--- a/app/helpers/maintenance_tasks/tasks_helper.rb
+++ b/app/helpers/maintenance_tasks/tasks_helper.rb
@@ -100,5 +100,11 @@ module MaintenanceTasks
         only_path: true
       )
     end
+
+    # @param task_data [TaskData] an instance of the TaskData.
+    # @return [MaintenanceTasks::Task] an instance of a task class.
+    def task_object_for(task_data)
+      MaintenanceTasks::Task.named(task_data.name).new
+    end
   end
 end

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -31,14 +31,15 @@
           <%= form.file_field :csv_file %>
         </div>
       <% end %>
-      <% if @task.parameter_names.any? %>
+      <% parameter_names = @task.parameter_names %>
+      <% if parameter_names.any? %>
         <div class="block">
-          <%= form.fields_for :task_arguments do |ff| %>
-            <% @task.parameter_names.each do |parameter| %>
+          <%= form.fields_for :task_arguments, task_object_for(@task) do |ff| %>
+            <% parameter_names.each do |parameter_name| %>
               <div class="field">
-                <%= ff.label parameter, parameter, class: "label is-family-monospace" %>
+                <%= ff.label parameter_name, parameter_name, class: "label is-family-monospace" %>
                 <div class="control">
-                  <%= ff.text_area parameter, class: "textarea" %>
+                  <%= ff.text_area parameter_name, class: "textarea" %>
                 </div>
               </div>
             <% end %>

--- a/test/dummy/app/tasks/maintenance/params_task.rb
+++ b/test/dummy/app/tasks/maintenance/params_task.rb
@@ -8,6 +8,9 @@ module Maintenance
       presence: true,
       format: { with: /\A(\s?\d+(,\s?\d+\s?)*)\z/, allow_blank: true }
 
+    attribute :content, :string, default: "default content"
+    attribute :integer_attr, :integer, default: 111_222_333
+
     class << self
       attr_accessor :fast_task
     end

--- a/test/helpers/maintenance_tasks/tasks_helper_test.rb
+++ b/test/helpers/maintenance_tasks/tasks_helper_test.rb
@@ -87,5 +87,10 @@ module MaintenanceTasks
       assert_match %r{rails/active_storage/blobs/\S+/sample.csv},
         csv_file_download_path(run)
     end
+
+    test "#task_object_for returns an instance of the task represented by a TaskData object" do
+      obj = task_object_for(TaskData.new("Maintenance::ParamsTask"))
+      assert_kind_of Maintenance::ParamsTask, obj
+    end
   end
 end

--- a/test/models/maintenance_tasks/task_data_test.rb
+++ b/test/models/maintenance_tasks/task_data_test.rb
@@ -149,12 +149,13 @@ module MaintenanceTasks
     end
 
     test "#parameter_names returns list of parameter names for Tasks supporting parameters" do
-      assert_equal ["post_ids"],
+      assert_equal ["post_ids", "content", "integer_attr"],
         TaskData.new("Maintenance::ParamsTask").parameter_names
     end
 
     test "#parameter_names returns empty list for deleted Tasks" do
-      assert_empty TaskData.new("Maintenance::DoesNotExist").parameter_names
+      names = TaskData.new("Maintenance::DoesNotExist").parameter_names
+      assert_equal [], names
     end
   end
 end

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -44,6 +44,17 @@ module MaintenanceTasks
       assert_text "Ran for less than 5 seconds, finished 8 days ago."
     end
 
+    test "task with attributes renders default values on the form" do
+      visit maintenance_tasks_path
+
+      click_on("Maintenance::ParamsTask")
+
+      content_text = page.find_field("[task_arguments][content]").text
+      assert_equal("default content", content_text)
+      integer_attr_text = page.find_field("[task_arguments][integer_attr]").text
+      assert_equal("111222333", integer_attr_text)
+    end
+
     test "view a Task with multiple pages of Runs" do
       Run.create!(
         task_name: "Maintenance::TestTask",


### PR DESCRIPTION
Addresses - https://github.com/Shopify/maintenance_tasks/issues/485

Currently blank attribute values passed from the form override all default values

The solution is far from being perfect but seems to be the most reasonable from UX point of view.
It seems helpful to render default values on the form so anyone can be aware of them just by looking on the UI 

Example:
![image](https://user-images.githubusercontent.com/5512772/142493408-0e1be576-4647-40a3-aef0-bbf00e902a32.png)


### Solution details

Using an instance of a task class seems to be the most appropriate and most publicly available API at the moment to get default values