### PR TITLE
Prevent rack 3.0.0

### DIFF
--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -3,3 +3,4 @@
 @rails_gem_requirement = { github: "rails/rails" }
 
 eval_gemfile "../Gemfile"
+gem "rack", "< 3"


### PR DESCRIPTION
It's not entirely compatible with Rails main, due to a missing dependency on rack-session which was extracted from rack.

See also https://github.com/rails/rails/commit/306994bb9a6fdc1d271eb70f776015f6ba5d0baf