### PR TITLE
Support Tasks that perform a single iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ module Maintenance
   class NoCollectionTask < MaintenanceTasks::Task
     no_collection
 
-    def process(_)
+    def process
       SomeAsyncJob.perform_later
     end
   end

--- a/README.md
+++ b/README.md
@@ -160,6 +160,36 @@ primary keys of the records of the batch first, and then perform an additional
 query to load the records when calling `each` (or any `Enumerable` method)
 inside `#process`.
 
+### Tasks that don't need a Collection
+
+Sometimes, you might want to run a Task that performs a single operation, such
+as enqueuing another background job or hitting an external API. The gem supports
+collection-less tasks.
+
+Generate a collection-less Task by running:
+
+```bash
+$ bin/rails generate maintenance_tasks:task no_collection_task --no-collection
+```
+
+The generated task is a subclass of `MaintenanceTasks::Task` that implements:
+
+* `process`: do the work of your maintenance task
+
+```ruby
+# app/tasks/maintenance/no_collection_task.rb
+
+module Maintenance
+  class NoCollectionTask < MaintenanceTasks::Task
+    no_collection
+
+    def process(_)
+      SomeAsyncJob.perform_later
+    end
+  end
+end
+```
+
 ### Throttling
 
 Maintenance Tasks often modify a lot of data and can be taxing on your database.

--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -36,6 +36,8 @@ module MaintenanceTasks
       @enumerator = nil
 
       collection_enum = case collection
+      when :no_collection
+        enumerator_builder.build_once_enumerator(cursor: nil)
       when ActiveRecord::Relation
         enumerator_builder.active_record_on_records(collection, cursor: cursor)
       when ActiveRecord::Batches::BatchEnumerator

--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -91,7 +91,11 @@ module MaintenanceTasks
     end
 
     def task_iteration(input)
-      @task.process(input)
+      if @task.no_collection?
+        @task.process
+      else
+        @task.process(input)
+      end
     rescue => error
       @errored_element = input
       raise error

--- a/app/models/maintenance_tasks/csv_collection_builder.rb
+++ b/app/models/maintenance_tasks/csv_collection_builder.rb
@@ -29,5 +29,10 @@ module MaintenanceTasks
     def has_csv_content?
       true
     end
+
+    # Returns that the Task processes a collection.
+    def no_collection?
+      false
+    end
   end
 end

--- a/app/models/maintenance_tasks/no_collection_builder.rb
+++ b/app/models/maintenance_tasks/no_collection_builder.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module MaintenanceTasks
+  # Strategy for building a Task that has no collection. These Tasks
+  # consist of a single iteration.
+  #
+  # @api private
+  class NoCollectionBuilder
+    # Specifies that this task does not process a collection.
+    def collection(_task)
+      :no_collection
+    end
+
+    # The number of rows to be processed. Always returns 1.
+    def count(_task)
+      1
+    end
+
+    # Return that the Task does not process CSV content.
+    def has_csv_content?
+      false
+    end
+  end
+end

--- a/app/models/maintenance_tasks/no_collection_builder.rb
+++ b/app/models/maintenance_tasks/no_collection_builder.rb
@@ -20,5 +20,10 @@ module MaintenanceTasks
     def has_csv_content?
       false
     end
+
+    # Returns that the Task is collection-less.
+    def no_collection?
+      true
+    end
   end
 end

--- a/app/models/maintenance_tasks/null_collection_builder.rb
+++ b/app/models/maintenance_tasks/null_collection_builder.rb
@@ -29,5 +29,10 @@ module MaintenanceTasks
     def has_csv_content?
       false
     end
+
+    # Returns that the Task processes a collection.
+    def no_collection?
+      false
+    end
   end
 end

--- a/app/models/maintenance_tasks/null_collection_builder.rb
+++ b/app/models/maintenance_tasks/null_collection_builder.rb
@@ -2,6 +2,8 @@
 
 module MaintenanceTasks
   # Base strategy for building a collection-based Task to be performed.
+  #
+  # @api private
   class NullCollectionBuilder
     # Placeholder method to raise in case a subclass fails to implement the
     # expected instance method.

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -18,6 +18,7 @@ module MaintenanceTasks
     # @api private
     class_attribute :throttle_conditions, default: []
 
+    # @api private
     class_attribute :collection_builder_strategy,
       default: NullCollectionBuilder.new
 

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -63,6 +63,13 @@ module MaintenanceTasks
           MaintenanceTasks::CsvCollectionBuilder.new
       end
 
+      # Make this a Task that calls #process once, instead of iterating over
+      # a collection.
+      def no_collection
+        self.collection_builder_strategy =
+          MaintenanceTasks::NoCollectionBuilder.new
+      end
+
       # Returns whether the Task handles CSV.
       #
       # @return [Boolean] whether the Task handles CSV.

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -71,19 +71,8 @@ module MaintenanceTasks
           MaintenanceTasks::NoCollectionBuilder.new
       end
 
-      # Returns whether the Task handles CSV.
-      #
-      # @return [Boolean] whether the Task handles CSV.
-      def has_csv_content?
-        collection_builder_strategy.has_csv_content?
-      end
-
-      # Returns whether the Task is collection-less.
-      #
-      # @return [Boolean] whether the Task is collection-less.
-      def no_collection?
-        collection_builder_strategy.no_collection?
-      end
+      delegate :has_csv_content?, :no_collection?,
+        to: :collection_builder_strategy
 
       # Processes one item.
       #

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -78,13 +78,20 @@ module MaintenanceTasks
         collection_builder_strategy.has_csv_content?
       end
 
+      # Returns whether the Task is collection-less.
+      #
+      # @return [Boolean] whether the Task is collection-less.
+      def no_collection?
+        collection_builder_strategy.no_collection?
+      end
+
       # Processes one item.
       #
       # Especially useful for tests.
       #
-      # @param item the item to process.
-      def process(item)
-        new.process(item)
+      # @param args [Object, nil] the item to process
+      def process(*args)
+        new.process(*args)
       end
 
       # Returns the collection for this Task.
@@ -203,6 +210,13 @@ module MaintenanceTasks
     # @return [Boolean] whether the Task handles CSV.
     def has_csv_content?
       self.class.has_csv_content?
+    end
+
+    # Returns whether the Task is collection-less.
+    #
+    # @return [Boolean] whether the Task is collection-less.
+    def no_collection?
+      self.class.no_collection?
     end
 
     # The collection to be processed, delegated to the strategy.

--- a/lib/generators/maintenance_tasks/task_generator.rb
+++ b/lib/generators/maintenance_tasks/task_generator.rb
@@ -30,7 +30,7 @@ module MaintenanceTasks
       )
       if options[:csv]
         template("csv_task.rb", template_file)
-      elsif options[:no_collection]
+      elsif no_collection?
         template("no_collection_task.rb", template_file)
       else
         template("task.rb", template_file)
@@ -84,6 +84,10 @@ module MaintenanceTasks
 
     def test_framework
       Rails.application.config.generators.options[:rails][:test_framework]
+    end
+
+    def no_collection?
+      options[:no_collection]
     end
   end
 end

--- a/lib/generators/maintenance_tasks/task_generator.rb
+++ b/lib/generators/maintenance_tasks/task_generator.rb
@@ -12,10 +12,17 @@ module MaintenanceTasks
     class_option :csv, type: :boolean, default: false,
       desc: "Generate a CSV Task."
 
+    class_option :no_collection, type: :boolean, default: false,
+      desc: "Generate a collection-less Task."
+
     check_class_collision suffix: "Task"
 
     # Creates the Task file.
     def create_task_file
+      if options[:csv] && options[:no_collection]
+        raise "Multiple Task type options provided. Please use either "\
+          "--csv or --no-collection."
+      end
       template_file = File.join(
         "app/tasks/#{tasks_module_file_path}",
         class_path,
@@ -23,6 +30,8 @@ module MaintenanceTasks
       )
       if options[:csv]
         template("csv_task.rb", template_file)
+      elsif options[:no_collection]
+        template("no_collection_task.rb", template_file)
       else
         template("task.rb", template_file)
       end

--- a/lib/generators/maintenance_tasks/templates/no_collection_task.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/no_collection_task.rb.tt
@@ -5,7 +5,7 @@ module <%= tasks_module %>
   class <%= class_name %>Task < MaintenanceTasks::Task
     no_collection
 
-    def process(_)
+    def process
       # The work to be done
     end
   end

--- a/lib/generators/maintenance_tasks/templates/no_collection_task.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/no_collection_task.rb.tt
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module <%= tasks_module %>
+<% module_namespacing do -%>
+  class <%= class_name %>Task < MaintenanceTasks::Task
+    no_collection
+
+    def process(_)
+      # The work to be done
+    end
+  end
+<% end -%>
+end

--- a/lib/generators/maintenance_tasks/templates/no_collection_task_test.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/no_collection_task_test.rb.tt
@@ -5,11 +5,7 @@ module <%= tasks_module %>
 <% module_namespacing do -%>
   class <%= class_name %>TaskTest < ActiveSupport::TestCase
     # test "#process performs a task iteration" do
-    <%- if no_collection? -%>
     #   <%= tasks_module %>::<%= class_name %>Task.process
-    <%- else -%>
-    #   <%= tasks_module %>::<%= class_name %>Task.process(element)
-    <%- end -%>
     # end
   end
 <% end -%>

--- a/test/dummy/app/tasks/maintenance/no_collection_task.rb
+++ b/test/dummy/app/tasks/maintenance/no_collection_task.rb
@@ -4,7 +4,7 @@ module Maintenance
   class NoCollectionTask < MaintenanceTasks::Task
     no_collection
 
-    def process(_)
+    def process
       Rails.logger.debug("#process method was called")
     end
   end

--- a/test/dummy/app/tasks/maintenance/no_collection_task.rb
+++ b/test/dummy/app/tasks/maintenance/no_collection_task.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class NoCollectionTask < MaintenanceTasks::Task
+    no_collection
+
+    def process(_)
+      Rails.logger.debug("#process method was called")
+    end
+  end
+end

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -253,6 +253,16 @@ module MaintenanceTasks
       assert_predicate run.reload, :succeeded?
     end
 
+    test ".perform_now can run a Task that uses no collection" do
+      Maintenance::NoCollectionTask.any_instance.expects(:process).once
+
+      run = Run.new(task_name: "Maintenance::NoCollectionTask")
+
+      TaskJob.perform_now(run)
+
+      assert_predicate run.reload, :succeeded?
+    end
+
     test ".perform_now sets the Run as errored when the Task collection is invalid" do
       freeze_time
       Maintenance::TestTask.any_instance.stubs(collection: "not a collection")

--- a/test/lib/generators/maintenance_tasks/task_generator_test.rb
+++ b/test/lib/generators/maintenance_tasks/task_generator_test.rb
@@ -81,5 +81,24 @@ module MaintenanceTasks
         assert_match(/def process\(row\)/, task)
       end
     end
+
+    test "generator creates a collection-less Task if the --no-collection option is supplied" do
+      run_generator ["sleepy", "--no-collection"]
+      assert_file "app/tasks/maintenance/sleepy_task.rb" do |task|
+        assert_match(/class SleepyTask < MaintenanceTasks::Task/, task)
+        assert_match(/no_collection/, task)
+        assert_match(/def process\(_\)/, task)
+      end
+    end
+
+    test "generator raises if multiple collection options provided" do
+      error = assert_raises do
+        run_generator(["sleepy", "--csv", "--no-collection"])
+      end
+
+      expected = "Multiple Task type options provided. "\
+        "Please use either --csv or --no-collection."
+      assert_equal(expected, error.message)
+    end
   end
 end

--- a/test/lib/generators/maintenance_tasks/task_generator_test.rb
+++ b/test/lib/generators/maintenance_tasks/task_generator_test.rb
@@ -87,7 +87,7 @@ module MaintenanceTasks
       assert_file "app/tasks/maintenance/sleepy_task.rb" do |task|
         assert_match(/class SleepyTask < MaintenanceTasks::Task/, task)
         assert_match(/no_collection/, task)
-        assert_match(/def process\(_\)/, task)
+        assert_match(/def process/, task)
       end
     end
 

--- a/test/models/maintenance_tasks/task_data_test.rb
+++ b/test/models/maintenance_tasks/task_data_test.rb
@@ -27,6 +27,7 @@ module MaintenanceTasks
         "Maintenance::EnqueueErrorTask",
         "Maintenance::ErrorTask",
         "Maintenance::ImportPostsTask",
+        "Maintenance::NoCollectionTask",
         "Maintenance::ParamsTask",
         "Maintenance::TestTask",
         "Maintenance::UpdatePostsInBatchesTask",

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -11,6 +11,7 @@ module MaintenanceTasks
         "Maintenance::EnqueueErrorTask",
         "Maintenance::ErrorTask",
         "Maintenance::ImportPostsTask",
+        "Maintenance::NoCollectionTask",
         "Maintenance::ParamsTask",
         "Maintenance::TestTask",
         "Maintenance::UpdatePostsInBatchesTask",

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -23,6 +23,7 @@ module MaintenanceTasks
         "Maintenance::EnqueueErrorTask\nNew",
         "Maintenance::ErrorTask\nNew",
         "Maintenance::ImportPostsTask\nNew",
+        "Maintenance::NoCollectionTask\nNew",
         "Maintenance::ParamsTask\nNew",
         "Maintenance::TestTask\nNew",
         "Maintenance::UpdatePostsInBatchesTask\nNew",


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/568

Sometimes, a Task may simply need to perform an action without iterating over multiple elements in a collection. For example, a Task might need to kick off another job, interact with a third-party API, or perform a single operation. This adds support for "collection-less" tasks, which need only to define a `#process` method.

I'm proposing an API similar to what we've done for `csv_collection` tasks, where we use a `no_collection` macro in the task. Under the hood, we can use a `NoCollectionBuilder` to handle defining `#collection` and `#count` (with collection simply being `:no_collection` for use when building the enumerator), and in the job we can use Job Iteration's `#build_once_enumerator` to handle this.

I've added a generator option for this as a distinct boolean option. We could change the task generator to take a `type` option (ie. `--type=csv`, `--type=no-collection`) but this is technically an API change, and I'm not sure it's necessary to generalize this yet (maybe it will make more sense if we have _three_ options at some point in the future 😉 ). Instead, I've opted to raise if a user supplies multiple option flags.

## Feedback

Thoughts on the generator flag / macro name? Is `process_once` more suitable?