### PR TITLE
Remove EXISTS query on tasks#show

### DIFF
--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -18,10 +18,14 @@ module MaintenanceTasks
     # Renders the page responsible for providing Task actions to users.
     # Shows running and completed instances of the Task.
     def show
-      @task = TaskDataShow.find(params.fetch(:id))
-      @active_runs = @task.active_runs
-      set_refresh if @active_runs.any?
+      task_name = params.fetch(:id)
+      @task = TaskDataShow.new(task_name)
+      @task.active_runs.load
+      set_refresh if @task.active_runs.any?
       @runs_page = RunsPage.new(@task.completed_runs, params[:cursor])
+      unless @task.active_runs.any? || @runs_page.records.any?
+        Task.named(task_name)
+      end
     end
 
     private

--- a/app/models/maintenance_tasks/task_data_show.rb
+++ b/app/models/maintenance_tasks/task_data_show.rb
@@ -11,26 +11,6 @@ module MaintenanceTasks
   #
   # @api private
   class TaskDataShow
-    class << self
-      # Initializes a Task Data by name, raising if the Task does not exist.
-      #
-      # For the purpose of this method, a Task does not exist if it's deleted
-      # and doesn't have a Run. While technically, it could have existed and
-      # been deleted since, if it never had a Run we may as well consider it
-      # non-existent since we don't have interesting data to show.
-      #
-      # @param name [String] the name of the Task subclass.
-      # @return [TaskDataShow] a Task Data instance.
-      # @raise [Task::NotFoundError] if the Task does not exist and doesn't have
-      #   a Run.
-      def find(name)
-        task_data = new(name)
-        task_data.active_runs.load
-        task_data.has_any_run? || Task.named(name)
-        task_data
-      end
-    end
-
     # Initializes a Task Data with a name and optionally a related run.
     #
     # @param name [String] the name of the Task subclass.
@@ -105,12 +85,6 @@ module MaintenanceTasks
       return if deleted?
 
       MaintenanceTasks::Task.named(name).new
-    end
-
-    # @return [Boolean] whether the Task has any Run.
-    # @api private
-    def has_any_run?
-      active_runs.any? || completed_runs.any?
     end
 
     private

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -38,12 +38,12 @@
   <pre><code><%= highlight_code(code) %></code></pre>
 <% end %>
 
-<% if @active_runs.any? %>
+<% if @task.active_runs.any? %>
   <hr/>
 
   <h4 class="title is-4">Active Runs</h4>
 
-  <%= render @active_runs %>
+  <%= render @task.active_runs %>
 <% end %>
 
 <% if @runs_page.records.present? %>

--- a/test/models/maintenance_tasks/task_data_show_test.rb
+++ b/test/models/maintenance_tasks/task_data_show_test.rb
@@ -4,22 +4,6 @@ require "test_helper"
 
 module MaintenanceTasks
   class TaskDataShowTest < ActiveSupport::TestCase
-    test ".find returns a TaskDataShow for an existing Task" do
-      task_data = TaskDataShow.find("Maintenance::UpdatePostsTask")
-      assert_equal "Maintenance::UpdatePostsTask", task_data.name
-    end
-
-    test ".find returns a TaskDataShow for a deleted Task with a Run" do
-      task_data = TaskDataShow.find("Maintenance::DeletedTask")
-      assert_equal "Maintenance::DeletedTask", task_data.name
-    end
-
-    test ".find raises if the Task does not exist" do
-      assert_raises Task::NotFoundError do
-        TaskDataShow.find("Maintenance::DoesNotExist")
-      end
-    end
-
     test "#code returns the code source of the Task" do
       task_data = TaskDataShow.new("Maintenance::UpdatePostsTask")
 
@@ -55,7 +39,7 @@ module MaintenanceTasks
 
       Run.create!(task_name: "Maintenance::UpdatePostsTask")
 
-      task_data = TaskDataShow.find("Maintenance::UpdatePostsTask")
+      task_data = TaskDataShow.new("Maintenance::UpdatePostsTask")
 
       assert_equal 2, task_data.completed_runs.count
       assert_equal run_2, task_data.completed_runs.first
@@ -65,7 +49,7 @@ module MaintenanceTasks
     test "#completed_runs is empty when there are no Runs for the Task" do
       Run.destroy_all
 
-      task_data = TaskDataShow.find("Maintenance::UpdatePostsTask")
+      task_data = TaskDataShow.new("Maintenance::UpdatePostsTask")
 
       assert_empty task_data.completed_runs
     end


### PR DESCRIPTION
Fixes https://github.com/Shopify/maintenance_tasks/issues/677

Since we're paginating, we're already loading the completed runs, so we can avoid one query by checking there's either an active run or a completed run before checking if it's a deleted task.

This is done by inlining TaskDataShow.find into the controller and then moving the Task.named call at the very last moment.

This has a small implication, if you "paginate" past the last cursor of a deleted task, you'll get a 404 instead of the empty task page with the last run at the top. This is not accessible via links anyway so it's fine.

Co-authored-by: Adrianna Chang <adrianna.chang@shopify.com>