### PR TITLE
Remove `pg` gem as a development requirement

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,10 +13,7 @@ Before engaging with this community, please read and understand our
 
 ## Setting up development environment
 
-* Make sure you have PostgreSQL installed, to be able to build the `pg` gem's
-  native extensions.
-  * If you're on MacOS and using Homebrew, you can `brew install postgresql`.
-* Everything else follows standard Rails practices:
+* The gem follows standard Rails practices:
   * `bundle install` to install dependencies
   * `bin/rails server` to start the server
   * `bin/rails test` to run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         ruby: ["2.7", "3.0", "3.1"]
         database: [sqlite]
         include:
-          - gemfile: Gemfile
+          - gemfile: "gemfiles/postgresql.gemfile"
             ruby: 3.1
             database: postgres
     env:

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "capybara"
 gem "mocha"
 gem "net-http" # Ruby 2.7 stdlib's net/http loads net/protocol relatively, which loads both the stdlib and gem version
 gem "net-smtp" # mail is missing a dependency on net-smtp https://github.com/mikel/mail/pull/1439
-gem "pg"
 gem "pry-byebug"
 gem "puma", "< 7.0"
 if defined?(@rails_gem_requirement) && @rails_gem_requirement

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,6 @@ GEM
     parallel (1.22.1)
     parser (3.2.0.0)
       ast (~> 2.4.1)
-    pg (1.4.5)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -261,7 +260,6 @@ DEPENDENCIES
   mocha
   net-http
   net-smtp
-  pg
   pry-byebug
   puma (< 7.0)
   rails

--- a/gemfiles/postgresql.gemfile
+++ b/gemfiles/postgresql.gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+gem "pg"
+
+eval_gemfile "../Gemfile"


### PR DESCRIPTION
PosgreSQL is not an actual development requirement for this gem and asking everyone to install it only discourages contributions and make it less approachable for cloud-based environments like codespaces.
For many parts of the maintenance tasks even an in-memory `sqlite` database will suffice. 

So this PR removes the `pg` gem from the `Gemfile` and moves it to a separate gemfile which will be used on CI only. 