### PR TITLE
update templates to prefer double-quoted strings

### DIFF
--- a/lib/generators/maintenance_tasks/templates/no_collection_task_test.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/no_collection_task_test.rb.tt
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require "test_helper"
 
 module <%= tasks_module %>
 <% module_namespacing do -%>

--- a/lib/generators/maintenance_tasks/templates/task_spec.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/task_spec.rb.tt
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 
 module <%= tasks_module %>
 <% module_namespacing do -%>
   RSpec.describe <%= class_name %>Task do
     describe "#process" do
       subject(:process) { described_class.process(element) }
-      let(:element) { 
+      let(:element) {
         # Object to be processed in a single iteration of this task
       }
       pending "add some examples to (or delete) #{__FILE__}"

--- a/lib/generators/maintenance_tasks/templates/task_test.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/task_test.rb.tt
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'test_helper'
+require "test_helper"
 
 module <%= tasks_module %>
 <% module_namespacing do -%>


### PR DESCRIPTION
While Rubocop always autocorrects it after the tests are generated:

`Style/StringLiterals: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping` 

I figured I'd update the templates to match our style guide and prefer double-quoted strings, and save Rubocop some work