### PR TITLE
Fix parameter name when creating a run fails due to an argument that's too long

### DIFF
--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -20,7 +20,7 @@ module MaintenanceTasks
     rescue ActiveRecord::RecordInvalid => error
       redirect_to(task_path(error.record.task_name), alert: error.message)
     rescue ActiveRecord::ValueTooLong => error
-      task_name = params.fetch(:id)
+      task_name = params.fetch(:task_id)
       redirect_to(task_path(task_name), alert: error.message)
     rescue Runner::EnqueuingError => error
       redirect_to(task_path(error.run.task_name), alert: error.message)


### PR DESCRIPTION
@adrianna-chang-shopify this is what I asked about earlier today - technically SQLite does have a limit (default of 1 billion bytes), but trying that breaks Selenium.