### PR TITLE
Don't rescue callback errors

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -140,7 +140,7 @@ module MaintenanceTasks
         backtrace: MaintenanceTasks.backtrace_cleaner.clean(error.backtrace),
         ended_at: Time.now,
       )
-      run_task_callbacks(:error)
+      run_error_callback
     rescue ActiveRecord::StaleObjectError
       reload_status
       retry
@@ -264,7 +264,7 @@ module MaintenanceTasks
     #   specified by the Task.
     def start(count)
       update!(started_at: Time.now, tick_total: count)
-      run_task_callbacks(:start)
+      task.run_callbacks(:start)
     rescue ActiveRecord::StaleObjectError
       reload_status
       retry
@@ -430,6 +430,12 @@ module MaintenanceTasks
 
     def run_task_callbacks(callback)
       task.run_callbacks(callback)
+    rescue Task::NotFoundError
+      nil
+    end
+
+    def run_error_callback
+      task.run_callbacks(:error)
     rescue
       nil
     end

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -172,6 +172,18 @@ module MaintenanceTasks
       run.persist_error(error)
     end
 
+    test "#persist_error can handle error callback raising" do
+      run = Run.create!(task_name: "Maintenance::CallbackTestTask")
+      error = ArgumentError.new("Something went wrong")
+      error.set_backtrace(["lib/foo.rb:42:in `bar'"])
+
+      run.task.expects(:after_error_callback).raises("Callback error!")
+
+      assert_nothing_raised do
+        run.persist_error(error)
+      end
+    end
+
     test "#persist_error does not raise on longer error class names" do
       run = Run.create!(task_name: "Maintenance::ErrorTask")
       error = ArgumentError.new("Something went wrong")


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/687

Callback errors should be allowed to bubble up, halting task execution
and triggering the error handler. We should only rescue errors raised
in the `after_error` callback, since these are not handled any other way.

We _do_ need to rescue `Task::NotFound` errors though, in case a Task is deleted in the middle of running.