### PR TITLE
Refresh by replacing document body instead of using header

### DIFF
--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -15,7 +15,7 @@ module MaintenanceTasks
       )
       policy.script_src(
         # page refresh script
-        "'sha256-2tgF+1+25h/mbN7WzbRy0lIuf3qoUBtqt/ipsHJXYfg='",
+        "'sha256-kOtH9RgO29UNB3GHLZpYttLMkK0yn5uWA9jDK1WLXlQ='",
       )
       policy.frame_ancestors(:self)
     end

--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -14,6 +14,10 @@ module MaintenanceTasks
         "'sha384-" \
           "MJ6MP7wjBI68eI1gLBSKU86HYHooeOnBdlmsV/RfzritEYu5Xaa1vROm+3dkbeZt'",
       )
+      policy.script_src(
+        # page refresh script
+        "'sha256-fADwJN++FN9LuhJ4XRCiIoJ7KPwmDYx2qiBgm20D8rA='",
+      )
       policy.frame_ancestors(:self)
     end
 

--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -11,12 +11,11 @@ module MaintenanceTasks
       policy.style_src(
         BULMA_CDN,
         # ruby syntax highlighting
-        "'sha384-" \
-          "MJ6MP7wjBI68eI1gLBSKU86HYHooeOnBdlmsV/RfzritEYu5Xaa1vROm+3dkbeZt'",
+        "'sha256-y9V0na/WU44EUNI/HDP7kZ7mfEci4PAOIjYOOan6JMA='",
       )
       policy.script_src(
         # page refresh script
-        "'sha256-fADwJN++FN9LuhJ4XRCiIoJ7KPwmDYx2qiBgm20D8rA='",
+        "'sha256-2tgF+1+25h/mbN7WzbRy0lIuf3qoUBtqt/ipsHJXYfg='",
       )
       policy.frame_ancestors(:self)
     end

--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -44,7 +44,7 @@ module MaintenanceTasks
     private
 
     def set_refresh
-      @refresh = 3
+      @refresh = true
     end
   end
 end

--- a/app/views/layouts/maintenance_tasks/application.html.erb
+++ b/app/views/layouts/maintenance_tasks/application.html.erb
@@ -31,24 +31,26 @@
       .ruby-label, .ruby-tstring-beg, .ruby-tstring-content, .ruby-tstring-end { color: #032f62; }
     </style>
 
-    <% if defined?(@refresh) %>
-      <script>
-        function refresh() {
+    <script>
+      function refresh() {
+        if (!("refresh" in document.body.dataset)) return
+        window.setTimeout(() => {
           fetch(document.location, { headers: { "X-Requested-With": "XMLHttpRequest" } }).then(
             async response => {
               const text = await response.text()
               const newDocument = new DOMParser().parseFromString(text, "text/html")
               document.body.replaceWith(newDocument.body)
+              refresh()
             },
             error => location.reload()
           )
-        }
-        window.setInterval(refresh, <%= @refresh * 1000 %>)
-      </script>
-    <% end %>
+        }, 3000)
+      }
+      document.addEventListener('DOMContentLoaded', refresh)
+    </script>
   </head>
 
-  <body>
+  <body <%= "data-refresh" if defined?(@refresh) && @refresh %>>
     <%= render 'layouts/maintenance_tasks/navbar' %>
 
     <section class="section">

--- a/app/views/layouts/maintenance_tasks/application.html.erb
+++ b/app/views/layouts/maintenance_tasks/application.html.erb
@@ -18,7 +18,7 @@
       stylesheet_link_tag(URI.join(controller.class::BULMA_CDN, 'npm/bulma@0.9.3/css/bulma.css'),
         media: :all,
         integrity: 'sha384-Zkr9rpl37lclZu6AwYQZZm0CxiMqLZFiibodW+UXLnAWPBr6qgIzPpcmHkpwnyWD',
-        crossorigin: 'anonymous') if request.headers.key?('Sec-Fetch-User')
+        crossorigin: 'anonymous') unless request.xhr?
     %>
 
     <style>
@@ -34,7 +34,7 @@
     <% if defined?(@refresh) %>
       <script>
         function refresh() {
-          fetch(document.location).then(
+          fetch(document.location, { headers: { "X-Requested-With": "XMLHttpRequest" } }).then(
             async response => {
               const text = await response.text()
               const newDocument = new DOMParser().parseFromString(text, "text/html")

--- a/app/views/layouts/maintenance_tasks/application.html.erb
+++ b/app/views/layouts/maintenance_tasks/application.html.erb
@@ -15,10 +15,10 @@
     <%= csrf_meta_tags %>
 
     <%=
-      stylesheet_link_tag URI.join(controller.class::BULMA_CDN, 'npm/bulma@0.9.3/css/bulma.css'),
+      stylesheet_link_tag(URI.join(controller.class::BULMA_CDN, 'npm/bulma@0.9.3/css/bulma.css'),
         media: :all,
         integrity: 'sha384-Zkr9rpl37lclZu6AwYQZZm0CxiMqLZFiibodW+UXLnAWPBr6qgIzPpcmHkpwnyWD',
-        crossorigin: 'anonymous'
+        crossorigin: 'anonymous') if request.headers.key?('Sec-Fetch-User')
     %>
 
     <style>
@@ -32,7 +32,19 @@
     </style>
 
     <% if defined?(@refresh) %>
-      <meta http-equiv="refresh" content="<%= @refresh %>">
+      <script>
+        function refresh() {
+          fetch(document.location).then(
+            async response => {
+              const text = await response.text()
+              const newDocument = new DOMParser().parseFromString(text, "text/html")
+              document.body.replaceWith(newDocument.body)
+            },
+            error => location.reload()
+          )
+        }
+        window.setInterval(refresh, <%= @refresh * 1000 %>)
+      </script>
     <% end %>
   </head>
 


### PR DESCRIPTION
Co-authored-by: Étienne Barrié <etienne.barrie@shopify.com>

Closes: https://github.com/Shopify/maintenance_tasks/issues/510, https://github.com/Shopify/maintenance_tasks/issues/569

This is an alternative approach to page refreshing, that should solve some of the complaints folks had with the meta tag usage (losing search abilities, making it difficult to copy/paste text, etc.)

We don't want to jump straight to Turbo for a couple of reasons:
- We'd need to make it an explicit dependency / configure it properly for support in pre Rails 7 apps
-  The gem doesn't use any assets currently / doesn't force embedding apps to use the asset pipeline, so it's tricky make the JS component for Turbo work
- Turbo includes a lot of stuff we don't need to achieve the desired behaviour (page refreshing)

@etiennebarrie and I came up with a fairly simple solution to replace using the `http-equiv="refresh"` attribute for refreshing, but that sticks with plain JS. We essentially just swap out the document body in an inline script that uses `window.setInterval()` to run repeatedly. The script's SHA is included in the allowlist for the gem's CSP.  This preserves the ability to do things like Cmd+F to search for tasks.