### PR TITLE
Document process for backporting features to release branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,3 +834,15 @@ Once a release is ready, follow these steps:
 
 [release]: https://help.github.com/articles/creating-releases/
 [shipit]: https://shipit.shopify.io/shopify/maintenance_tasks/rubygems
+
+### Backporting changes to a previous major version
+
+Bug fixes and backwards-compatible changes should typically be backported to previous
+major versions of the gem. To do this, follow these steps:
+
+* Checkout the release branch you'd like to backport changes to, e.g. `v1.x`
+* Cherry-pick relevant commits to that branch. If changes were just merged into main,
+you can use `git cherry-pick main -m 1` to cherry-pick the most recent merge commit.
+* Bump the spec version in `maintenance_tasks.gemspec` and run `bundle install`.
+* Follow the process documented above to cut a release, ensuring that it's pointed
+to the correct branch (e.g. `v1.x`).


### PR DESCRIPTION
Important bug-fixes and features should be backported to the `v1.x` branch, and future major versions of the gem (ie. once we've rolled out v2.0, if we wanted to release an eventual 3.0, we'd want a `v2.x` branch to backport fixes to).

I've added some notes to the README on how to do this.