### PR TITLE
Update maintenance_tasks to 1.8.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    maintenance_tasks (1.8.0)
+    maintenance_tasks (1.8.1)
       actionpack (>= 6.0)
       activejob (>= 6.0)
       activerecord (>= 6.0)

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "maintenance_tasks"
-  spec.version = "1.8.0"
+  spec.version = "1.8.1"
   spec.author = "Shopify Engineering"
   spec.email = "gems@shopify.com"
   spec.homepage = "https://github.com/Shopify/maintenance_tasks"


### PR DESCRIPTION
Bumps version to 1.8.1 to include the fix in https://github.com/Shopify/maintenance_tasks/pull/581.

I'd like to point Core to this version so that we can source the gem from RubyGems instead of from the GitHub repo, since the latter means we don't get Dependabot updates (and we've fallen behind on updating this gem in Core).