### PR TITLE
Add `parent_controller` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,6 +804,33 @@ MaintenanceTasks.backtrace_cleaner = cleaner
 If none is specified, the default `Rails.backtrace_cleaner` will be used to
 clean backtraces.
 
+#### Customizing the parent controller for the web UI
+
+`MaintenanceTasks.parent_controller` can be configured to specify a controller class 
+for all of the web UI engine's controllers to inherit from.
+
+This allows applications with common logic in their `ApplicationController` (or any other controller) 
+to optionally configure the web UI to inherit that logic with a simple assignment in the initializer.
+
+```ruby
+# config/initializers/maintenance_tasks.rb
+
+MaintenanceTasks.parent_controller = "CustomController"
+
+# app/controllers/services/custom_controller.rb
+
+class Services::CustomController < ActionController::Base
+  include CustomSecurityThings
+  include CustomLoggingThings
+  ...
+end
+```
+
+The parent controller value **must** be a string corresponding to an existing 
+controller class which **must inherit** from `ActionController::Base`. 
+
+If no value is specified, it will default to `"ActionController::Base"`.
+
 ## Upgrading
 
 Use bundler to check for and upgrade to newer versions. After installing a new

--- a/README.md
+++ b/README.md
@@ -806,11 +806,12 @@ clean backtraces.
 
 #### Customizing the parent controller for the web UI
 
-`MaintenanceTasks.parent_controller` can be configured to specify a controller class 
-for all of the web UI engine's controllers to inherit from.
+`MaintenanceTasks.parent_controller` can be configured to specify a controller class for all of the web UI engine's
+controllers to inherit from.
 
-This allows applications with common logic in their `ApplicationController` (or any other controller) 
-to optionally configure the web UI to inherit that logic with a simple assignment in the initializer.
+This allows applications with common logic in their `ApplicationController` (or
+any other controller) to optionally configure the web UI to inherit that logic
+with a simple assignment in the initializer.
 
 ```ruby
 # config/initializers/maintenance_tasks.rb
@@ -826,8 +827,8 @@ class Services::CustomController < ActionController::Base
 end
 ```
 
-The parent controller value **must** be a string corresponding to an existing 
-controller class which **must inherit** from `ActionController::Base`. 
+The parent controller value **must** be a string corresponding to an existing
+controller class which **must inherit** from `ActionController::Base`.
 
 If no value is specified, it will default to `"ActionController::Base"`.
 

--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -4,7 +4,7 @@ module MaintenanceTasks
   # Base class for all controllers used by this engine.
   #
   # Can be extended to add different authentication and authorization code.
-  class ApplicationController < ActionController::Base
+  class ApplicationController < MaintenanceTasks.parent_controller.constantize
     BULMA_CDN = "https://cdn.jsdelivr.net"
 
     content_security_policy do |policy|

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -72,4 +72,14 @@ module MaintenanceTasks
   #   @return [Proc] the callback to perform when an error occurs in the Task.
   mattr_accessor :error_handler, default:
     ->(_error, _task_context, _errored_element) {}
+
+  # @!attribute parent_controller
+  #   @scope class
+  #
+  #   The parent controller all web UI controllers will inherit from.
+  #   Must be a class that inherits from `ActionController::Base`.
+  #   Defaults to `"ActionController::Base"`
+  #
+  #   @return [String] the name of the parent controller for web UI.
+  mattr_accessor :parent_controller, default: "ActionController::Base"
 end

--- a/test/documentation_test.rb
+++ b/test/documentation_test.rb
@@ -5,7 +5,21 @@ require "active_support/test_case"
 require "yard"
 
 class DocumentationTest < ActiveSupport::TestCase
+  DOC_WARNING_ALLOWLIST = [
+    "Undocumentable superclass",
+  ]
+
   test "documentation is correctly written" do
-    assert_empty %x(bundle exec yard --no-save --no-output --no-stats)
+    output = %x(bundle exec yard --no-save --no-output --no-stats)
+    warnings = output.scan(/\[warn\]: .*/).reject { |warning| warning_ignored?(warning) }
+    assert_empty warnings
+  end
+
+  private
+
+  def warning_ignored?(warning)
+    DOC_WARNING_ALLOWLIST.any? do |matcher|
+      warning.match?(matcher)
+    end
   end
 end

--- a/test/documentation_test.rb
+++ b/test/documentation_test.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
-require "active_support"
-require "active_support/test_case"
+require "test_helper"
 require "yard"
 
 class DocumentationTest < ActiveSupport::TestCase
   DOC_WARNING_ALLOWLIST = [
-    "Undocumentable superclass",
+    /Undocumentable superclass.*class ApplicationController/m,
   ]
 
   test "documentation is correctly written" do
     output = %x(bundle exec yard --no-save --no-output --no-stats)
-    warnings = output.scan(/\[warn\]: .*/).reject { |warning| warning_ignored?(warning) }
+    warnings = output.scan(/\[warn\]: .*\n\n/m).reject { |warning| warning_ignored?(warning) }
     assert_empty warnings
   end
 


### PR DESCRIPTION
Add `MaintenanceTasks.parent_controller` configuration applications can assign the parent controller for the `maintenance_tasks` web UI. It defaults to `"ActionController::Base"` providing a flexible but non-breaking change.

This change allows applications with common logic in their `ApplicationController` (or any other controller) to optionally configure this web UI to inherit that logic with a simple assignment in the initializer.
eg.
`MaintenanceTasks.parent_controller = 'ApplicationController'`

## Why?
Many applications rely on every controller inheriting from their `ApplicationController` to provide consistency in pre/post processing, security, logging, etc.

Currently, because all controllers for this web UI inherit from `MaintenanceTasks::ApplicationController` (which inherits from `ActionController::Base`) the only way (afaik) to provide consistency across all controllers would be to extend the gem's `ApplicationController` with something like:
```
  MaintenanceTasks::ApplicationController.class_eval do
    include CommonThings
  end
```

That works if your application relies on a concern or two, but does not work for applications relying on `ApplicationController` inheritance, and is a bit unwieldy when you get into a large number of concerns you want to keep consistent across all controllers.

## Notes
Replaces https://github.com/Shopify/maintenance_tasks/pull/817 where I had suggested using `::ApplicationController` as the parent instead of `ActionController::Base` but that would be a breaking change, and also assumes an `ApplicationController` exists in the host app. This approach removes both obstacles.

The other part of this change is to ignore the YARD warning when trying to document our `ApplicationController` which now has a "Undocumentable superclass".