### PR TITLE
Allow tasks to be loaded from nested task directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,6 +696,26 @@ MaintenanceTasks.tasks_module = "TaskModule"
 
 If no value is specified, it will default to `Maintenance`.
 
+#### Organizing tasks using namespaces
+
+Tasks may be nested arbitrarily deeply under `app/tasks/maintenance`, for example given a
+task file `app/tasks/maintenance/team_name/service_name/update_posts_task.rb` we
+can define the task as:
+
+```ruby
+module Maintenance
+  module TeamName
+    module ServiceName
+      class UpdatePostsTask < MaintenanceTasks::Task
+        def process(rows)
+          # ...
+        end
+      end
+    end
+  end
+end
+```
+
 #### Customizing the underlying job class
 
 `MaintenanceTasks.job` can be configured to define a Job class for your tasks to

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -175,7 +175,13 @@ module MaintenanceTasks
         namespace = MaintenanceTasks.tasks_module.safe_constantize
         return unless namespace
 
-        namespace.constants.map { |constant| namespace.const_get(constant) }
+        load_const = lambda do |root|
+          root.constants.each do |name|
+            object = root.const_get(name)
+            load_const.call(object) if object.instance_of?(Module)
+          end
+        end
+        load_const.call(namespace)
       end
     end
 

--- a/test/dummy/app/tasks/maintenance/nested/nested_more/nested_more_task.rb
+++ b/test/dummy/app/tasks/maintenance/nested/nested_more/nested_more_task.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Maintenance
+  module Nested
+    module NestedMore
+      class NestedMoreTask < MaintenanceTasks::Task
+        def process(rows)
+          # Task only exists to verify correct loading of tasks within subfolders
+        end
+      end
+    end
+  end
+end

--- a/test/dummy/app/tasks/maintenance/nested/nested_more/nested_more_task.rb
+++ b/test/dummy/app/tasks/maintenance/nested/nested_more/nested_more_task.rb
@@ -4,7 +4,9 @@ module Maintenance
   module Nested
     module NestedMore
       class NestedMoreTask < MaintenanceTasks::Task
-        def process(rows)
+        no_collection
+
+        def process
           # Task only exists to verify correct loading of tasks within subfolders
         end
       end

--- a/test/dummy/app/tasks/maintenance/nested/nested_task.rb
+++ b/test/dummy/app/tasks/maintenance/nested/nested_task.rb
@@ -3,7 +3,9 @@
 module Maintenance
   module Nested
     class NestedTask < MaintenanceTasks::Task
-      def process(rows)
+      no_collection
+
+      def process
         # Task only exists to verify correct loading of tasks within subfolders
       end
     end

--- a/test/dummy/app/tasks/maintenance/nested/nested_task.rb
+++ b/test/dummy/app/tasks/maintenance/nested/nested_task.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Maintenance
+  module Nested
+    class NestedTask < MaintenanceTasks::Task
+      def process(rows)
+        # Task only exists to verify correct loading of tasks within subfolders
+      end
+    end
+  end
+end

--- a/test/models/maintenance_tasks/task_data_index_test.rb
+++ b/test/models/maintenance_tasks/task_data_index_test.rb
@@ -12,6 +12,7 @@ module MaintenanceTasks
         "Maintenance::EnqueueErrorTask",
         "Maintenance::ErrorTask",
         "Maintenance::ImportPostsTask",
+        "Maintenance::Nested::NestedMore::NestedMoreTask",
         "Maintenance::Nested::NestedTask",
         "Maintenance::NoCollectionTask",
         # duplicate due to fixtures containing two active runs of this task

--- a/test/models/maintenance_tasks/task_data_index_test.rb
+++ b/test/models/maintenance_tasks/task_data_index_test.rb
@@ -12,6 +12,7 @@ module MaintenanceTasks
         "Maintenance::EnqueueErrorTask",
         "Maintenance::ErrorTask",
         "Maintenance::ImportPostsTask",
+        "Maintenance::Nested::NestedTask",
         "Maintenance::NoCollectionTask",
         # duplicate due to fixtures containing two active runs of this task
         "Maintenance::NoCollectionTask",

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -12,6 +12,7 @@ module MaintenanceTasks
         "Maintenance::EnqueueErrorTask",
         "Maintenance::ErrorTask",
         "Maintenance::ImportPostsTask",
+        "Maintenance::Nested::NestedMore::NestedMoreTask",
         "Maintenance::Nested::NestedTask",
         "Maintenance::NoCollectionTask",
         "Maintenance::ParamsTask",

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -12,6 +12,7 @@ module MaintenanceTasks
         "Maintenance::EnqueueErrorTask",
         "Maintenance::ErrorTask",
         "Maintenance::ImportPostsTask",
+        "Maintenance::Nested::NestedTask",
         "Maintenance::NoCollectionTask",
         "Maintenance::ParamsTask",
         "Maintenance::TestTask",

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -27,6 +27,7 @@ module MaintenanceTasks
         "Maintenance::CancelledEnqueueTask\nNew",
         "Maintenance::EnqueueErrorTask\nNew",
         "Maintenance::ErrorTask\nNew",
+        "Maintenance::Nested::NestedTask\nNew",
         "Maintenance::ParamsTask\nNew",
         "Maintenance::TestTask\nNew",
         "Maintenance::UpdatePostsInBatchesTask\nNew",

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -27,6 +27,7 @@ module MaintenanceTasks
         "Maintenance::CancelledEnqueueTask\nNew",
         "Maintenance::EnqueueErrorTask\nNew",
         "Maintenance::ErrorTask\nNew",
+        "Maintenance::Nested::NestedMore::NestedMoreTask\nNew",
         "Maintenance::Nested::NestedTask\nNew",
         "Maintenance::ParamsTask\nNew",
         "Maintenance::TestTask\nNew",


### PR DESCRIPTION
In [shop-server](https://github.com/Shopify/shop-server/tree/main/app/tasks/maintenance) we have tasks which are in sub-folders (e.g. `app/tasks/maintenance/deep_understanding`). These are available in production, but in development they are not automatically loaded, making them harder to test (TODO: verify this).

Before this PR, only tasks directly under `app/tasks` will be loaded in development. After this commit, one level of nesting is supported.