### PR TITLE
Lock selenium-webdriver to 4.9.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "debug"
 gem "mocha"
 gem "net-http" # Ruby 2.7 stdlib's net/http loads net/protocol relatively, which loads both the stdlib and gem version
 gem "net-smtp" # mail is missing a dependency on net-smtp https://github.com/mikel/mail/pull/1439
-gem "puma", "< 7.0"
+gem "puma"
 if defined?(@rails_gem_requirement) && @rails_gem_requirement
   # causes Dependabot to ignore the next line and update the next gem "rails"
   rails = "rails"
@@ -20,7 +20,7 @@ else
 end
 gem "rubocop"
 gem "rubocop-shopify"
-gem "selenium-webdriver"
+gem "selenium-webdriver", "< 4.9.1"
 gem "sprockets-rails"
 gem "sqlite3"
 gem "webdrivers", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,11 +259,11 @@ DEPENDENCIES
   mocha
   net-http
   net-smtp
-  puma (< 7.0)
+  puma
   rails
   rubocop
   rubocop-shopify
-  selenium-webdriver
+  selenium-webdriver (< 4.9.1)
   sprockets-rails
   sqlite3
   webdrivers


### PR DESCRIPTION
selenium-webdriver 4.9.1 is incompatible with the latest capybara

#818 