### PR TITLE
Add documentation option for tasks

### DIFF
--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -21,6 +21,9 @@ module MaintenanceTasks
     # @api private
     class_attribute :collection_builder_strategy, default: NullCollectionBuilder.new
 
+    # @api private
+    class_attribute :task_documentation
+
     define_callbacks :start, :complete, :error, :cancel, :pause, :interrupt
 
     class << self
@@ -167,6 +170,13 @@ module MaintenanceTasks
       #   (see https://api.rubyonrails.org/classes/ActiveSupport/Callbacks/ClassMethods.html#method-i-set_callback)
       def after_error(*filter_list, &block)
         set_callback(:error, :after, *filter_list, &block)
+      end
+
+      # Set the documentation string for the task
+      #
+      # @param doc [String] the documentation for the task
+      def documentation(doc)
+        self.task_documentation = doc
       end
 
       private

--- a/app/models/maintenance_tasks/task_data_show.rb
+++ b/app/models/maintenance_tasks/task_data_show.rb
@@ -99,6 +99,15 @@ module MaintenanceTasks
       end
     end
 
+    # @return [String] the documentation string for the Task
+    def task_documentation
+      if deleted?
+        nil
+      else
+        Task.named(name).task_documentation
+      end
+    end
+
     # @return [MaintenanceTasks::Task, nil] an instance of the Task class.
     # @return [nil] if the Task file was deleted.
     def new

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -4,6 +4,13 @@
   <%= @task %>
 </h1>
 
+<% if @task.task_documentation %>
+  </br>
+  <h4 class="subtitle is-4">Documentation:</h4>
+  <p><%= @task.task_documentation %></p>
+  </br>
+<% end %>
+
 <div class="buttons">
   <%= form_with url: task_runs_path(@task), method: :post do |form| %>
     <% if @task.csv_task? %>

--- a/test/dummy/app/tasks/maintenance/update_posts_task.rb
+++ b/test/dummy/app/tasks/maintenance/update_posts_task.rb
@@ -6,6 +6,8 @@ module Maintenance
       attr_accessor :fast_task
     end
 
+    documentation "This task updates posts"
+
     def collection
       Post.all
     end

--- a/test/models/maintenance_tasks/task_data_show_test.rb
+++ b/test/models/maintenance_tasks/task_data_show_test.rb
@@ -113,5 +113,14 @@ module MaintenanceTasks
     test "#new returns nil for a deleted Task" do
       assert_nil TaskDataShow.new("Maintenance::DoesNotExist").new
     end
+
+    test "#task_documentation returns the docs for a task" do
+      docs = TaskDataShow.new("Maintenance::UpdatePostsTask").task_documentation
+      assert_equal "This task updates posts", docs
+    end
+
+    test "#task_documentation returns nil for a deleted Task" do
+      assert_nil TaskDataShow.new("Maintenance::DoesNotExist").task_documentation
+    end
   end
 end

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -95,5 +95,12 @@ module MaintenanceTasks
     ensure
       Maintenance::TestTask.throttle_conditions = []
     end
+
+    test ".documentation sets task documentation" do
+      docs = "this is the documentation for the TestTask"
+      Maintenance::TestTask.documentation(docs)
+
+      assert_equal(Maintenance::TestTask.task_documentation, docs)
+    end
   end
 end

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -57,7 +57,9 @@ module MaintenanceTasks
       assert_title "Maintenance::UpdatePostsTask"
       assert_text "Paused"
 
-      assert_equal ["Active Runs", "Previous Runs"], page.all("h4").map(&:text)
+      assert_text "This task updates posts"
+
+      assert_equal ["Documentation:", "Active Runs", "Previous Runs"], page.all("h4").map(&:text)
       runs = page.all("h5").map(&:text)
       assert_includes runs, "July 18, 2022 11:05\nPaused"
       assert_includes runs, "January 01, 2020 01:00\nSucceeded"


### PR DESCRIPTION
I wanted to request the ability to add documentation for a task that would be displayed in the UI and I figured a Pull Request was the best way to get the conversation started on that. 

### The Problem

Imagine I had the following maintenance task:

```ruby
module Maintenance
  class DeletePostsTask < MaintenanceTasks::Task
    attribute :title_match, :string

    def collection
      Post.all
    end

    def process(post)
      return unless /#{title_match}/.match? post.title
      post.destroy
    end
  end
end
```

This can be conveniently used from the UI to delete posts. However I would like to notify the user of some things before they hit `Run`, notably that `title_match` is a regex and that this deletion is permanent. This example is somewhat contrived, but as it stands there's not a great way for me to warn the user about those things. I can put a comment in the task itself which they'll see if they read the displayed code, but I don't really expect people to do that.

### Proposal

I'd like to add something like a `documentation` field:

```ruby
module Maintenance
  class DeletePostsTask < MaintenanceTasks::Task
    documentation <<~TEXT
      Deletes posts whose titles match title_match as a regular expression.
      WARNING: deletion is PERMANENT.
    TEXT

    attribute :title_match, :string

    def collection
      Post.all
    end

    def process(post)
      return unless /#{title_match}/.match?(post.title)

      post.destroy
    end
  end
end
```

This will be displayed on the task's page like so:

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/3507058/195174709-fd4bb96a-ac95-46f2-a3df-1b41cf5f78da.png">

### Caveats

1: The current implementation doesn't support styling at all. You basically just get one paragraph of plain text. Could possibly support injecting markdown or something but that seems like overkill.

2: I'm not a designer so this might be ugly.

3: It'd be nice to add the ability to document individual attributes as well, but in order to do something like 

```ruby
module Maintenance
  class DeletePostsTask < MaintenanceTasks::Task
    attribute :title_match, :string, documentation: "a regular expression matching post titles to delete"
    # ...
  end
end
```

One would need to override the definition of `.attribute` provided by `ActiveModel::Attributes` which seems hairy even if it's just `super` plus parsing out some new options.

An alternative would be to have a separate method call like:

```ruby
module Maintenance
  class DeletePostsTask < MaintenanceTasks::Task
    attribute :title_match, :string
    attribute_documentation :title_match, "a regular expression matching post titles to delete"
    # ...
  end
end
```

but that feels a bit awkward (should it error if the attribute isn't present?)

---

I tried my best to follow what seem to be the conventions of the repo, but this is my first time touching it. I'm happy to work with someone on making this adhere to the standards of the project, and I don't mind changing the details of the implementation if needed.
