### PR TITLE
Add support for multiple runs per task

### DIFF
--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -26,7 +26,7 @@ module MaintenanceTasks
 
     # Resumes a previously paused Run.
     def resume
-      Runner.run(name: @run.task_name)
+      Runner.resume(@run)
       redirect_to(task_path(@run.task_name))
     rescue ActiveRecord::RecordInvalid => error
       redirect_to(task_path(@run.task_name), alert: error.message)

--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -19,8 +19,9 @@ module MaintenanceTasks
     # Shows running and completed instances of the Task.
     def show
       @task = TaskData.find(params.fetch(:id))
-      set_refresh if @task.last_run&.active?
-      @runs_page = RunsPage.new(@task.previous_runs, params[:cursor])
+      @active_runs = @task.active_runs
+      set_refresh if @active_runs.any?
+      @runs_page = RunsPage.new(@task.completed_runs, params[:cursor])
     end
 
     # Runs a given Task and redirects to the Task page.

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -50,6 +50,7 @@ module MaintenanceTasks
     serialize :arguments, JSON
 
     scope :active, -> { where(status: ACTIVE_STATUSES) }
+    scope :completed, -> { where(status: COMPLETED_STATUSES) }
 
     # Ensure ActiveStorage is in use before preloading the attachments
     scope :with_attached_csv, -> do

--- a/app/views/maintenance_tasks/runs/_run.html.erb
+++ b/app/views/maintenance_tasks/runs/_run.html.erb
@@ -17,4 +17,21 @@
   <%= render "maintenance_tasks/runs/csv", run: run %>
   <%= tag.hr if run.csv_file.present? && run.arguments.present? %>
   <%= render "maintenance_tasks/runs/arguments", run: run %>
+
+  <div class="buttons">
+    <% if run.paused? %>
+      <%= button_to 'Resume', resume_task_run_path(@task, run), method: :put, class: 'button is-primary', disabled: @task.deleted? %>
+      <%= button_to 'Cancel', cancel_task_run_path(@task, run), method: :put, class: 'button is-danger' %>
+    <% elsif run.cancelling? %>
+      <% if run.stuck? %>
+        <%= button_to 'Cancel', cancel_task_run_path(@task, run), method: :put, class: 'button is-danger', disabled: @task.deleted? %>
+      <% end %>
+    <% elsif run.pausing? %>
+      <%= button_to 'Pausing', pause_task_run_path(@task, run), method: :put, class: 'button is-warning', disabled: true %>
+      <%= button_to 'Cancel', cancel_task_run_path(@task, run), method: :put, class: 'button is-danger' %>
+    <% elsif run.active? %>
+      <%= button_to 'Pause', pause_task_run_path(@task, run), method: :put, class: 'button is-warning', disabled: @task.deleted? %>
+      <%= button_to 'Cancel', cancel_task_run_path(@task, run), method: :put, class: 'button is-danger' %>
+    <% end%>
+  </div>
 </div>

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -1,79 +1,49 @@
 <% content_for :page_title, @task %>
 
 <h1 class="title is-1">
-  <%= @task %> <%= status_tag(@task.status) %>
+  <%= @task %>
 </h1>
 
-<% last_run = @task.last_run %>
-<% if last_run %>
-  <h5 class="title is-5">
-    <%= time_tag last_run.created_at, title: last_run.created_at %>
-  </h5>
-
-  <%= progress last_run %>
-
-  <div class="content">
-    <%= render "maintenance_tasks/runs/info/#{last_run.status}", run: last_run %>
-  </div>
-
-  <div class="content" id="custom-content">
-    <%= render "maintenance_tasks/runs/info/custom", run: last_run %>
-  </div>
-
-  <%= render "maintenance_tasks/runs/csv", run: last_run %>
-  <%= tag.hr if last_run.csv_file.present? %>
-  <%= render "maintenance_tasks/runs/arguments", run: last_run %>
-  <%= tag.hr if last_run.arguments.present? %>
-<% end %>
-
 <div class="buttons">
-  <% if last_run.nil? || last_run.completed? %>
-    <%= form_with url: run_task_path(@task), method: :put do |form| %>
-      <% if @task.csv_task? %>
-        <div class="block">
-          <%= form.label :csv_file %>
-          <%= form.file_field :csv_file, accept: "text/csv" %>
-        </div>
-      <% end %>
-      <% parameter_names = @task.parameter_names %>
-      <% if parameter_names.any? %>
-        <div class="block">
-          <%= form.fields_for :task_arguments, @task.new do |ff| %>
-            <% parameter_names.each do |parameter_name| %>
-              <div class="field">
-                <%= ff.label parameter_name, parameter_name, class: "label is-family-monospace" %>
-                <div class="control">
-                  <%= parameter_field(ff, parameter_name) %>
-                </div>
-              </div>
-            <% end %>
-          <% end %>
-        </div>
-      <% end %>
-      <%= render "maintenance_tasks/tasks/custom", form: form %>
+  <%= form_with url: run_task_path(@task), method: :put do |form| %>
+    <% if @task.csv_task? %>
       <div class="block">
-        <%= form.submit 'Run', class: "button is-success", disabled: @task.deleted? %>
+        <%= form.label :csv_file %>
+        <%= form.file_field :csv_file, accept: "text/csv" %>
       </div>
     <% end %>
-  <% elsif last_run.cancelling? %>
-    <%= button_to 'Run', run_task_path(@task), method: :put, class: 'button is-success', disabled: true %>
-    <% if last_run.stuck? %>
-      <%= button_to 'Cancel', cancel_task_run_path(@task, last_run), method: :put, class: 'button is-danger', disabled: @task.deleted? %>
+    <% parameter_names = @task.parameter_names %>
+    <% if parameter_names.any? %>
+      <div class="block">
+        <%= form.fields_for :task_arguments, @task.new do |ff| %>
+          <% parameter_names.each do |parameter_name| %>
+            <div class="field">
+              <%= ff.label parameter_name, parameter_name, class: "label is-family-monospace" %>
+              <div class="control">
+                <%= parameter_field(ff, parameter_name) %>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
     <% end %>
-  <% elsif last_run.pausing? %>
-    <%= button_to 'Pausing', pause_task_run_path(@task, last_run), method: :put, class: 'button is-warning', disabled: true %>
-    <%= button_to 'Cancel', cancel_task_run_path(@task, last_run), method: :put, class: 'button is-danger' %>
-  <% elsif last_run.paused? %>
-    <%= button_to 'Resume', resume_task_run_path(@task, last_run), method: :put, class: 'button is-primary', disabled: @task.deleted? %>
-    <%= button_to 'Cancel', cancel_task_run_path(@task, last_run), method: :put, class: 'button is-danger' %>
-  <% else %>
-    <%= button_to 'Pause', pause_task_run_path(@task, last_run), method: :put, class: 'button is-warning', disabled: @task.deleted? %>
-    <%= button_to 'Cancel', cancel_task_run_path(@task, last_run), method: :put, class: 'button is-danger' %>
-  <% end%>
+    <%= render "maintenance_tasks/tasks/custom", form: form %>
+    <div class="block">
+      <%= form.submit 'Run', class: "button is-success", disabled: @task.deleted? %>
+    </div>
+  <% end %>
 </div>
 
 <% if (code = @task.code) %>
   <pre><code><%= highlight_code(code) %></code></pre>
+<% end %>
+
+<% if @active_runs.any? %>
+  <hr/>
+
+  <h4 class="title is-4">Active Runs</h4>
+
+  <%= render @active_runs %>
 <% end %>
 
 <% if @runs_page.records.present? %>

--- a/db/migrate/20220713131925_add_index_on_task_name_and_status_to_runs.rb
+++ b/db/migrate/20220713131925_add_index_on_task_name_and_status_to_runs.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddIndexOnTaskNameAndStatusToRuns < ActiveRecord::Migration[6.0]
+  def change
+    remove_index(:maintenance_tasks_runs,
+      column: [:task_name, :created_at], order: { created_at: :desc },
+      name: :index_maintenance_tasks_runs_on_task_name_and_created_at)
+
+    add_index(:maintenance_tasks_runs, [:task_name, :status, :created_at],
+      name: :index_maintenance_tasks_runs,
+      order: { created_at: :desc })
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_06_101937) do
-
+ActiveRecord::Schema.define(version: 2022_07_13_131925) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -57,7 +56,7 @@ ActiveRecord::Schema.define(version: 2022_07_06_101937) do
     t.datetime "updated_at", precision: 6, null: false
     t.text "arguments"
     t.integer "lock_version", default: 0, null: false
-    t.index ["task_name", "created_at"], name: "index_maintenance_tasks_runs_on_task_name_and_created_at", order: { created_at: :desc }
+    t.index ["task_name", "status", "created_at"], name: "index_maintenance_tasks_runs", order: { created_at: :desc }
   end
 
   create_table "posts", force: :cascade do |t|

--- a/test/fixtures/maintenance_tasks/runs.yml
+++ b/test/fixtures/maintenance_tasks/runs.yml
@@ -10,6 +10,15 @@ update_posts_task:
   started_at: '01 Jan 2020 01:00:25'
   ended_at: '01 Jan 2020 01:00:36'
 
+update_posts_task_paused:
+  task_name: Maintenance::UpdatePostsTask
+  tick_count: 10
+  tick_total: 10
+  job_id: '123abc'
+  status: 'paused'
+  created_at: '18 Jul 2022 11:05:00'
+  started_at: '18 Jul 2022 11:05:20'
+
 deleted_task:
   task_name: Maintenance::DeletedTask
   tick_count: 10
@@ -28,3 +37,30 @@ paused_deleted_task:
   status: 'paused'
   created_at: '09 Jan 2020 09:30:00'
   started_at: '09 Jan 2020 09:30:25'
+
+no_collection_task_paused:
+  task_name: Maintenance::NoCollectionTask
+  tick_count: 5
+  tick_total: 10
+  job_id: '123abc'
+  status: 'paused'
+  created_at: '19 Jul 2022 11:05:00'
+  started_at: '19 Jul 2022 11:05:20'
+
+no_collection_task_enqueued:
+  task_name: Maintenance::NoCollectionTask
+  tick_count: 5
+  tick_total: 10
+  job_id: '123abc'
+  status: 'enqueued'
+  created_at: '19 Jul 2022 12:05:00'
+
+import_posts_task_succeeded:
+  task_name: Maintenance::ImportPostsTask
+  tick_count: 10
+  tick_total: 10
+  job_id: '123abc'
+  status: 'succeeded'
+  created_at: '01 Jan 2020 01:00:00'
+  started_at: '01 Jan 2020 01:00:25'
+  ended_at: '01 Jan 2020 01:00:36'

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -651,6 +651,11 @@ module MaintenanceTasks
       assert_predicate run, :cancelling?
     end
 
+    test "ACTIVE_STATUSES and COMPLETED_STATUSES contain all valid statuses" do
+      assert Run::STATUSES.sort ==
+        (Run::ACTIVE_STATUSES + Run::COMPLETED_STATUSES).sort
+    end
+
     private
 
     def count_uncached_queries(&block)

--- a/test/models/maintenance_tasks/task_data_test.rb
+++ b/test/models/maintenance_tasks/task_data_test.rb
@@ -29,6 +29,8 @@ module MaintenanceTasks
         "Maintenance::ErrorTask",
         "Maintenance::ImportPostsTask",
         "Maintenance::NoCollectionTask",
+        # duplicate due to fixtures containing two active runs of this task
+        "Maintenance::NoCollectionTask",
         "Maintenance::ParamsTask",
         "Maintenance::TestTask",
         "Maintenance::UpdatePostsInBatchesTask",
@@ -65,24 +67,13 @@ module MaintenanceTasks
       assert_nil task_data.code
     end
 
-    test "#last_run returns the last Run associated with the Task" do
-      Run.create!(
-        task_name: "Maintenance::UpdatePostsTask",
-        status: :succeeded
-      )
-      latest = Run.create!(task_name: "Maintenance::UpdatePostsTask")
-      task_data = TaskData.new("Maintenance::UpdatePostsTask")
-
-      assert_equal latest, task_data.last_run
-    end
-
     test "#to_s returns the name of the Task" do
       task_data = TaskData.new("Maintenance::UpdatePostsTask")
 
       assert_equal "Maintenance::UpdatePostsTask", task_data.to_s
     end
 
-    test "#previous_runs returns all Runs for the Task except the first one" do
+    test "#completed_runs returns all completed Runs for the Task" do
       run_1 = maintenance_tasks_runs(:update_posts_task)
 
       run_2 = Run.create!(
@@ -94,17 +85,17 @@ module MaintenanceTasks
 
       task_data = TaskData.find("Maintenance::UpdatePostsTask")
 
-      assert_equal 2, task_data.previous_runs.count
-      assert_equal run_2, task_data.previous_runs.first
-      assert_equal run_1, task_data.previous_runs.last
+      assert_equal 2, task_data.completed_runs.count
+      assert_equal run_2, task_data.completed_runs.first
+      assert_equal run_1, task_data.completed_runs.last
     end
 
-    test "#previous_runs is empty when there are no Runs for the Task" do
+    test "#completed_runs is empty when there are no Runs for the Task" do
       Run.destroy_all
 
       task_data = TaskData.find("Maintenance::UpdatePostsTask")
 
-      assert_empty task_data.previous_runs
+      assert_empty task_data.completed_runs
     end
 
     test "#deleted? returns true if the Task does not exist" do
@@ -116,20 +107,22 @@ module MaintenanceTasks
     end
 
     test "#status is new when Task does not have any Runs" do
-      Run.destroy_all
-      task_data = TaskData.find("Maintenance::UpdatePostsTask")
+      task_data = TaskData.new("Maintenance::UpdatePostsTask")
       assert_equal "new", task_data.status
     end
 
     test "#status is the latest Run status" do
-      Run.create!(task_name: "Maintenance::UpdatePostsTask", status: :paused)
-      task_data = TaskData.find("Maintenance::UpdatePostsTask")
+      run = Run.create!(
+        task_name: "Maintenance::UpdatePostsTask",
+        status: :paused
+      )
+      task_data = TaskData.new("Maintenance::UpdatePostsTask", run)
       assert_equal "paused", task_data.status
     end
 
     test "#category returns :active if the task is active" do
-      Run.create!(task_name: "Maintenance::UpdatePostsTask")
-      task_data = TaskData.new("Maintenance::UpdatePostsTask")
+      run = Run.create!(task_name: "Maintenance::UpdatePostsTask")
+      task_data = TaskData.new("Maintenance::UpdatePostsTask", run)
       assert_equal :active, task_data.category
     end
 
@@ -138,11 +131,11 @@ module MaintenanceTasks
     end
 
     test "#category returns :completed if the task is completed" do
-      Run.create!(
+      run = Run.create!(
         task_name: "Maintenance::UpdatePostsTask",
         status: :succeeded
       )
-      task_data = TaskData.new("Maintenance::UpdatePostsTask")
+      task_data = TaskData.new("Maintenance::UpdatePostsTask", run)
       assert_equal :completed, task_data.category
     end
 

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -13,7 +13,6 @@ module MaintenanceTasks
       assert_title "Maintenance::UpdatePostsTask"
       assert_text "Enqueued"
       assert_text "Waiting to start."
-      assert_no_button "Run"
     end
 
     test "run a CSV Task" do
@@ -26,7 +25,6 @@ module MaintenanceTasks
       assert_title "Maintenance::ImportPostsTask"
       assert_text "Enqueued"
       assert_text "Waiting to start."
-      assert_no_button "Run"
     end
 
     test "run a Task that accepts parameters" do
@@ -97,7 +95,7 @@ module MaintenanceTasks
     test "resume a Run" do
       visit maintenance_tasks_path
 
-      click_on("Maintenance::UpdatePostsTask")
+      click_on("Maintenance::UpdatePostsInBatchesTask")
       click_on "Run"
       click_on "Pause"
       perform_enqueued_jobs
@@ -111,7 +109,7 @@ module MaintenanceTasks
     test "cancel a Run" do
       visit maintenance_tasks_path
 
-      click_on("Maintenance::UpdatePostsTask")
+      click_on("Maintenance::UpdatePostsInBatchesTask")
       click_on "Run"
       click_on "Cancel"
 
@@ -122,7 +120,7 @@ module MaintenanceTasks
     test "cancel a pausing Run" do
       visit maintenance_tasks_path
 
-      click_on("Maintenance::UpdatePostsTask")
+      click_on("Maintenance::UpdatePostsInBatchesTask")
       click_on "Run"
       click_on "Pause"
       assert_text "Pausing"
@@ -134,7 +132,7 @@ module MaintenanceTasks
     test "cancel a stuck Run" do
       visit maintenance_tasks_path
 
-      click_on("Maintenance::UpdatePostsTask")
+      click_on("Maintenance::UpdatePostsInBatchesTask")
       click_on "Run"
       click_on "Cancel"
 
@@ -175,19 +173,25 @@ module MaintenanceTasks
     test "errors for double enqueue are shown" do
       visit maintenance_tasks_path
 
-      click_on("Maintenance::UpdatePostsTask")
+      click_on("Maintenance::UpdatePostsInBatchesTask")
+
+      click_on "Run"
+      click_on "Pause"
+
+      perform_enqueued_jobs
+
+      page.refresh
 
       url = page.current_url
       using_session(:other_tab) do
         visit url
-        click_on "Run"
-        click_on "Pause"
+        click_on "Resume"
       end
 
-      click_on "Run"
+      click_on "Resume"
 
       alert_text = "Validation failed: " \
-        "Status Cannot transition run from status pausing to enqueued"
+        "Status Cannot transition run from status enqueued to enqueued"
       assert_text alert_text
     end
 
@@ -211,7 +215,7 @@ module MaintenanceTasks
 
     test "errors for invalid pause or cancel due to stale UI are shown" do
       visit maintenance_tasks_path
-      click_on("Maintenance::UpdatePostsTask")
+      click_on("Maintenance::UpdatePostsInBatchesTask")
 
       url = page.current_url
       click_on "Run"

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -17,21 +17,23 @@ module MaintenanceTasks
       visit maintenance_tasks_path
 
       expected = [
+        "Active Tasks",
+        "Maintenance::NoCollectionTask\nEnqueued",
+        "Maintenance::NoCollectionTask\nPaused",
+        "Maintenance::UpdatePostsTask\nPaused",
         "New Tasks",
         "Maintenance::BatchImportPostsTask\nNew",
         "Maintenance::CallbackTestTask\nNew",
         "Maintenance::CancelledEnqueueTask\nNew",
         "Maintenance::EnqueueErrorTask\nNew",
         "Maintenance::ErrorTask\nNew",
-        "Maintenance::ImportPostsTask\nNew",
-        "Maintenance::NoCollectionTask\nNew",
         "Maintenance::ParamsTask\nNew",
         "Maintenance::TestTask\nNew",
         "Maintenance::UpdatePostsInBatchesTask\nNew",
         "Maintenance::UpdatePostsModulePrependedTask\nNew",
         "Maintenance::UpdatePostsThrottledTask\nNew",
         "Completed Tasks",
-        "Maintenance::UpdatePostsTask\nSucceeded",
+        "Maintenance::ImportPostsTask\nSucceeded",
       ]
 
       assert_equal expected, page.all("h3").map(&:text)
@@ -45,6 +47,20 @@ module MaintenanceTasks
       assert_title "Maintenance::UpdatePostsTask"
       assert_text "Succeeded"
       assert_text "Ran for less than 5 seconds, finished 8 days ago."
+    end
+
+    test "show a Task with active and completed runs" do
+      visit maintenance_tasks_path
+
+      click_on("Maintenance::UpdatePostsTask")
+
+      assert_title "Maintenance::UpdatePostsTask"
+      assert_text "Paused"
+
+      assert_equal ["Active Runs", "Previous Runs"], page.all("h4").map(&:text)
+      runs = page.all("h5").map(&:text)
+      assert_includes runs, "July 18, 2022 11:05\nPaused"
+      assert_includes runs, "January 01, 2020 01:00\nSucceeded"
     end
 
     test "task with attributes renders default values on the form" do


### PR DESCRIPTION
Currently, only one task run can be active (running or paused) at a given time. This PR intends to add support for multiple runs for a given task to the gem.

The approach here was to introduce as least disruption as possible and implement minimal changes to both backend and UI, still adhering to current patterns. The dashboard and individual task pages were tweaked a bit in order to allow displaying more than one run for the same task. This means we should rely less on the concept of _last run_ and more on _active runs_.

I haven't experienced issues when manually testing this. Multiple task runs can be triggered using the usual _Run_ button and individual runs can be paused and resumed accordingly.

This is how the "new" index page looks like with these changes (the list of "New Tasks" and "Completed Tasks" look the same):

<img width="906" alt="image" src="https://user-images.githubusercontent.com/450960/179249021-e4660b71-099f-4753-b7a3-6fb56e61bb59.png">

The above screenshot shows a real example of two runs of the same task being active at the same time.

As for the individual task page, this is the current state:

<img width="694" alt="image" src="https://user-images.githubusercontent.com/450960/179249368-7c7484fd-e479-494f-b03e-be98b05e92cd.png">

That is an example of a task with multiple active runs listed on its own page.

I will keep pushing changes to this branch but wanted to have some early feedback. The proposed UI might not be what we want. I'm also considering splitting this in separate backend/frontend PRs if that favors iteration. 

Thanks!