### PR TITLE
Use the newer `serialize` signature of Rails 7.1 if available

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -46,8 +46,13 @@ module MaintenanceTasks
 
     attr_readonly :task_name
 
-    serialize :backtrace
-    serialize :arguments, JSON
+    if Rails.gem_version >= Gem::Version.new("7.1.alpha")
+      serialize :backtrace, coder: YAML
+      serialize :arguments, coder: JSON
+    else
+      serialize :backtrace
+      serialize :arguments, JSON
+    end
 
     scope :active, -> { where(status: ACTIVE_STATUSES) }
     scope :completed, -> { where(status: COMPLETED_STATUSES) }


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/47463

On 7.1 serialize properly split `coder` and `type` arguments instead of taking a single positional argument and try to figure out which is which.

While we're at it, we can explictly define we're using YAML here instead of relying on the default that is now configurable.