### PR TITLE
Don't re-enqueue stopped throttled jobs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionpack (>= 6.0)
       activejob (>= 6.0)
       activerecord (>= 6.0)
-      job-iteration (~> 1.1)
+      job-iteration (~> 1.3.6)
       railties (>= 6.0)
 
 GEM
@@ -98,10 +98,10 @@ GEM
     erubi (1.10.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    i18n (1.9.1)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     io-wait (0.2.1)
-    job-iteration (1.3.5)
+    job-iteration (1.3.6)
       activejob (>= 5.2)
     loofah (2.14.0)
       crass (~> 1.0.2)

--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -151,7 +151,7 @@ module MaintenanceTasks
     def after_perform
       @run.persist_transition
       if defined?(@reenqueue_iteration_job) && @reenqueue_iteration_job
-        reenqueue_iteration_job(should_ignore: false)
+        reenqueue_iteration_job(should_ignore: false) unless @run.stopped?
       end
     end
 

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency("actionpack", ">= 6.0")
   spec.add_dependency("activejob", ">= 6.0")
   spec.add_dependency("activerecord", ">= 6.0")
-  spec.add_dependency("job-iteration", "~> 1.1")
+  spec.add_dependency("job-iteration", "~> 1.3.6")
   spec.add_dependency("railties", ">= 6.0")
 end


### PR DESCRIPTION
Currently throttling relies on the Enumerator enqueuing a job, which is problematic if we don't want to re-enqueue because the run is stopping (pausing or cancelling). This is shown in the new test which fails on main. The run is properly cancelled, but there's an enqueued job which then fails because it tries to move the run from cancelled to running.

This adds a conditional in the `after_perform` callback when we enqueue the job, to not do so when the run is stopped (at this point we've transitioned from _stopping_ to _stopped_.

This only works if we also change job-iteration to use the same `reenqueue_iteration_job` method for throttling, which is done in https://github.com/Shopify/job-iteration/pull/190.

If that PR gets merged, I'll release a new version and update this PR to require that fixed version.