### PR TITLE
Make error handler proc be called with job as self

### DIFF
--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -177,7 +177,7 @@ module MaintenanceTasks
       end
       errored_element = @errored_element if defined?(@errored_element)
     ensure
-      MaintenanceTasks.error_handler.call(error, task_context, errored_element)
+      instance_exec(*[error, task_context, errored_element], &MaintenanceTasks.error_handler)
     end
   end
 end

--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -177,7 +177,7 @@ module MaintenanceTasks
       end
       errored_element = @errored_element if defined?(@errored_element)
     ensure
-      instance_exec(*[error, task_context, errored_element], &MaintenanceTasks.error_handler)
+      instance_exec(error, task_context, errored_element, &MaintenanceTasks.error_handler)
     end
   end
 end

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -337,11 +337,13 @@ module MaintenanceTasks
       handled_error = nil
       handled_task_context = nil
       handled_errored_element = nil
+      handled_self_klass = nil
 
       MaintenanceTasks.error_handler = ->(error, task_context, errored_el) do
         handled_error = error
         handled_task_context = task_context
         handled_errored_element = errored_el
+        handled_self_klass = self.class
       end
 
       run = Run.create!(task_name: "Maintenance::ErrorTask")
@@ -351,6 +353,7 @@ module MaintenanceTasks
       assert_equal(ArgumentError, handled_error.class)
       assert_equal("Maintenance::ErrorTask", handled_task_context[:task_name])
       assert_equal(2, handled_errored_element)
+      assert_equal(TaskJob, handled_self_klass)
     ensure
       MaintenanceTasks.error_handler = error_handler_before
     end
@@ -375,9 +378,11 @@ module MaintenanceTasks
       error_handler_before = MaintenanceTasks.error_handler
       handled_error = nil
       handled_task_context = nil
+      handled_self_klass = nil
       MaintenanceTasks.error_handler = ->(error, task_context, _errored_el) do
         handled_error = error
         handled_task_context = task_context
+        handled_self_klass = self.class
       end
 
       RaisingTaskJob = Class.new(TaskJob) do
@@ -388,6 +393,7 @@ module MaintenanceTasks
 
       assert_equal("Uh oh!", handled_error.message)
       assert_empty(handled_task_context)
+      assert_equal(RaisingTaskJob, handled_self_klass)
     ensure
       MaintenanceTasks.error_handler = error_handler_before
     end


### PR DESCRIPTION
In error handler I would like to have access to job's methods, so I think it would be perfect to use instance_exec to make `self` inside error_handler proc, instance of job in which error was raised.