### PR TITLE
Add resume run action to RunsController

### DIFF
--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -24,6 +24,16 @@ module MaintenanceTasks
       redirect_to(task_path(@run.task_name), alert: error.message)
     end
 
+    # Resumes a previously paused Run.
+    def resume
+      Runner.run(name: @run.task_name)
+      redirect_to(task_path(@run.task_name))
+    rescue ActiveRecord::RecordInvalid => error
+      redirect_to(task_path(@run.task_name), alert: error.message)
+    rescue Runner::EnqueuingError => error
+      redirect_to(task_path(@run.task_name), alert: error.message)
+    end
+
     private
 
     def set_run

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -64,7 +64,7 @@
     <%= button_to 'Pausing', pause_task_run_path(@task, last_run), method: :put, class: 'button is-warning', disabled: true %>
     <%= button_to 'Cancel', cancel_task_run_path(@task, last_run), method: :put, class: 'button is-danger' %>
   <% elsif last_run.paused? %>
-    <%= button_to 'Resume', run_task_path(@task), method: :put, class: 'button is-primary', disabled: @task.deleted? %>
+    <%= button_to 'Resume', resume_task_run_path(@task, last_run), method: :put, class: 'button is-primary', disabled: @task.deleted? %>
     <%= button_to 'Cancel', cancel_task_run_path(@task, last_run), method: :put, class: 'button is-danger' %>
   <% else %>
     <%= button_to 'Pause', pause_task_run_path(@task, last_run), method: :put, class: 'button is-warning', disabled: @task.deleted? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ MaintenanceTasks::Engine.routes.draw do
       member do
         put "pause"
         put "cancel"
+        put "resume"
       end
     end
   end


### PR DESCRIPTION
This PR adds a `resume` route and controller action that takes an individual `Run` into account, in a similar fashion as `pause` and `cancel`.

Even though it seems redundant, this is ground work for a larger initiative, which is to allow tasks to have multiple active runs at a given time. I've decided to extract this particular bit in a separate PR since it is self-contained.

Current tests already cover the resume functionality, and that's why I haven't added any new tests.