### PR TITLE
Drop support for classic autoloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ take a look at the [Active Job documentation][active-job-docs].
 [async-adapter]: https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/AsyncAdapter.html
 [active-job-docs]: https://guides.rubyonrails.org/active_job_basics.html#setting-the-backend
 
+
+### Autoloading
+
+The Maintenance Tasks framework does not support autoloading in `:classic` mode.
+Please ensure your application is using [Zeitwerk](https://github.com/fxn/zeitwerk) to load your code.
+For more information, please consult the [Rails guides on autoloading and reloading constants](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html).
+
 ## Usage
 
 ### Creating a Task

--- a/lib/maintenance_tasks/engine.rb
+++ b/lib/maintenance_tasks/engine.rb
@@ -10,15 +10,11 @@ module MaintenanceTasks
 
     initializer "maintenance_tasks.warn_classic_autoloader" do
       unless Rails.autoloaders.zeitwerk_enabled?
-        ActiveSupport::Deprecation.warn(<<~MSG.squish)
-          Autoloading in classic mode is deprecated and support will be removed in the next
-          release of Maintenance Tasks. Please use Zeitwerk to autoload your application.
+        raise <<~MSG.squish
+          Autoloading in classic mode is not supported.
+          Please use Zeitwerk to autoload your application.
         MSG
       end
-    end
-
-    initializer "maintenance_tasks.eager_load_for_classic_autoloader" do
-      eager_load! unless Rails.autoloaders.zeitwerk_enabled?
     end
 
     initializer "maintenance_tasks.configs" do
@@ -27,12 +23,6 @@ module MaintenanceTasks
 
     config.to_prepare do
       _ = TaskJobConcern # load this for JobIteration compatibility check
-      unless Rails.autoloaders.zeitwerk_enabled?
-        tasks_module = MaintenanceTasks.tasks_module.underscore
-        Dir["#{Rails.root}/app/tasks/#{tasks_module}/*.rb"].each do |file|
-          require_dependency(file)
-        end
-      end
     end
 
     config.after_initialize do

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -17,11 +17,6 @@ module Dummy
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults("#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}")
 
-    if ENV["CLASSIC_AUTOLOADER"].present?
-      puts "=> Using classic autoloader"
-      config.autoloader = :classic
-    end
-
     config.to_prepare do
       MaintenanceTasks.job = "CustomTaskJob"
     end


### PR DESCRIPTION
In https://github.com/Shopify/maintenance_tasks/commit/c11faffc00218cb703e804444a83ced2d0e21cd8 we accidentally broke classic autoloading by referencing `CsvCollectionBuilder`. This made me remember that we should have removed support for this it several releases ago anyway. 

Yes, we could instead make it clearer that we need to reference `MaintenanceTasks::CsvCollectionBuilder` in a fully qualified way, but I think since classic autoloading is deprecated both in Rails and the gem, we can just remove it now.

Closes https://github.com/Shopify/maintenance_tasks/issues/528