### PR TITLE
Remove direct reference to MaintenanceTasks::Run in `#truncate` method

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -424,7 +424,7 @@ module MaintenanceTasks
     end
 
     def truncate(attribute_name, value)
-      limit = MaintenanceTasks::Run.column_for_attribute(attribute_name).limit
+      limit = self.class.column_for_attribute(attribute_name).limit
       return value unless limit
       value&.first(limit)
     end


### PR DESCRIPTION
Follow up to https://github.com/Shopify/maintenance_tasks/pull/494

This prevents us from upgrading the gem in Shopify/shopify, because `MaintenanceTasks::Run` is abstract + not backed by a table. We need to use `self.class` instead.