### PR TITLE
Release version 1.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    maintenance_tasks (1.9.0)
+    maintenance_tasks (1.10.0)
       actionpack (>= 6.0)
       activejob (>= 6.0)
       activerecord (>= 6.0)

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "maintenance_tasks"
-  spec.version = "1.9.0"
+  spec.version = "1.10.0"
   spec.author = "Shopify Engineering"
   spec.email = "gems@shopify.com"
   spec.homepage = "https://github.com/Shopify/maintenance_tasks"


### PR DESCRIPTION
Let's do a minor version release ahead of 2.0 where we'll remove some old deprecations.

Draft release notes: https://github.com/Shopify/maintenance_tasks/releases/edit/untagged-cfa8f1922a34059c3c3a