### PR TITLE
Inherit from `::ApplicationController`

### DIFF
--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -4,7 +4,7 @@ module MaintenanceTasks
   # Base class for all controllers used by this engine.
   #
   # Can be extended to add different authentication and authorization code.
-  class ApplicationController < ActionController::Base
+  class ApplicationController < ::ApplicationController
     BULMA_CDN = "https://cdn.jsdelivr.net"
 
     content_security_policy do |policy|


### PR DESCRIPTION
I think we should default to inheriting from the application's `ApplicationController` as documented here: https://guides.rubyonrails.org/engines.html#using-a-controller-provided-by-the-application

This ensures the web UI handles requests/security etc as the including application has already specified.