### PR TITLE
Remove silenced warning by requiring necessary file

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -2,6 +2,7 @@
 
 require "test_helper"
 require "webdrivers/chromedriver"
+require "selenium/webdriver/remote/commands"
 require "action_dispatch/system_testing/server"
 
 ActionDispatch::SystemTesting::Server.silence_puma = true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,11 +40,6 @@ require "csv"
 module Warning
   class << self
     def warn(message)
-      # gems/selenium-webdriver-4.7.1/lib/selenium/webdriver/remote/bridge.rb:633:
-      # warning: Expected selenium/webdriver/remote/commands
-      # to define Selenium::WebDriver::Remote::COMMANDS but it didn't
-      return if message.match?(/Selenium::WebDriver::Remote::COMMANDS/)
-
       raise message.to_s
     end
   end


### PR DESCRIPTION
`Selenium::WebDriver::Remote::COMMANDS` does not exist but instead it's `Selenium::WebDriver::Remote::Bridge::COMMANDS,` defined in `selenium/webdriver/remote/commands`

https://github.com/SeleniumHQ/selenium/blob/selenium-4.7.1-ruby/rb/lib/selenium/webdriver/remote.rb#L30

I'll rebase once #757 is merged.