### PR TITLE
Revert "Bump job-iteration from 1.3.0 to 1.3.3"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,9 +91,9 @@ GEM
     erubi (1.10.0)
     globalid (0.5.2)
       activesupport (>= 5.0)
-    i18n (1.8.11)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    job-iteration (1.3.3)
+    job-iteration (1.3.0)
       activejob (>= 5.2)
     loofah (2.12.0)
       crass (~> 1.0.2)
@@ -203,7 +203,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.26)
-    zeitwerk (2.5.1)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Reverts Shopify/maintenance_tasks#536