### PR TITLE
Release 2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    maintenance_tasks (1.10.1)
+    maintenance_tasks (2.0.0)
       actionpack (>= 6.0)
       activejob (>= 6.0)
       activerecord (>= 6.0)

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "maintenance_tasks"
-  spec.version = "1.10.1"
+  spec.version = "2.0.0"
   spec.author = "Shopify Engineering"
   spec.email = "gems@shopify.com"
   spec.homepage = "https://github.com/Shopify/maintenance_tasks"


### PR DESCRIPTION
With our all of our 2.0 milestones tackled, I think we're ready to release v2.0 for the gem!

I've drafted up a release [here](https://github.com/Shopify/maintenance_tasks/releases/edit/untagged-ace2100246d37ac480bf) that could use feedback.

Let me know if there's anything else we should address before performing a major version bump.