### PR TITLE
add an extra line in rspec template to avoid rubocop errors

### DIFF
--- a/lib/generators/maintenance_tasks/templates/task_spec.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/task_spec.rb.tt
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "rails_helper"
 
 module <%= tasks_module %>


### PR DESCRIPTION
**What are you trying to accomplish?**

When using the generator to create a new maintenance task and an associated spec I get a rubocop warning about having to add a new line "RuboCop: Add an empty line after magic comments. [Layout/EmptyLineAfterMagicComment]"