### PR TITLE
Fail on invalid CSV content type

### DIFF
--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -32,7 +32,7 @@
       <% if @task.csv_task? %>
         <div class="block">
           <%= form.label :csv_file %>
-          <%= form.file_field :csv_file %>
+          <%= form.file_field :csv_file, accept: "text/csv" %>
         </div>
       <% end %>
       <% parameter_names = @task.parameter_names %>

--- a/lib/maintenance_tasks/cli.rb
+++ b/lib/maintenance_tasks/cli.rb
@@ -58,9 +58,17 @@ module MaintenanceTasks
       csv_option = options[:csv]
 
       if csv_option == :stdin
-        { io: StringIO.new($stdin.read), filename: "stdin.csv" }
+        {
+          io: StringIO.new($stdin.read),
+          filename: "stdin.csv",
+          content_type: "text/csv",
+        }
       else
-        { io: File.open(csv_option), filename: File.basename(csv_option) }
+        {
+          io: File.open(csv_option),
+          filename: File.basename(csv_option),
+          content_type: "text/csv",
+        }
       end
     rescue Errno::ENOENT
       raise ArgumentError, "CSV file not found: #{csv_option}"

--- a/test/fixtures/files/sample.tsv
+++ b/test/fixtures/files/sample.tsv
@@ -1,0 +1,6 @@
+title	content
+My Title 1	Hello World 1!
+My Title 2	Hello World 2!
+My Title 3	Hello World 3!
+My Title 4	Hello World 4!
+My Title 5	Hello World 5!

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -21,6 +21,14 @@ module MaintenanceTasks
       refute_predicate run, :valid?
     end
 
+    test "invalid if content_type is not text/csv" do
+      run = Run.new(task_name: "Maintenance::ImportPostsTask")
+      tsv = Rack::Test::UploadedFile.new(file_fixture("sample.tsv"),
+        "text/tab-separated-values")
+      run.csv_file.attach(tsv)
+      refute_predicate run, :valid?
+    end
+
     test "invalid if associated Task has parameters and they are invalid" do
       run = Run.new(
         task_name: "Maintenance::ParamsTask",

--- a/test/models/maintenance_tasks/runner_test.rb
+++ b/test/models/maintenance_tasks/runner_test.rb
@@ -165,7 +165,7 @@ module MaintenanceTasks
     private
 
     def csv_io
-      { io: File.open(@csv), filename: "sample.csv" }
+      { io: File.open(@csv), filename: "sample.csv", content_type: "text/csv" }
     end
   end
 end


### PR DESCRIPTION
Co-authored-by: @promulo 

Closes #443 

## What are you trying to accomplish?
Fails early when the content type is not a "text/csv"
![image](https://user-images.githubusercontent.com/20158582/173867401-8b04a8af-78c7-4426-b544-2a3db59fd226.png)

## What should reviewers focus on?
We are setting the CLI `content_type` to be "text/csv" because unlike on the controller, the CLI csv_file is a hash.

### Before you deploy
- [X] I [tophatted](https://development.shopify.io/engineering/developing_at_Shopify/write-code/tophatting) or tested this change. (tested on my own sandbox repo)
- [x] This PR is [safe to rollback](https://development.shopify.io/engineering/developersToolbox/ship/safe_to_merge#Signs_your_PR_is_safe_to_rollback).