### PR TITLE
Optimistic locking + fix data races

### DIFF
--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -122,8 +122,7 @@ module MaintenanceTasks
     end
 
     def on_complete
-      @run.status = :succeeded
-      @run.ended_at = Time.now
+      @run.complete
     end
 
     # We are reopening a private part of Job Iteration's API here, so we should

--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -12,8 +12,8 @@ module MaintenanceTasks
       before_perform(:before_perform)
 
       on_start(:on_start)
-      on_complete(:on_complete)
       on_shutdown(:on_shutdown)
+      on_complete(:on_complete)
 
       after_perform(:after_perform)
 
@@ -115,23 +115,15 @@ module MaintenanceTasks
       @run.start(count)
     end
 
+    def on_shutdown
+      @run.job_shutdown
+      @run.cursor = cursor_position
+      @ticker.persist
+    end
+
     def on_complete
       @run.status = :succeeded
       @run.ended_at = Time.now
-    end
-
-    def on_shutdown
-      if @run.cancelling?
-        @run.status = :cancelled
-        @run.ended_at = Time.now
-      elsif @run.pausing?
-        @run.status = :paused
-      else
-        @run.status = :interrupted
-      end
-
-      @run.cursor = cursor_position
-      @ticker.persist
     end
 
     # We are reopening a private part of Job Iteration's API here, so we should

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -249,6 +249,9 @@ module MaintenanceTasks
     def start(count)
       update!(started_at: Time.now, tick_total: count)
       run_task_callbacks(:start)
+    rescue ActiveRecord::StaleObjectError
+      reload_status
+      retry
     end
 
     def job_shutdown

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -214,6 +214,17 @@ module MaintenanceTasks
       run_task_callbacks(:start)
     end
 
+    def job_shutdown
+      if cancelling?
+        self.status = :cancelled
+        self.ended_at = Time.now
+      elsif pausing?
+        self.status = :paused
+      else
+        self.status = :interrupted
+      end
+    end
+
     # Cancels a Run.
     #
     # If the Run is paused, it will transition directly to cancelled, since the

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -102,6 +102,11 @@ module MaintenanceTasks
         time_running: duration,
         touch: true
       )
+      if locking_enabled?
+        locking_column = self.class.locking_column
+        self[locking_column] += 1
+        clear_attribute_change(locking_column)
+      end
     end
 
     # Marks the run as errored and persists the error data.

--- a/db/migrate/20211210152329_add_lock_version_to_maintenance_tasks_runs.rb
+++ b/db/migrate/20211210152329_add_lock_version_to_maintenance_tasks_runs.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddLockVersionToMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
+  def change
+    add_column(:maintenance_tasks_runs, :lock_version, :integer,
+      default: 0, null: false)
+  end
+end

--- a/test/dummy/app/jobs/custom_task_job.rb
+++ b/test/dummy/app/jobs/custom_task_job.rb
@@ -8,8 +8,13 @@ class CustomTaskJob < MaintenanceTasks::TaskJob
   end
 
   class_attribute :race_condition_hook, instance_accessor: false
+  class_attribute :race_condition_after_hook, instance_accessor: false
 
   before_perform(prepend: true) do
     CustomTaskJob.race_condition_hook&.call
+  end
+
+  after_perform do
+    CustomTaskJob.race_condition_after_hook&.call
   end
 end

--- a/test/dummy/app/jobs/custom_task_job.rb
+++ b/test/dummy/app/jobs/custom_task_job.rb
@@ -9,6 +9,7 @@ class CustomTaskJob < MaintenanceTasks::TaskJob
 
   class_attribute :race_condition_hook, instance_accessor: false
   class_attribute :race_condition_after_hook, instance_accessor: false
+  class_attribute :race_condition_prepended_after_hook, instance_accessor: false
 
   before_perform(prepend: true) do
     CustomTaskJob.race_condition_hook&.call
@@ -16,5 +17,9 @@ class CustomTaskJob < MaintenanceTasks::TaskJob
 
   after_perform do
     CustomTaskJob.race_condition_after_hook&.call
+  end
+
+  after_perform(prepend: true) do
+    CustomTaskJob.race_condition_prepended_after_hook&.call
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_17_131953) do
+ActiveRecord::Schema.define(version: 2021_12_10_152329) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2021_05_17_131953) do
     t.datetime "updated_at", precision: 6, null: false
     t.text "arguments"
     t.index ["task_name", "created_at"], name: "index_maintenance_tasks_runs_on_task_name_and_created_at"
+    t.integer "lock_version", default: 0, null: false
   end
 
   create_table "posts", force: :cascade do |t|

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -556,6 +556,20 @@ module MaintenanceTasks
       assert_predicate run, :errored?
     end
 
+    test "#start rescues and retries ActiveRecord::StaleObjectError" do
+      run = Run.create!(
+        task_name: "Maintenance::UpdatePostsTask",
+        status: :running
+      )
+      Run.find(run.id).cancelling!
+
+      assert_nothing_raised do
+        run.start(2)
+      end
+
+      assert_predicate run, :cancelling?
+    end
+
     private
 
     def count_uncached_queries(&block)

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -328,6 +328,28 @@ module MaintenanceTasks
       run.start(2)
     end
 
+    test "#job_shutdown sets running run to interrupted" do
+      run = Run.new(status: :running)
+      run.job_shutdown
+      assert_predicate run, :interrupted?
+    end
+
+    test "#job_shutdown sets cancelling run to cancelled, and sets ended_at" do
+      freeze_time
+      now = Time.now
+      run = Run.new(status: :cancelling)
+      run.job_shutdown
+
+      assert_predicate run, :cancelled?
+      assert_equal now, run.ended_at
+    end
+
+    test "#job_shutdown sets pausing run to paused" do
+      run = Run.new(status: :pausing)
+      run.job_shutdown
+      assert_predicate run, :paused?
+    end
+
     test "#cancel transitions the Run to cancelling if not paused" do
       [:enqueued, :running, :pausing, :interrupted].each do |status|
         run = Run.create!(

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -103,6 +103,17 @@ module MaintenanceTasks
       assert_equal 12.2, run.time_running
     end
 
+    test "#persist_progress increments the lock version in memory" do
+      run = Run.create!(
+        task_name: "Maintenance::UpdatePostsTask",
+        status: :running,
+      )
+      run.persist_progress(2, 2)
+      refute_predicate run, :changed?
+      lock_version = run.lock_version
+      assert_equal run.reload.lock_version, lock_version
+    end
+
     test "#persist_error updates Run to errored, sets ended_at, and sets started_at if not yet set" do
       freeze_time
       run = Run.create!(task_name: "Maintenance::ErrorTask")

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -127,12 +127,15 @@ module MaintenanceTasks
       run.persist_error(error)
     end
 
-    test "#reload_status reloads status and clears dirty tracking" do
+    test "#reload_status reloads status and lock version, and clears dirty tracking" do
       run = Run.create!(task_name: "Maintenance::UpdatePostsTask")
-      Run.find(run.id).running!
+      original_lock_version = run.lock_version
+
+      Run.find(run.id).running! # race condition
 
       run.reload_status
       assert_predicate run, :running?
+      assert_equal original_lock_version + 1, run.lock_version
       refute run.changed?
     end
 


### PR DESCRIPTION
Take 2 of https://github.com/Shopify/maintenance_tasks/pull/178

## Problem
Data races are a problem in the gem because:
1) We update the status of a `MaintenanceTasks::Run` object frequently as it progresses through the lifecycle of a Task, and
2) A `run` is updated by a running `TaskJob`, but also by the controller when pausing / resuming / cancelling a Task. This can create race conditions between writes. The primary scenario is that the `@run` in the job gets "stale" if a write happens between when we read the status value for an in-memory run object (where this value determines what status we should write), and when we actually perform the write.

Why is this a problem?

- It can lead to tasks not getting cancelled properly. If an interrupt happens at the same time as the task is cancelled, the `interrupted` state may end up getting persisted and the task won't stop.
- It can lead to tasks getting into a stuck state if the task is cancelled or paused as it succeeds -- if the run moves to succeeded just as the user cancels, the run can get updated to `cancelling`, but the job will be finished, so the run will stay stuck.
- In general, the nature of the gem is highly conducive to races, so we should address this properly so that unexpected state transitions / status changes "not going through" don't keep happening.

## Solution
This PR uses [`ActiveRecord::Locking::Optimistic`](https://api.rubyonrails.org/classes/ActiveRecord/Locking/Optimistic.html) to handle data races. Any scenarios we have seen or suspect might cause a data race are handled by:
1) Rescuing the `ActiveRecord::StaleObjectError`
2) Reloading the status on the `run` record
3) Retrying the status transition

Any data races that are missed will result in an unhandled `ActiveRecord::StaleObjectError` being raised, and will let us know there is a race condition to be handled.

## Summary of changes
- Adds `lock_version` column to `maintenance_tasks_runs` table, which will automatically set us up to use optimistic locking on this model
- Ensure we refresh lock version when reloading status so that any time we're fetching an updated status, we're also taking into account the latest lock version for that status
- Ensure we also refresh the lock version after persisting progress in `on_shutdown` -- `update_counters` [handles optimistic locking](https://api.rubyonrails.org/classes/ActiveRecord/Locking/Optimistic/ClassMethods.html#method-i-update_counters) in the db, but won't update the lock version for our in-memory `@run`. We don't need to do this when persisting progress (`@ticker.tick`) in `#each_iteration`, because we call `@run.reload_status` immediately after, which will reload the lock version.
- Converts all of the status transition methods on the `Run` to rescue, reload, and retry stale object errors. For `#running`, I decided to leave our swap-and-replace implementation in the case where optimistic locking is not being used, to preserve backwards compatibility for users who may not want to update their dbs right away. I also extracted `#start` to its own method, and it handles optimistic locking.
- Handling data races between interrupt / pause / cancel are a bit trickier due to the fact that assigning the status to the object in memory, and persisting the object to the db, are done in separate statements (and in separate callbacks!)

I'll go into the commits in a bit more detail:

[Address race conditions between interrupts and pause / cancel operation](https://github.com/Shopify/maintenance_tasks/pull/549/commits/d4800bb4d6df86df716b3da7e1262a7644935b6a):
- Handles race conditions between the run being "interrupted" after a pause / cancel, and the job not actually stopping
- AFTER we set the status on the run in `shutdown`, we check the db lock version against the run's current lock version. If the values are different, we manually raise a stale object error (this would replicate the behaviour we would see if we were _writing_ to the db with these status updates instead of just assigning the attribute)
- We will then rescue, reload, and retry as usual

[Handle data races between run succeeding and being paused / cancelled](https://github.com/Shopify/maintenance_tasks/pull/549/commits/baf3ab73bb9e640d3241677b5a1e1e95b97eade1)
- Handles races where we pause / cancel a run in between the status being set to `:succeeded` and the run actually being saved in the `after_perform` callback
- Basically, we just use the same rescue, reload and retry flow in `after_perform`, WITH the caveat of needing to save the status at the start so that we don't lose it when we reload

[ Early return when cancelling / pausing run if run is completed](https://github.com/Shopify/maintenance_tasks/pull/549/commits/e0e9287243d13470978de3e44483b37ba163857b):
- Handles races where we pause / cancel a run immediately after the status has been updated as `:succeeded` in the db (ie. user presses "cancel" right as the task finishes - the `@run` in the controller is not yet `succeeded`, so we will call `#cancel` on the run despite the fact that its status has since changed to `succeeded` in the db)
- The early return is necessary, because after we rescue / reload / retry to get the completed status, we'll want to return from the method rather than trying to perform an invalid status transition.

## Feedback
Does this make sense? Are there any flows I'm missing?
Do the tests make sense? Race conditions are pretty tricky to test. I opted to hijack Mocha's `#with` method and use a block to try and simulate some of the races, and then followed the tests we wrote to ensure `#running` handled races properly and used a callback on `CustomTaskJob` to execute a block. If anyone has better ideas for how to write these, I'm all ears.