### PR TITLE
set enqueued after job has been enqueued

### DIFF
--- a/app/models/maintenance_tasks/runner.rb
+++ b/app/models/maintenance_tasks/runner.rb
@@ -57,8 +57,8 @@ module MaintenanceTasks
       job = instantiate_job(run)
       run.job_id = job.job_id
       yield run if block_given?
-      run.enqueued!
       enqueue(run, job)
+      run.enqueued!
       Task.named(name)
     end
 

--- a/app/models/maintenance_tasks/runner.rb
+++ b/app/models/maintenance_tasks/runner.rb
@@ -57,7 +57,7 @@ module MaintenanceTasks
       job = instantiate_job(run)
       run.job_id = job.job_id
       yield run if block_given?
-      enqueue(run, job)
+      enqueue(run, job) unless run.enqueued?
       run.enqueued!
       Task.named(name)
     end


### PR DESCRIPTION
We are experiencing an [issue where Maintenance Tasks are getting stuck in an `enqueued` state](https://github.com/Shopify/ihub/issues/1338). This is happening when tasks are `enqueued` during a deploy.

This is because the code sets tasks to `enqueued` before they are actually enqueued. This makes it possible for the task to have an `enqueued` status, but not actually be enqueued. New attempts to enqueue tasks with a status of enqueued are ignored. Since the task was never enqueued the status will never get updated from `enqueued`.

In our case the task is getting set to `enqueued`, but the pod is shut down before the task is actually enqueued. All subsequent attempts to enqueue the task are ignored because it is already in an `enqueued` state. Only manual intervention will change the state to anything other than `enqueued`.

This PR fixes this issue by setting the task to `enqueued` after the task is enqueued instead of before.