### PR TITLE
[PoC] Introduce approved task runs

### DIFF
--- a/app/helpers/maintenance_tasks/tasks_helper.rb
+++ b/app/helpers/maintenance_tasks/tasks_helper.rb
@@ -9,6 +9,8 @@ module MaintenanceTasks
   module TasksHelper
     STATUS_COLOURS = {
       "new" => ["is-primary"],
+      "pending_approval" => ["is-primary"],
+      "approved" => ["is-primary"],
       "enqueued" => ["is-primary is-light"],
       "running" => ["is-info"],
       "interrupted" => ["is-info", "is-light"],

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -7,18 +7,22 @@ module MaintenanceTasks
   class Run < ApplicationRecord
     # Various statuses a run can be in.
     STATUSES = [
-      :enqueued,    # The task has been enqueued by the user.
-      :running,     # The task is being performed by a job worker.
-      :succeeded,   # The task finished without error.
-      :cancelling,  # The task has been told to cancel but is finishing work.
-      :cancelled,   # The user explicitly halted the task's execution.
-      :interrupted, # The task was interrupted by the job infrastructure.
-      :pausing,     # The task has been told to pause but is finishing work.
-      :paused,      # The task was paused in the middle of the run by the user.
-      :errored,     # The task code produced an unhandled exception.
+      :pending_approval, # The task has been submitted and is waiting for approval.
+      :approved,         # The task was approved and can be enqueued.
+      :enqueued,         # The task has been enqueued by the user.
+      :running,          # The task is being performed by a job worker.
+      :succeeded,        # The task finished without error.
+      :cancelling,       # The task has been told to cancel but is finishing work.
+      :cancelled,        # The user explicitly halted the task's execution.
+      :interrupted,      # The task was interrupted by the job infrastructure.
+      :pausing,          # The task has been told to pause but is finishing work.
+      :paused,           # The task was paused in the middle of the run by the user.
+      :errored,          # The task code produced an unhandled exception.
     ]
 
     ACTIVE_STATUSES = [
+      :pending_approval,
+      :approved,
       :enqueued,
       :running,
       :paused,

--- a/app/validators/maintenance_tasks/run_status_validator.rb
+++ b/app/validators/maintenance_tasks/run_status_validator.rb
@@ -8,6 +8,8 @@ module MaintenanceTasks
   class RunStatusValidator < ActiveModel::Validator
     # Valid status transitions a Run can make.
     VALID_STATUS_TRANSITIONS = {
+      "pending_approval" => ["approved"],
+      "approved" => ["enqueued"],
       # enqueued -> running occurs when the task starts performing.
       # enqueued -> pausing occurs when the task is paused before starting.
       # enqueued -> cancelling occurs when the task is cancelled

--- a/app/views/maintenance_tasks/runs/info/_approved.html.erb
+++ b/app/views/maintenance_tasks/runs/info/_approved.html.erb
@@ -1,0 +1,1 @@
+<p>Task run approved.</p>

--- a/app/views/maintenance_tasks/runs/info/_pending_approval.html.erb
+++ b/app/views/maintenance_tasks/runs/info/_pending_approval.html.erb
@@ -1,0 +1,1 @@
+<p>This task run is pending approval.</p>

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -23,7 +23,34 @@
 <% end %>
 
 <div class="buttons">
-  <% if last_run.nil? || last_run.completed? %>
+  <% if last_run.present? && last_run.pending_approval? %>
+    <%= form_with url: approve_task_path(@task), method: :put do |form| %>
+      <% if @task.csv_task? %>
+        <div class="block">
+          <%= form.label :csv_file %>
+          <%= form.file_field :csv_file %>
+        </div>
+      <% end %>
+      <% parameter_names = @task.parameter_names %>
+      <% if parameter_names.any? %>
+        <div class="block">
+          <%= form.fields_for :task_arguments, @task.new do |ff| %>
+            <% parameter_names.each do |parameter_name| %>
+              <div class="field">
+                <%= ff.label parameter_name, parameter_name, class: "label is-family-monospace" %>
+                <div class="control">
+                  <%= ff.text_area parameter_name, class: "textarea" %>
+                </div>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
+      <div class="block">
+        <%= form.submit 'Approve run', class: "button is-success", disabled: @is_creator %>
+      </div>
+    <% end %>
+  <% elsif last_run.present? && last_run.approved? %>
     <%= form_with url: run_task_path(@task), method: :put do |form| %>
       <% if @task.csv_task? %>
         <div class="block">
@@ -48,6 +75,37 @@
       <% end %>
       <div class="block">
         <%= form.submit 'Run', class: "button is-success", disabled: @task.deleted? %>
+      </div>
+    <% end %>
+  <% elsif last_run.nil? || last_run.completed? %>
+    <%= form_with url: MaintenanceTasks.approved_runs_only ? request_run_task_path(@task) : run_task_path(@task), method: :put do |form| %>
+      <% if @task.csv_task? %>
+        <div class="block">
+          <%= form.label :csv_file %>
+          <%= form.file_field :csv_file %>
+        </div>
+      <% end %>
+      <% parameter_names = @task.parameter_names %>
+      <% if parameter_names.any? %>
+        <div class="block">
+          <%= form.fields_for :task_arguments, @task.new do |ff| %>
+            <% parameter_names.each do |parameter_name| %>
+              <div class="field">
+                <%= ff.label parameter_name, parameter_name, class: "label is-family-monospace" %>
+                <div class="control">
+                  <%= ff.text_area parameter_name, class: "textarea" %>
+                </div>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
+      <div class="block">
+        <% if MaintenanceTasks.approved_runs_only %>
+          <%= form.submit 'Request run', class: "button is-success", disabled: @task.deleted? %>
+        <% else %>
+          <%= form.submit 'Run', class: "button is-success", disabled: @task.deleted? %>
+        <% end %>
       </div>
     <% end %>
   <% elsif last_run.cancelling? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@
 MaintenanceTasks::Engine.routes.draw do
   resources :tasks, only: [:index, :show], format: false do
     member do
+      put "request_run"
+      put "approve"
       put "run"
     end
 

--- a/db/migrate/20211126151216_add_creator_and_approval_to_maintenance_tasks_runs.rb
+++ b/db/migrate/20211126151216_add_creator_and_approval_to_maintenance_tasks_runs.rb
@@ -1,0 +1,6 @@
+class AddCreatorAndApprovalToMaintenanceTasksRuns < ActiveRecord::Migration[6.1]
+  def change
+    add_column(:maintenance_tasks_runs, :creator, :string)
+    add_column(:maintenance_tasks_runs, :approver, :string)
+  end
+end

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -63,6 +63,10 @@ module MaintenanceTasks
   #     use when cleaning a Run's backtrace.
   mattr_accessor :backtrace_cleaner
 
+  mattr_accessor :approved_runs_only, default: false
+
+  mattr_accessor :current_user_identifier
+
   # @private
   def self.error_handler
     return @error_handler if defined?(@error_handler)


### PR DESCRIPTION
This is a follow-up to this spike: https://docs.google.com/document/d/1cAhQ0WUnR7fc_xNHl_HWKebGXSQwyqp3fHUIeZIfb74/edit

This draft PoC introduces the concept of approved runs to the maintenance_tasks gem. Please note that this code is not at all production-ready and is a work in progress for the purpose of proof of concept.