### PR TITLE
Allow `TasksController#run` to accept a block

### DIFF
--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -24,11 +24,12 @@ module MaintenanceTasks
     end
 
     # Runs a given Task and redirects to the Task page.
-    def run
+    def run(&block)
       task = Runner.run(
         name: params.fetch(:id),
         csv_file: params[:csv_file],
         arguments: params.fetch(:task_arguments, {}).permit!.to_h,
+        &block
       )
       redirect_to(task_path(task))
     rescue ActiveRecord::RecordInvalid => error


### PR DESCRIPTION
`Runner.run` currently accepts a block and yields the `run` to it, which allows us to define other attributes on the `Run` model in `Shopify/shopify`. We end up calling `Runner.run` from our own code (outside of a controller), so it works as-is.

However, it would be nice if other apps could also leverage this yielding of the run in `Runner`, and in most cases they won't want to completely redefine the entrypoint to the Runner / rewrite the controller. If we allow `TasksController#run` to accept a block, apps can patch only this controller method downstream and call `super` with a block that configures the run the way they want.

For example:

```ruby
# config/initializers/maintenance_tasks.rb
Dir[Rails.root + 'lib/patches/maintenance_tasks/*.rb'].each { |file| require file }
Rails.autoloaders.main.on_load("MaintenanceTasks::TasksController") do
  MaintenanceTasks::TasksController.prepend(MaintenanceTasks::TasksControllerPatch)
end

# lib/patches/maintenance_tasks/tasks_controller_patch.rb
module MaintenanceTasks
  module TasksControllerPatch
    def run
      super do |run|
        run.x_attribute = "foo"
      end
    end
  end
end
```

I've opted not to document this, since yielding the run in Runner is not documented. It's difficult to test this without controller tests, are we okay with adding this untested? Passing a block down is pretty simple behaviour 😄 

cc @promulo 