### PR TITLE
Clarify newline must be at EOF of CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ title,content
 My Title,Hello World!
 ```
 
-The files uploaded to your Active Storage service provider will be renamed first
+The files uploaded to your Active Storage service provider will be renamed
 to include an ISO8601 timestamp and the Task name in snake case format.
+The CSV is expected to have a trailing newline at the end of the file.
 
 ### Processing Batch Collections
 

--- a/app/models/maintenance_tasks/csv_collection_builder.rb
+++ b/app/models/maintenance_tasks/csv_collection_builder.rb
@@ -15,9 +15,10 @@ module MaintenanceTasks
       CSV.new(task.csv_content, headers: true)
     end
 
-    # The number of rows to be processed. Excludes the header row from the count
-    # and assumed a trailing new line in the CSV file. Note that this number is
-    # an approximation based on the number of new lines.
+    # The number of rows to be processed. Excludes the header row from the
+    # count and assumes a trailing newline is at the end of the CSV file.
+    # Note that this number is an approximation based on the number of
+    # newlines.
     #
     # @return [Integer] the approximate number of rows to process.
     def count(task)


### PR DESCRIPTION
Clarify that CSV uploads must have a newline at the end of the file for counts to be accurate.