### PR TITLE
Add Rails 7 and Ruby 3.2 to ci matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gemfile: [Gemfile, gemfiles/rails_6_0.gemfile, gemfiles/rails_6_1.gemfile, gemfiles/rails_edge.gemfile]
-        ruby: ["2.7", "3.0", "3.1"]
+        gemfile: [Gemfile, gemfiles/rails_6_0.gemfile, gemfiles/rails_6_1.gemfile, gemfiles/rails_7_0.gemfile, gemfiles/rails_edge.gemfile]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
         database: [sqlite]
         include:
           - gemfile: "gemfiles/postgresql.gemfile"

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+@rails_gem_requirement = "~> 7.0.4"
+
+eval_gemfile "../Gemfile"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,6 +40,11 @@ require "csv"
 module Warning
   class << self
     def warn(message)
+      # gems/selenium-webdriver-4.7.1/lib/selenium/webdriver/remote/bridge.rb:633:
+      # warning: Expected selenium/webdriver/remote/commands
+      # to define Selenium::WebDriver::Remote::COMMANDS but it didn't
+      return if message.match?(/Selenium::WebDriver::Remote::COMMANDS/)
+
       raise message.to_s
     end
   end


### PR DESCRIPTION
Additions to the CI:

`Ruby 3.2` - Just a new ruby version

`Rails 7` - Every day Rails 7 differs from rails edge more and more and now it's actually closer to Rails 7.1 so I would like to test specifically against Rails 7.

❓ 
- Ruby 2.7 has end of life in a few month. I don't think it means we should drop the support right now but we might want to do it soon
