### PR TITLE
load_constants now supports namespace nesting

### DIFF
--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -175,7 +175,13 @@ module MaintenanceTasks
         namespace = MaintenanceTasks.tasks_module.safe_constantize
         return unless namespace
 
-        namespace.constants.map { |constant| namespace.const_get(constant) }
+        load_const = lambda do |root|
+          root.constants.each do |name|
+            object = root.const_get(name)
+            load_const.call(object) if object.instance_of?(Module)
+          end
+        end
+        load_const.call(namespace)
       end
     end
 


### PR DESCRIPTION
When a large number of tasks were added, we wanted to separate them by namespace, but only those directly under MaintenanceTasks.tasks_module were targeted, so we modified it to read the namespace recursively.