### PR TITLE
Preserve inputs by only refreshing parts of the page

### DIFF
--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -15,7 +15,7 @@ module MaintenanceTasks
       )
       policy.script_src(
         # page refresh script
-        "'sha256-2RPaBS4XCMLp0JJ/sW407W9l4qjC+WQAHmTOFJTGfqo='",
+        "'sha256-NiHKryHWudRC2IteTqmY9v1VkaDUA/5jhgXkMTkgo2w='",
       )
       policy.frame_ancestors(:self)
     end

--- a/app/views/layouts/maintenance_tasks/application.html.erb
+++ b/app/views/layouts/maintenance_tasks/application.html.erb
@@ -33,17 +33,19 @@
 
     <script>
       function refresh() {
-        if (!("refresh" in document.body.dataset)) return
+        const target = document.querySelector("[data-refresh]")
+        if (!target || !target.dataset.refresh) return
         window.setTimeout(() => {
           document.body.style.cursor = "wait"
           fetch(document.location, { headers: { "X-Requested-With": "XMLHttpRequest" } }).then(
             async response => {
               const text = await response.text()
               const newDocument = new DOMParser().parseFromString(text, "text/html")
-              document.body.replaceWith(newDocument.body)
-              <%# force a redraw for Safari %>
-              window.scrollTo({ top: document.documentElement.scrollTop + 1 })
-              window.scrollTo({ top: document.documentElement.scrollTop - 1 })
+              const newTarget = newDocument.querySelector("[data-refresh]")
+              if (newTarget) {
+                target.replaceWith(newTarget)
+              }
+              document.body.style.cursor = ""
               refresh()
             },
             error => location.reload()
@@ -54,7 +56,7 @@
     </script>
   </head>
 
-  <%= tag.body(data: { refresh: defined?(@refresh) && @refresh }) do %>
+  <body>
     <%= render 'layouts/maintenance_tasks/navbar' %>
 
     <section class="section">
@@ -68,5 +70,5 @@
         <%= yield %>
       </div>
     </div>
-  <% end %>
+  </body>
 </html>

--- a/app/views/maintenance_tasks/tasks/index.html.erb
+++ b/app/views/maintenance_tasks/tasks/index.html.erb
@@ -1,22 +1,24 @@
-<% if @available_tasks.empty? %>
-  <div class="content is-large">
-    <h3 class="title is-3"> The MaintenanceTasks gem has been successfully installed! </h3>
-    <p>
-      Any new Tasks will show up here. To start writing your first Task,
-      run <code>bin/rails generate maintenance_tasks:task my_task</code>.
-    </p>
-  </div>
-<% else %>
-  <% if active_tasks = @available_tasks[:active] %>
-    <h3 class="title is-3">Active Tasks</h3>
-    <%= render partial: 'task', collection: active_tasks %>
-  <% end %>
-  <% if new_tasks = @available_tasks[:new] %>
-    <h3 class="title is-3">New Tasks</h3>
-    <%= render partial: 'task', collection: new_tasks %>
-  <% end %>
-  <% if completed_tasks = @available_tasks[:completed] %>
-    <h3 class="title is-3">Completed Tasks</h3>
-    <%= render partial: 'task', collection: completed_tasks %>
+<%= tag.div(data: { refresh: (defined?(@refresh) && @refresh) || "" }) do %>
+  <% if @available_tasks.empty? %>
+    <div class="content is-large">
+      <h3 class="title is-3"> The MaintenanceTasks gem has been successfully installed! </h3>
+      <p>
+        Any new Tasks will show up here. To start writing your first Task,
+        run <code>bin/rails generate maintenance_tasks:task my_task</code>.
+      </p>
+    </div>
+  <% else %>
+    <% if active_tasks = @available_tasks[:active] %>
+      <h3 class="title is-3">Active Tasks</h3>
+      <%= render partial: 'task', collection: active_tasks %>
+    <% end %>
+    <% if new_tasks = @available_tasks[:new] %>
+      <h3 class="title is-3">New Tasks</h3>
+      <%= render partial: 'task', collection: new_tasks %>
+    <% end %>
+    <% if completed_tasks = @available_tasks[:completed] %>
+      <h3 class="title is-3">Completed Tasks</h3>
+      <%= render partial: 'task', collection: completed_tasks %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -38,20 +38,22 @@
   <pre><code><%= highlight_code(code) %></code></pre>
 <% end %>
 
-<% if @task.active_runs.any? %>
-  <hr/>
+<%= tag.div(data: { refresh: (defined?(@refresh) && @refresh) || "" }) do %>
+  <% if @task.active_runs.any? %>
+    <hr/>
 
-  <h4 class="title is-4">Active Runs</h4>
+    <h4 class="title is-4">Active Runs</h4>
 
-  <%= render @task.active_runs %>
-<% end %>
+    <%= render @task.active_runs %>
+  <% end %>
 
-<% if @runs_page.records.present? %>
-  <hr/>
+  <% if @runs_page.records.present? %>
+    <hr/>
 
-  <h4 class="title is-4">Previous Runs</h4>
+    <h4 class="title is-4">Previous Runs</h4>
 
-  <%= render @runs_page.records %>
+    <%= render @runs_page.records %>
 
-  <%= link_to "Next page", task_path(@task, cursor: @runs_page.next_cursor) unless @runs_page.last? %>
+    <%= link_to "Next page", task_path(@task, cursor: @runs_page.next_cursor) unless @runs_page.last? %>
+  <% end %>
 <% end %>

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -34,18 +34,19 @@ module MaintenanceTasks
       post_id = Post.first.id
       fill_in("_task_arguments_post_ids", with: post_id.to_s)
 
-      perform_enqueued_jobs do
-        click_on "Run"
-      end
+      click_on "Run"
+      fill_in("_task_arguments_post_ids", with: "42")
+      perform_enqueued_jobs
 
       assert_title "Maintenance::ParamsTask"
-      assert_text "Succeeded"
+      assert_text "Succeeded", wait: 3 # refreshes every 3 seconds
       assert_text "Processed 1 out of 1 item (100%)."
       assert_text "Arguments"
       assert_table do |table|
         table.assert_text("post_ids")
         table.assert_text(post_id.to_s)
       end
+      assert has_field?("_task_arguments_post_ids", with: "42")
     end
 
     test "errors for Task with invalid arguments shown" do


### PR DESCRIPTION
We've added support to have multiple runs of the same task in 2.0, but it's pretty frustrating when the task has attributes and you want to fill some values in the task page, because the page gets refreshed after 3 seconds, and we don't have a way to stop that.

Instead of replacing the entire `<body>`, this PR only replaces some parts of the page, which allows to preserve the inputs.

[This turned out to be a bit flaky](https://github.com/Shopify/maintenance_tasks/actions?query=branch%3Adont-refresh-inputs) because previously with the `perform_enqueued_jobs` as a block, it was running the jobs inline, so by the time the page was refreshed, the job was already succeeded, which wasn't always the case when clicking Run and then performing the jobs.

This does mean the test now relies on the refresh working, which is a nice side effect, but I had to increase the wait time to make sure the page was refreshed via JavaScript in the test. Now we can see the value in the input isn't lost by the refresh.

cc @joelpinheiro who reported the issue