### PR TITLE
Remove prefixed $ from shell command examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ A Rails engine for queuing and managing maintenance tasks.
 To install the gem and run the install generator, execute:
 
 ```bash
-$ bundle add maintenance_tasks
-$ bin/rails generate maintenance_tasks:install
+bundle add maintenance_tasks
+bin/rails generate maintenance_tasks:install
 ```
 
 The generator creates and runs a migration to add the necessary table to your
@@ -40,7 +40,7 @@ take a look at the [Active Job documentation][active-job-docs].
 A generator is provided to create tasks. Generate a new task by running:
 
 ```bash
-$ bin/rails generate maintenance_tasks:task update_posts
+bin/rails generate maintenance_tasks:task update_posts
 ```
 
 This creates the task file `app/tasks/maintenance/update_posts_task.rb`.
@@ -87,7 +87,7 @@ instuctions][setup].
 Generate a CSV Task by running:
 
 ```bash
-$ bin/rails generate maintenance_tasks:task import_posts --csv
+bin/rails generate maintenance_tasks:task import_posts --csv
 ```
 
 The generated task is a subclass of `MaintenanceTasks::Task` that implements:
@@ -196,7 +196,7 @@ collection-less tasks.
 Generate a collection-less Task by running:
 
 ```bash
-$ bin/rails generate maintenance_tasks:task no_collection_task --no-collection
+bin/rails generate maintenance_tasks:task no_collection_task --no-collection
 ```
 
 The generated task is a subclass of `MaintenanceTasks::Task` that implements:
@@ -484,20 +484,20 @@ You can run your new Task by accessing the Web UI and clicking on "Run".
 Alternatively, you can run your Task in the command line:
 
 ```bash
-$ bundle exec maintenance_tasks perform Maintenance::UpdatePostsTask
+bundle exec maintenance_tasks perform Maintenance::UpdatePostsTask
 ```
 
 To run a Task that processes CSVs from the command line, use the --csv option:
 
 ```bash
-$ bundle exec maintenance_tasks perform Maintenance::ImportPostsTask --csv "path/to/my_csv.csv"
+bundle exec maintenance_tasks perform Maintenance::ImportPostsTask --csv "path/to/my_csv.csv"
 ```
 
 To run a Task that takes arguments from the command line, use the --arguments
 option, passing arguments as a set of \<key>:\<value> pairs:
 
 ```bash
-$ bundle exec maintenance_tasks perform Maintenance::ParamsTask \
+bundle exec maintenance_tasks perform Maintenance::ParamsTask \
   --arguments post_ids:1,2,3 content:"Hello, World!"
 ```
 
@@ -746,7 +746,7 @@ Use bundler to check for and upgrade to newer versions. After installing a new
 version, re-run the install command:
 
 ```bash
-$ bin/rails generate maintenance_tasks:install
+bin/rails generate maintenance_tasks:install
 ```
 
 This ensures that new migrations are installed and run as well.


### PR DESCRIPTION
As the prefixed `$` makes it impossible to copy and paste example shell commands, I was thinking it might be beneficial to remove them from the README. What do y'all think?