### PR TITLE
Prevent double loading of net-protocol in Ruby 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+        rubygems: ${{ matrix.ruby == '2.7' && 'latest' || 'default' }}
     - name: Rails version
       if: ${{ matrix.gemfile == 'gemfiles/rails_edge.gemfile' }}
       run: bundle info rails | head -1

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gemspec
 gem "better_html"
 gem "capybara"
 gem "mocha"
+gem "net-http" # Ruby 2.7 stdlib's net/http loads net/protocol relatively, which loads both the stdlib and gem version
 gem "net-smtp" # mail is missing a dependency on net-smtp https://github.com/mikel/mail/pull/1439
 gem "pg"
 gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,8 @@ GEM
     mini_portile2 (2.8.0)
     minitest (5.16.3)
     mocha (1.15.0)
+    net-http (0.2.2)
+      uri
     net-imap (0.2.3)
       digest
       net-protocol
@@ -228,6 +230,7 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
+    uri (0.11.0)
     webdrivers (5.2.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -253,6 +256,7 @@ DEPENDENCIES
   capybara
   maintenance_tasks!
   mocha
+  net-http
   net-smtp
   pg
   pry-byebug


### PR DESCRIPTION
Ruby 2.7 stdlib's net-http, loaded by capybara, loads net/protocol from the stdlib ([with require_relative](https://github.com/ruby/ruby/blob/v2_7_6/lib/net/http.rb#L23)), and then we get [warnings for re-defining constants](https://github.com/Shopify/maintenance_tasks/actions/runs/3174329071/jobs/5170982966#step:7:8) when loading the gem version from net-smtp.

This fixes it by also using net-http as a gem, which since 3.0 loads it correctly with `require "net/protocol"`

Resolves #707 

It was also necessary to update rubygems for Ruby 2.7, otherwise there was an issue of stdlib's uri being loaded before the gem.