### PR TITLE
[Hackdays] CSV sample support for maintenance tasks

### DIFF
--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -41,6 +41,19 @@ module MaintenanceTasks
       redirect_to(task_path(error.run.task_name), alert: error.message)
     end
 
+    # Downloads the CSV sample
+    def csv_sample
+      task = TaskData.find(params.fetch(:id))
+      filename = "#{task.name.demodulize.underscore}_template.csv"
+
+      send_data(
+        task.csv_sample_content,
+        type: "text/csv",
+        disposition: "attachment",
+        filename: filename,
+      )
+    end
+
     private
 
     def set_refresh

--- a/app/models/maintenance_tasks/csv_collection_builder.rb
+++ b/app/models/maintenance_tasks/csv_collection_builder.rb
@@ -7,6 +7,8 @@ module MaintenanceTasks
   #
   # @api private
   class CsvCollectionBuilder
+    attr_accessor :csv_sample
+
     # Defines the collection to be iterated over, based on the provided CSV.
     #
     # @return [CSV] the CSV object constructed from the specified CSV content,
@@ -33,6 +35,14 @@ module MaintenanceTasks
     # Returns that the Task processes a collection.
     def no_collection?
       false
+    end
+
+    # Checks if CSV sample is present on the task.
+    #
+    # @return [boolean] true if sample is present, false otherwise.
+
+    def has_csv_sample?
+      csv_sample.present?
     end
   end
 end

--- a/app/models/maintenance_tasks/no_collection_builder.rb
+++ b/app/models/maintenance_tasks/no_collection_builder.rb
@@ -25,5 +25,17 @@ module MaintenanceTasks
     def no_collection?
       true
     end
+
+    def has_csv_sample?
+      false
+    end
+
+    def csv_sample
+      raise NotImplementedError, "Only CSV tasks can have a sample CSV"
+    end
+
+    def csv_sample=(_sample)
+      raise NotImplementedError, "Only CSV tasks can have a sample CSV"
+    end
   end
 end

--- a/app/models/maintenance_tasks/null_collection_builder.rb
+++ b/app/models/maintenance_tasks/null_collection_builder.rb
@@ -34,5 +34,17 @@ module MaintenanceTasks
     def no_collection?
       false
     end
+
+    def has_csv_sample?
+      false
+    end
+
+    def csv_sample
+      raise NotImplementedError, "Only CSV tasks can have a sample CSV"
+    end
+
+    def csv_sample=(_sample)
+      raise NotImplementedError, "Only CSV tasks can have a sample CSV"
+    end
   end
 end

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -22,6 +22,8 @@ module MaintenanceTasks
     class_attribute :collection_builder_strategy,
       default: NullCollectionBuilder.new
 
+    class_attribute :csv_sample
+
     define_callbacks :start, :complete, :error, :cancel, :pause, :interrupt
 
     class << self
@@ -72,6 +74,15 @@ module MaintenanceTasks
         end
       end
 
+      # Sets the CSV sample for the task.
+      def csv_sample(sample)
+        self.collection_builder_strategy.csv_sample = sample
+      end
+
+      def csv_sample_content
+        self.collection_builder_strategy.csv_sample
+      end
+
       # Make this a Task that calls #process once, instead of iterating over
       # a collection.
       def no_collection
@@ -79,7 +90,7 @@ module MaintenanceTasks
           MaintenanceTasks::NoCollectionBuilder.new
       end
 
-      delegate :has_csv_content?, :no_collection?,
+      delegate :has_csv_content?, :no_collection?, :has_csv_sample?,
         to: :collection_builder_strategy
 
       # Processes one item.

--- a/app/models/maintenance_tasks/task_data.rb
+++ b/app/models/maintenance_tasks/task_data.rb
@@ -140,6 +140,16 @@ module MaintenanceTasks
       !deleted? && Task.named(name).has_csv_content?
     end
 
+    # @return [String] CSV sample.
+    def csv_sample_content
+      Task.named(name).csv_sample_content
+    end
+
+    # @return [Boolean] whether the Task has a CSV sample.
+    def has_csv_sample?
+      Task.named(name).has_csv_sample?
+    end
+
     # @return [Array<String>] the names of parameters the Task accepts.
     def parameter_names
       if deleted?

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -31,6 +31,11 @@
     <%= form_with url: run_task_path(@task), method: :put do |form| %>
       <% if @task.csv_task? %>
         <div class="block">
+          <%  if @task.has_csv_sample? %>
+            <div>
+              <%= link_to("Download CSV Sample", sample_csv_task_path(@task)) %>
+            </div>
+          <% end %>
           <%= form.label :csv_file %>
           <%= form.file_field :csv_file %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ MaintenanceTasks::Engine.routes.draw do
   resources :tasks, only: [:index, :show], format: false do
     member do
       put "run"
+      get "csv_sample"
     end
 
     resources :runs, only: [], format: false do


### PR DESCRIPTION
We wanted to add a way for developers to define a CSV template when using the csv maintenance task.

<img width="1396" alt="image" src="https://user-images.githubusercontent.com/1433383/167606866-165fa0d2-e28e-446c-bcb4-eab9f73a593a.png">

Co-authored-by: @keoghpe 

TODOs:

- [ ] Add tests
- [ ] Add some docs