### PR TITLE
Fix test on Rails edge

### DIFF
--- a/test/helpers/maintenance_tasks/tasks_helper_test.rb
+++ b/test/helpers/maintenance_tasks/tasks_helper_test.rb
@@ -85,6 +85,7 @@ module MaintenanceTasks
       run = Run.new(task_name: "Maintenance::ImportPostsTask")
       csv = Rack::Test::UploadedFile.new(file_fixture("sample.csv"), "text/csv")
       run.csv_file.attach(csv)
+      run.save!
 
       assert_match %r{rails/active_storage/blobs/\S+/sample.csv},
         csv_file_download_path(run)


### PR DESCRIPTION
Generating a signed ID for the URL for an Active Storage Blob now requires that it's persisted.

https://github.com/rails/rails/pull/47027