### PR TITLE
feat(tags): Adding the ability to tag tasks for filtering on the index page

### DIFF
--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -12,7 +12,9 @@ module MaintenanceTasks
     # Renders the maintenance_tasks/tasks page, displaying
     # available tasks to users, grouped by category.
     def index
-      @available_tasks = TaskDataIndex.available_tasks.group_by(&:category)
+      tag = params[:tag] || nil
+
+      @available_tasks = TaskDataIndex.available_tasks(tag).group_by(&:category)
     end
 
     # Renders the page responsible for providing Task actions to users.

--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -12,7 +12,7 @@ module MaintenanceTasks
     # Renders the maintenance_tasks/tasks page, displaying
     # available tasks to users, grouped by category.
     def index
-      tag = params[:tag] || nil
+      tag = params[:tag]
 
       @available_tasks = TaskDataIndex.available_tasks(tag).group_by(&:category)
     end

--- a/app/helpers/maintenance_tasks/tasks_helper.rb
+++ b/app/helpers/maintenance_tasks/tasks_helper.rb
@@ -63,6 +63,15 @@ module MaintenanceTasks
       tag.span(status.capitalize, class: ["tag"] + STATUS_COLOURS.fetch(status))
     end
 
+    # Returns the list of all available tags.
+    #
+    # This list is used to filter Tasks by tags in the index page.
+    #
+    # @return [Array<String>] the list of all available tags.
+    def tag_names
+      MaintenanceTasks::Task.available_tasks.map(&:tags).flatten.uniq
+    end
+
     # Reports the approximate elapsed time a Run has been processed so far based
     # on the Run's time running attribute.
     #

--- a/app/helpers/maintenance_tasks/tasks_helper.rb
+++ b/app/helpers/maintenance_tasks/tasks_helper.rb
@@ -69,7 +69,7 @@ module MaintenanceTasks
     #
     # @return [Array<String>] the list of all available tags.
     def tag_names
-      MaintenanceTasks::Task.available_tasks.map(&:tags).flatten.uniq
+      @tag_names = MaintenanceTasks::Task.available_tasks.flat_map(&:tags).uniq
     end
 
     # Reports the approximate elapsed time a Run has been processed so far based

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -21,6 +21,10 @@ module MaintenanceTasks
     # @api private
     class_attribute :collection_builder_strategy, default: NullCollectionBuilder.new
 
+    # The tags for a given Task. This is provided as an array of strings.
+    # Tags are used to group and filter tasks in the UI.
+    class_attribute :tags, default: []
+
     define_callbacks :start, :complete, :error, :cancel, :pause, :interrupt
 
     class << self

--- a/app/models/maintenance_tasks/task_data_index.rb
+++ b/app/models/maintenance_tasks/task_data_index.rb
@@ -19,13 +19,19 @@ module MaintenanceTasks
       # Determining a Task's category requires their latest Run records.
       # Two queries are done to get the currently active and completed Run
       # records, and Task Data instances are initialized with these related run
-      # values.
+      # values. Tasks are filtered by tag if a tag is provided.
       #
       # @return [Array<TaskDataIndex>] the list of Task Data.
-      def available_tasks
+      def available_tasks(tag = nil)
         tasks = []
 
-        task_names = Task.available_tasks.map(&:name)
+        task_names = Task.available_tasks
+
+        if tag.present?
+          task_names.select!{ |t| t.tags.include?(tag.to_sym) }
+        end
+
+        task_names.map!(&:name)
 
         active_runs = Run.with_attached_csv.active.where(task_name: task_names)
         active_runs.each do |run|

--- a/app/views/maintenance_tasks/tasks/index.html.erb
+++ b/app/views/maintenance_tasks/tasks/index.html.erb
@@ -8,6 +8,14 @@
       </p>
     </div>
   <% else %>
+    <% if tag_names.any? %>
+      <h3 class="title is-3">Task Tags</h3>
+      <div class="box">
+        <% tag_names.each do |t| %>
+          <%= link_to "#{t} ", tasks_path(tag: t) %>
+        <% end %>
+      </div>
+    <% end %>
     <% if active_tasks = @available_tasks[:active] %>
       <h3 class="title is-3">Active Tasks</h3>
       <%= render partial: 'task', collection: active_tasks %>

--- a/test/dummy/app/tasks/maintenance/batch_import_posts_task.rb
+++ b/test/dummy/app/tasks/maintenance/batch_import_posts_task.rb
@@ -2,6 +2,8 @@
 
 module Maintenance
   class BatchImportPostsTask < MaintenanceTasks::Task
+    self.tags = [:one_off, :data_maintenance]
+
     csv_collection(in_batches: 2)
 
     def process(post_rows)

--- a/test/dummy/app/tasks/maintenance/import_posts_task.rb
+++ b/test/dummy/app/tasks/maintenance/import_posts_task.rb
@@ -2,6 +2,8 @@
 
 module Maintenance
   class ImportPostsTask < MaintenanceTasks::Task
+    self.tags = [:data_maintenance]
+
     csv_collection
 
     def process(row)

--- a/test/helpers/maintenance_tasks/tasks_helper_test.rb
+++ b/test/helpers/maintenance_tasks/tasks_helper_test.rb
@@ -54,6 +54,10 @@ module MaintenanceTasks
       assert_equal expected, status_tag("pausing")
     end
 
+    test "#tag_names returns a lists of tags assigned to tasks" do
+      assert_equal ["data_maintenance", "one_off"], tag_names
+    end
+
     test "#time_running_in_words reports the approximate time running of the given Run" do
       @run.time_running = 182.5
       assert_equal "3 minutes", time_running_in_words(@run)

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -4,6 +4,15 @@ require "application_system_test_case"
 
 module MaintenanceTasks
   class TasksTest < ApplicationSystemTestCase
+    test "list all tags" do
+      visit maintenance_tasks_path
+
+      assert_title "Maintenance Tasks"
+
+      assert_link "one_off"
+      assert_link "data_maintenance"
+    end
+
     test "list all tasks" do
       visit maintenance_tasks_path
 


### PR DESCRIPTION
- In our team's usage of maintenance tasks we found that with the additions of new tasks, and previous runs displaying raw data it made it difficult to find specific tasks.
- We wanted a way to be able to group certain tasks either by domain or usage.
- Adding the ability to filter by using links defined by tags on the tasks.
- If there are tags assigned to any task, it will be listed at the top of the index page. The tags are links to the tasks controller with a parameter of the selected tag. This will only surface tasks that have the given tag.

When no tasks have assigned tags:
<img width="1273" alt="Screenshot 2023-04-29 at 12 16 26 AM" src="https://user-images.githubusercontent.com/3063931/235284886-7d0229bf-95b3-4f06-a9b6-aa601ace0cd8.png">

When tasks have assigned tags:
<img width="1158" alt="Screenshot 2023-04-29 at 12 15 40 AM" src="https://user-images.githubusercontent.com/3063931/235284899-afe1011b-f8c3-4a46-ac1c-47c581d2dae0.png">

Demo:
https://user-images.githubusercontent.com/3063931/235284910-65f7fd35-a18f-4214-b7e9-8b7f3efe3035.mov

