### PR TITLE
2.7 EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         gemfile: [Gemfile, gemfiles/rails_6_0.gemfile, gemfiles/rails_6_1.gemfile, gemfiles/rails_7_0.gemfile, gemfiles/rails_edge.gemfile]
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2"]
         database: [sqlite]
         include:
           - gemfile: "gemfiles/postgresql.gemfile"
@@ -28,7 +28,7 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
         cache-version: 1
-        rubygems: ${{ (matrix.ruby == '2.7' || matrix.ruby == '3.0') && 'latest' || 'default' }}
+        rubygems: ${{ matrix.ruby == '3.0' && 'latest' || 'default' }}
     - name: Rails version
       if: ${{ matrix.gemfile == 'gemfiles/rails_edge.gemfile' }}
       run: bundle info rails | head -1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         database: [sqlite]
         include:
           - gemfile: "gemfiles/postgresql.gemfile"
-            ruby: 3.1
+            ruby: 3.2
             database: postgres
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}


### PR DESCRIPTION
Ruby 2.7 has reached end-of-life, selenium-webdriver has dropped support for it by [requiring Ruby >= 3.0 in version 4.9.1](https://rubygems.org/gems/selenium-webdriver/versions/4.9.1) and it's blocking #818.

This removes 2.7 from the CI. 

I also moved the PostgreSQL test suite to use Ruby 3.2.