### PR TITLE
Skips abstract classes from task UI

### DIFF
--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -175,7 +175,17 @@ module MaintenanceTasks
         namespace = MaintenanceTasks.tasks_module.safe_constantize
         return unless namespace
 
-        namespace.constants.map { |constant| namespace.const_get(constant) }
+        namespace.constants
+          .map { |constant| namespace.const_get(constant) }
+          .filter { |klass| can_initialize?(klass) }
+      end
+
+      def can_initialize?(klass)
+        klass.new
+
+        true
+      rescue
+        false
       end
     end
 

--- a/test/dummy/app/tasks/maintenance/abstract_task.rb
+++ b/test/dummy/app/tasks/maintenance/abstract_task.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class AbstractTask < MaintenanceTasks::Task
+    def initialize
+      raise NotImplementedError
+    end
+  end
+end


### PR DESCRIPTION
This is a draft, more a check to see if the idea makes sense — I haven't run the tests yet. That said…

In a project we have an abstract-base class for maintenance tasks, and it appears on the web UI. Surely one cannot run it:

```
RuntimeError in MaintenanceTasks::RunsController#create
Maintenance::BaseTask is declared as abstract; it cannot be instantiated
```

So I thought that this gem shouldn't show abstract classes in the web UI. Does that make sense?

If so… this PRs suggests:
1. a private helper `#can_initialize?(klass)` to tell if a class can be initialized (I don't want to inject Sorbet here, so the basic assumption is that if `klass.new` fails it will break the controller as in the error above)
2. filter out all classes that cannot be initialized from the `#load_constants` that is used in the controller (maybe there's more to it, another reason this is mostly a draft to get feedback on the idea)
3. Add an abstract class (or a fake abstract class) to the dummy/test app and still expects the same output in the task model test

I am not 100% convinced about the `#can_initialize?(klass)` implementation though — any ideas? 