### PR TITLE
Don't generate a nonce

### DIFF
--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -20,11 +20,6 @@ module MaintenanceTasks
       policy.frame_ancestors(:self)
     end
 
-    before_action do
-      request.content_security_policy_nonce_generator ||= ->(_request) { SecureRandom.base64(16) }
-      request.content_security_policy_nonce_directives = ["style-src"]
-    end
-
     protect_from_forgery with: :exception
   end
 end


### PR DESCRIPTION
The need for a nonce was removed in 3ba21de59b76b60335988eff2b08db0c51d542d6.

Rails needs to generate the nonce to put in the headers, even if nothing uses it later.

Before:
```sh-session
$ curl localhost:3000/maintenance_tasks -sD - | grep Content-Security-Policy                                                                                                                                                           
Content-Security-Policy: base-uri 'none'; default-src 'self'; object-src 'none'; script-src 'sha256-NiHKryHWudRC2IteTqmY9v1VkaDUA/5jhgXkMTkgo2w='; frame-ancestors 'self'; block-all-mixed-content; style-src https://cdn.jsdelivr.net 'sha256-y9V0na/WU44EUNI/HDP7kZ7mfEci4PAOIjYOOan6JMA=' 'nonce-J0XZEshlYJMsNi23H63z0w=='
```

After:
```sh-session
$ curl localhost:3000/maintenance_tasks -sD - | grep Content-Security-Policy
Content-Security-Policy: base-uri 'none'; default-src 'self'; object-src 'none'; script-src 'sha256-NiHKryHWudRC2IteTqmY9v1VkaDUA/5jhgXkMTkgo2w='; frame-ancestors 'self'; block-all-mixed-content; style-src https://cdn.jsdelivr.net 'sha256-y9V0na/WU44EUNI/HDP7kZ7mfEci4PAOIjYOOan6JMA='
```