### PR TITLE
Upgrade Bulma CSS from 0.9.3 to 0.9.4

### DIFF
--- a/app/views/layouts/maintenance_tasks/application.html.erb
+++ b/app/views/layouts/maintenance_tasks/application.html.erb
@@ -15,9 +15,9 @@
     <%= csrf_meta_tags %>
 
     <%=
-      stylesheet_link_tag(URI.join(controller.class::BULMA_CDN, 'npm/bulma@0.9.3/css/bulma.css'),
+      stylesheet_link_tag(URI.join(controller.class::BULMA_CDN, 'npm/bulma@0.9.4/css/bulma.css'),
         media: :all,
-        integrity: 'sha384-Zkr9rpl37lclZu6AwYQZZm0CxiMqLZFiibodW+UXLnAWPBr6qgIzPpcmHkpwnyWD',
+        integrity: 'sha384-qQlNh1kc0FyhUqUDXKkl5wpiiSm8PXQw2ZWhAVfU46tmdMDfq2vXG2CXWYT+Dls3',
         crossorigin: 'anonymous') unless request.xhr?
     %>
 


### PR DESCRIPTION
Quick upgrade of Bulma from 0.9.3 to 0.9.4.

https://github.com/jgthms/bulma/releases/tag/0.9.4

🎩 🎩 🎩 🎩 🎩 
<img width="1920" alt="Screenshot 2023-02-09 at 15 19 46" src="https://user-images.githubusercontent.com/1557529/217734007-1b52d0ce-d520-437e-aff2-df06888fccdf.png">
<img width="1920" alt="Screenshot 2023-02-09 at 15 21 08" src="https://user-images.githubusercontent.com/1557529/217734025-f213f276-a1ee-43dc-9de1-d278fa12de2c.png">
