### PR TITLE
Ignore tasks defined outside of Task module

### DIFF
--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -37,6 +37,13 @@ module MaintenanceTasks
         unless task.is_a?(Class) && task < Task
           raise NotFoundError.new("#{name} is not a Task.", name)
         end
+        unless task.module_parent_name == MaintenanceTasks.tasks_module
+          raise NotFoundError.new(
+            "#{name} is not defined in "\
+              "the #{MaintenanceTasks.tasks_module} module.",
+            name
+          )
+        end
         task
       end
 
@@ -46,7 +53,9 @@ module MaintenanceTasks
       # @return [Array<Class>] the list of classes.
       def available_tasks
         load_constants
-        descendants
+        descendants.select do |task|
+          task.module_parent_name == MaintenanceTasks.tasks_module
+        end
       end
 
       # Make this Task a task that handles CSV.

--- a/test/dummy/app/tasks/ignored_task.rb
+++ b/test/dummy/app/tasks/ignored_task.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class IgnoredTask < MaintenanceTasks::Task
+  def collection
+    []
+  end
+
+  def process(_element)
+  end
+end

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -22,6 +22,12 @@ module MaintenanceTasks
         MaintenanceTasks::Task.available_tasks.map(&:name).sort
     end
 
+    test ".available_tasks ignores tasks not defined in the module" do
+      _ = IgnoredTask
+      assert_not_includes MaintenanceTasks::Task.available_tasks.map(&:name),
+        "IgnoredTask"
+    end
+
     test ".named returns the task based on its name" do
       expected_task = Maintenance::UpdatePostsTask
       assert_equal expected_task, Task.named("Maintenance::UpdatePostsTask")
@@ -41,6 +47,15 @@ module MaintenanceTasks
       end
       assert_equal "Array is not a Task.", error.message
       assert_equal "Array", error.name
+    end
+
+    test ".named raises Not Found Error if the name refers to a Task outside of tasks_module" do
+      error = assert_raises(Task::NotFoundError) do
+        Task.named("IgnoredTask")
+      end
+      assert_equal "IgnoredTask is not defined in the Maintenance module.",
+        error.message
+      assert_equal "IgnoredTask", error.name
     end
 
     test ".process calls #process" do


### PR DESCRIPTION
This changes the gem to only consider Tasks (MaintenanceTasks::Task subclasses) defined in the `MaintenanceTasks.tasks_module` (`Maintenance` by default).

Previously it was possible to define a Task anywhere:

* It wouldn't show in the list by default in development (the constant would not have been loaded).
* It would show in production though.
* In any case it was possible to access the task URL directly and start running.
* Running would work normally.

I think the first point in particular is not ideal, and we have no way of finding all the subclasses without knowing where to look for them when eager loading is not on.

With these changes:
* Accessing the URL directly doesn't work.
* Running will cause a validation error (using Runner or the command line).

This is a breaking change but it's also a use case that wasn't supported so I think it's OK to do this.