### PR TITLE
Removes unused code

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -32,7 +32,6 @@ module MaintenanceTasks
       :cancelled,
     ]
     COMPLETED_STATUSES = [:succeeded, :errored, :cancelled]
-    COMPLETED_RUNS_LIMIT = 10
     STUCK_TASK_TIMEOUT = 5.minutes
 
     enum status: STATUSES.to_h { |status| [status, status.to_s] }


### PR DESCRIPTION
If my understanding is correct, this constant is no longer used. There is no reference to it elsewhere in the codebase.

Unless there is something special about this constant that a dependency relies upon?