### PR TITLE
Handle Rails 7.1 deprecation of TestFixtures#fixture_path

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,12 +24,15 @@ end
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 
 # Load fixtures from the engine
-if ActiveSupport::TestCase.respond_to?(:fixture_path=)
+if ActiveSupport::TestCase.respond_to?(:fixture_paths=)
+  ActiveSupport::TestCase.fixture_paths = [File.expand_path("fixtures", __dir__)]
+  ActionDispatch::IntegrationTest.fixture_paths = ActiveSupport::TestCase.fixture_paths
+  ActiveSupport::TestCase.file_fixture_path = File.expand_path("fixtures", __dir__) + "/files"
+  ActiveSupport::TestCase.fixtures(:all)
+elsif ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.fixture_path = File.expand_path("fixtures", __dir__)
-  ActionDispatch::IntegrationTest.fixture_path =
-    ActiveSupport::TestCase.fixture_path
-  ActiveSupport::TestCase.file_fixture_path =
-    ActiveSupport::TestCase.fixture_path + "/files"
+  ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
+  ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + "/files"
   ActiveSupport::TestCase.fixtures(:all)
 end
 


### PR DESCRIPTION
We still have to support 7.0 and below.