### PR TITLE
Support processing CSVs in batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,33 @@ The files uploaded to your Active Storage service provider will be renamed
 to include an ISO8601 timestamp and the Task name in snake case format.
 The CSV is expected to have a trailing newline at the end of the file.
 
+#### Batch CSV Tasks
+
+Tasks can process CSVs in batches. Add the `in_batches` option to your task's
+`csv_collection` macro:
+
+```ruby
+# app/tasks/maintenance/batch_import_posts_task.rb
+
+module Maintenance
+  class BatchImportPostsTask < MaintenanceTasks::Task
+    csv_collection(in_batches: 50)
+
+    def process(batch_of_rows)
+      Post.insert_all(post_rows.map(&:to_h))
+    end
+  end
+end
+```
+
+As with a regular CSV task, ensure you've implemented the following method:
+
+* `process`: do the work of your Task on a batch (array of `CSV::Row` objects).
+
+Note that `#count` is calculated automatically based on the number of batches in
+your collection, and your Task's progress will be displayed in terms of batches
+(not the total number of rows in your CSV).
+
 ### Processing Batch Collections
 
 The Maintenance Tasks gem supports processing Active Records in batches. This

--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -57,6 +57,11 @@ module MaintenanceTasks
         )
       when Array
         enumerator_builder.build_array_enumerator(collection, cursor: cursor)
+      when BatchCsvCollectionBuilder::BatchCsv
+        JobIteration::CsvEnumerator.new(collection.csv).batches(
+          batch_size: collection.batch_size,
+          cursor: cursor,
+        )
       when CSV
         JobIteration::CsvEnumerator.new(collection).rows(cursor: cursor)
       else

--- a/app/models/maintenance_tasks/batch_csv_collection_builder.rb
+++ b/app/models/maintenance_tasks/batch_csv_collection_builder.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module MaintenanceTasks
+  # Strategy for building a Task that processes CSV files in batches.
+  #
+  # @api private
+  class BatchCsvCollectionBuilder
+    BatchCsv = Struct.new(:csv, :batch_size, keyword_init: true)
+
+    # Initialize a BatchCsvCollectionBuilder with a batch size.
+    #
+    # @param batch_size [Integer] the number of CSV rows in a batch.
+    def initialize(batch_size)
+      @batch_size = batch_size
+    end
+
+    # Defines the collection to be iterated over, based on the provided CSV.
+    # Includes the CSV and the batch size.
+    def collection(task)
+      BatchCsv.new(
+        csv: CSV.new(task.csv_content, headers: true),
+        batch_size: @batch_size
+      )
+    end
+
+    # The number of batches to be processed. Excludes the header row from the
+    # count and assumes a trailing newline is at the end of the CSV file.
+    # Note that this number is an approximation based on the number of
+    # newlines.
+    #
+    # @return [Integer] the approximate number of batches to process.
+    def count(task)
+      (task.csv_content.count("\n") + @batch_size - 1) / @batch_size
+    end
+
+    # Return that the Task processes CSV content.
+    def has_csv_content?
+      true
+    end
+
+    # Returns that the Task processes a collection.
+    def no_collection?
+      false
+    end
+  end
+end

--- a/app/models/maintenance_tasks/batch_csv_collection_builder.rb
+++ b/app/models/maintenance_tasks/batch_csv_collection_builder.rb
@@ -6,7 +6,7 @@ module MaintenanceTasks
   # Strategy for building a Task that processes CSV files in batches.
   #
   # @api private
-  class BatchCsvCollectionBuilder
+  class BatchCsvCollectionBuilder < CsvCollectionBuilder
     BatchCsv = Struct.new(:csv, :batch_size, keyword_init: true)
 
     # Initialize a BatchCsvCollectionBuilder with a batch size.
@@ -14,6 +14,7 @@ module MaintenanceTasks
     # @param batch_size [Integer] the number of CSV rows in a batch.
     def initialize(batch_size)
       @batch_size = batch_size
+      super()
     end
 
     # Defines the collection to be iterated over, based on the provided CSV.
@@ -33,16 +34,6 @@ module MaintenanceTasks
     # @return [Integer] the approximate number of batches to process.
     def count(task)
       (task.csv_content.count("\n") + @batch_size - 1) / @batch_size
-    end
-
-    # Return that the Task processes CSV content.
-    def has_csv_content?
-      true
-    end
-
-    # Returns that the Task processes a collection.
-    def no_collection?
-      false
     end
   end
 end

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -53,16 +53,23 @@ module MaintenanceTasks
 
       # Make this Task a task that handles CSV.
       #
+      # @param in_batches [Integer] optionally, supply a batch size if the CSV
+      # should be processed in batches.
+      #
       # An input to upload a CSV will be added in the form to start a Run. The
       # collection and count method are implemented.
-      def csv_collection
+      def csv_collection(in_batches: nil)
         unless defined?(ActiveStorage)
           raise NotImplementedError, "Active Storage needs to be installed\n"\
             "To resolve this issue run: bin/rails active_storage:install"
         end
 
-        self.collection_builder_strategy =
-          MaintenanceTasks::CsvCollectionBuilder.new
+        if in_batches
+          self.collection_builder_strategy =
+            BatchCsvCollectionBuilder.new(in_batches)
+        else
+          self.collection_builder_strategy = CsvCollectionBuilder.new
+        end
       end
 
       # Make this a Task that calls #process once, instead of iterating over

--- a/test/dummy/app/tasks/maintenance/batch_import_posts_task.rb
+++ b/test/dummy/app/tasks/maintenance/batch_import_posts_task.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class BatchImportPostsTask < MaintenanceTasks::Task
+    csv_collection(in_batches: 2)
+
+    def process(post_rows)
+      Post.insert_all(post_rows.map(&:to_h))
+    end
+  end
+end

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -263,6 +263,17 @@ module MaintenanceTasks
       assert_predicate run.reload, :succeeded?
     end
 
+    test ".perform_now accepts a CSV collection to be performed in batches" do
+      Maintenance::BatchImportPostsTask.any_instance.expects(:process).times(3)
+
+      run = Run.new(task_name: "Maintenance::BatchImportPostsTask")
+      run.csv_file.attach(
+        { io: File.open(file_fixture("sample.csv")), filename: "sample.csv" }
+      )
+      run.save
+      TaskJob.perform_now(run)
+    end
+
     test ".perform_now sets the Run as errored when the Task collection is invalid" do
       freeze_time
       Maintenance::TestTask.any_instance.stubs(collection: "not a collection")

--- a/test/models/maintenance_tasks/task_data_test.rb
+++ b/test/models/maintenance_tasks/task_data_test.rb
@@ -22,6 +22,7 @@ module MaintenanceTasks
 
     test ".available_tasks returns a list of Tasks as TaskData, ordered alphabetically by name" do
       expected = [
+        "Maintenance::BatchImportPostsTask",
         "Maintenance::CallbackTestTask",
         "Maintenance::CancelledEnqueueTask",
         "Maintenance::EnqueueErrorTask",

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -6,6 +6,7 @@ module MaintenanceTasks
   class TaskTest < ActiveSupport::TestCase
     test ".available_tasks returns list of tasks that inherit from the Task superclass" do
       expected = [
+        "Maintenance::BatchImportPostsTask",
         "Maintenance::CallbackTestTask",
         "Maintenance::CancelledEnqueueTask",
         "Maintenance::EnqueueErrorTask",

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -18,6 +18,7 @@ module MaintenanceTasks
 
       expected = [
         "New Tasks",
+        "Maintenance::BatchImportPostsTask\nNew",
         "Maintenance::CallbackTestTask\nNew",
         "Maintenance::CancelledEnqueueTask\nNew",
         "Maintenance::EnqueueErrorTask\nNew",


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/601

This PR adds support for batch-processing CSV rows in a task by extending the existing `csv_collection` macro to take an `in_batches` option . Arrays of `CSV::Row` objects are then passed as input to the task's `#process` method.

Job Iteration already has [support for iterating over CSVs in batches](https://github.com/Shopify/job-iteration/blob/2e29ba910b7b97bfbe318a97e33918638dfd2d36/lib/job-iteration/csv_enumerator.rb#L39-L47), so our `#build_enumerator` method simply needs to hit job-iteration's `#batches` API to achieve this.

🎩 

- `bin/rails s`
- Navigate to http://127.0.0.1:3000/maintenance_tasks/tasks/Maintenance::BatchImportPostsTask
- Upload `test/fixtures/files/sample.csv`
- Run the task 