### PR TITLE
Move Task instantiation to TaskData

### DIFF
--- a/app/helpers/maintenance_tasks/tasks_helper.rb
+++ b/app/helpers/maintenance_tasks/tasks_helper.rb
@@ -100,11 +100,5 @@ module MaintenanceTasks
         only_path: true
       )
     end
-
-    # @param task_data [TaskData] an instance of the TaskData.
-    # @return [MaintenanceTasks::Task] an instance of a task class.
-    def task_object_for(task_data)
-      MaintenanceTasks::Task.named(task_data.name).new
-    end
   end
 end

--- a/app/models/maintenance_tasks/task_data.rb
+++ b/app/models/maintenance_tasks/task_data.rb
@@ -146,8 +146,10 @@ module MaintenanceTasks
       end
     end
 
-    # @return [MaintenanceTasks::Task] an instance of a task class.
+    # @return [MaintenanceTasks::Task, nil] an instance of the Task class.
+    # @return [nil] if the Task file was deleted.
     def new
+      return if deleted?
       MaintenanceTasks::Task.named(name).new
     end
 

--- a/app/models/maintenance_tasks/task_data.rb
+++ b/app/models/maintenance_tasks/task_data.rb
@@ -146,6 +146,11 @@ module MaintenanceTasks
       end
     end
 
+    # @return [MaintenanceTasks::Task] an instance of a task class.
+    def new
+      MaintenanceTasks::Task.named(name).new
+    end
+
     private
 
     def runs

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -34,7 +34,7 @@
       <% parameter_names = @task.parameter_names %>
       <% if parameter_names.any? %>
         <div class="block">
-          <%= form.fields_for :task_arguments, task_object_for(@task) do |ff| %>
+          <%= form.fields_for :task_arguments, @task.new do |ff| %>
             <% parameter_names.each do |parameter_name| %>
               <div class="field">
                 <%= ff.label parameter_name, parameter_name, class: "label is-family-monospace" %>

--- a/test/helpers/maintenance_tasks/tasks_helper_test.rb
+++ b/test/helpers/maintenance_tasks/tasks_helper_test.rb
@@ -87,10 +87,5 @@ module MaintenanceTasks
       assert_match %r{rails/active_storage/blobs/\S+/sample.csv},
         csv_file_download_path(run)
     end
-
-    test "#task_object_for returns an instance of the task represented by a TaskData object" do
-      obj = task_object_for(TaskData.new("Maintenance::ParamsTask"))
-      assert_kind_of Maintenance::ParamsTask, obj
-    end
   end
 end

--- a/test/models/maintenance_tasks/task_data_test.rb
+++ b/test/models/maintenance_tasks/task_data_test.rb
@@ -169,5 +169,9 @@ module MaintenanceTasks
     test "#new returns a Task instance" do
       assert_kind_of Task, TaskData.new("Maintenance::ParamsTask").new
     end
+
+    test "#new returns nil for a deleted Task" do
+      assert_nil TaskData.new("Maintenance::DoesNotExist").new
+    end
   end
 end

--- a/test/models/maintenance_tasks/task_data_test.rb
+++ b/test/models/maintenance_tasks/task_data_test.rb
@@ -165,5 +165,9 @@ module MaintenanceTasks
       names = TaskData.new("Maintenance::DoesNotExist").parameter_names
       assert_equal [], names
     end
+
+    test "#new returns a Task instance" do
+      assert_kind_of Task, TaskData.new("Maintenance::ParamsTask").new
+    end
   end
 end


### PR DESCRIPTION
Follow up to #532

I feel like the presenter is a good place to deal with this, TaskData takes the place of a Task class in views (we even call its instance `@task`), so since we want `Task.new` to instantiate a task and get its attributes for defaults, we can use instead `TaskData#new`.

Also added an edge case about deleted Tasks. It's not strictly necessary since `parameter_names` is empty when the task is deleted, and we don't show the form and instantiate the Task in that situation, but it's more for completeness.