### PR TITLE
Use resourceful route for running a Task

### DIFF
--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -6,7 +6,25 @@ module MaintenanceTasks
   #
   # @api private
   class RunsController < ApplicationController
-    before_action :set_run
+    before_action :set_run, except: :create
+
+    # Creates a Run for a given Task and redirects to the Task page.
+    def create(&block)
+      task = Runner.run(
+        name: params.fetch(:task_id),
+        csv_file: params[:csv_file],
+        arguments: params.fetch(:task_arguments, {}).permit!.to_h,
+        &block
+      )
+      redirect_to(task_path(task))
+    rescue ActiveRecord::RecordInvalid => error
+      redirect_to(task_path(error.record.task_name), alert: error.message)
+    rescue ActiveRecord::ValueTooLong => error
+      task_name = params.fetch(:id)
+      redirect_to(task_path(task_name), alert: error.message)
+    rescue Runner::EnqueuingError => error
+      redirect_to(task_path(error.run.task_name), alert: error.message)
+    end
 
     # Updates a Run status to paused.
     def pause

--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -24,24 +24,6 @@ module MaintenanceTasks
       @runs_page = RunsPage.new(@task.completed_runs, params[:cursor])
     end
 
-    # Runs a given Task and redirects to the Task page.
-    def run(&block)
-      task = Runner.run(
-        name: params.fetch(:id),
-        csv_file: params[:csv_file],
-        arguments: params.fetch(:task_arguments, {}).permit!.to_h,
-        &block
-      )
-      redirect_to(task_path(task))
-    rescue ActiveRecord::RecordInvalid => error
-      redirect_to(task_path(error.record.task_name), alert: error.message)
-    rescue ActiveRecord::ValueTooLong => error
-      task_name = params.fetch(:id)
-      redirect_to(task_path(task_name), alert: error.message)
-    rescue Runner::EnqueuingError => error
-      redirect_to(task_path(error.run.task_name), alert: error.message)
-    end
-
     private
 
     def set_refresh

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -5,7 +5,7 @@
 </h1>
 
 <div class="buttons">
-  <%= form_with url: run_task_path(@task), method: :put do |form| %>
+  <%= form_with url: task_runs_path(@task), method: :post do |form| %>
     <% if @task.csv_task? %>
       <div class="block">
         <%= form.label :csv_file %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,11 +2,7 @@
 
 MaintenanceTasks::Engine.routes.draw do
   resources :tasks, only: [:index, :show], format: false do
-    member do
-      put "run"
-    end
-
-    resources :runs, only: [], format: false do
+    resources :runs, only: [:create], format: false do
       member do
         put "pause"
         put "cancel"


### PR DESCRIPTION
Closes: https://github.com/Shopify/maintenance_tasks/issues/671

Instead of using a custom tasks#run route, we should move this action to the RunsController as runs#create, taking advantage of conventional CRUD operations.

Note that this will be a breaking change for apps who are patching the `TasksController` to provide a block for `tasks#run` (see https://github.com/Shopify/maintenance_tasks/pull/559). We may need to follow up with these apps after the 2.0 release.