### PR TITLE
Pin puma to prevent compatibility issue with Capybara

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "mocha"
 gem "net-smtp" # mail is missing a dependency on net-smtp https://github.com/mikel/mail/pull/1439
 gem "pg"
 gem "pry-byebug"
-gem "puma"
+gem "puma", "< 6.0"
 if defined?(@rails_gem_requirement) && @rails_gem_requirement
   # causes Dependabot to ignore the next line and update the next gem "rails"
   rails = "rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,7 +256,7 @@ DEPENDENCIES
   net-smtp
   pg
   pry-byebug
-  puma
+  puma (< 6.0)
   rails
   rubocop (= 1.36.0)
   rubocop-shopify


### PR DESCRIPTION
It's fixed in
https://github.com/teamcapybara/capybara/commit/de2f221aeb4688de9d428db696f34acb44b02739 but not yet released.

That will unblock #712 and #714.