### PR TITLE
feat(optional): Add optional helper text for optional attributes

### DIFF
--- a/app/models/maintenance_tasks/task_data_show.rb
+++ b/app/models/maintenance_tasks/task_data_show.rb
@@ -79,6 +79,16 @@ module MaintenanceTasks
       end
     end
 
+    # Returns whether a given attribute name is required
+    # by checking if a presence validator is added to the attribute.
+    #
+    # @param attribute_name [String] the name of the Task attribute.
+    # @return [Boolean] whether the Task attribute is required
+    def required_parameter?(attribute_name)
+      Task.named(name).validators_on(attribute_name)
+        .any? { |v| v.is_a?(ActiveModel::Validations::PresenceValidator) }
+    end
+
     # @return [MaintenanceTasks::Task, nil] an instance of the Task class.
     # @return [nil] if the Task file was deleted.
     def new

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -22,6 +22,9 @@
               <div class="control">
                 <%= parameter_field(ff, parameter_name) %>
               </div>
+              <% unless @task.required_parameter?(parameter_name) %>
+                <p class="help">Optional</p>
+              <% end %>
             </div>
           <% end %>
         <% end %>

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -79,6 +79,15 @@ module MaintenanceTasks
       assert_equal("111222333", integer_attr_val)
     end
 
+    test "task with optional attributes renders with helper text on the form" do
+      visit maintenance_tasks_path
+
+      click_on("Maintenance::ParamsTask")
+
+      refute_selector ".field:has(label[for='_task_arguments_post_ids']) .help"
+      assert_selector ".field:has(label[for='_task_arguments_content']) .help", text: "Optional"
+    end
+
     test "task with attributes renders correct field tags on the form" do
       visit maintenance_tasks_path
 


### PR DESCRIPTION
### What does this PR do and why is it necessary?

This PR adds the feature support to add optional helper text to tasks. 

### How does this PR work?

* Adds a new method `required_parameter?` that checks if the `PresenceValidator` is well.. uh present for a given attribute
* In the `erb` file it will display an optional helper text if `required_parameter?` returns false.

### What could go wrong?

* Existing maintenance tasks might not have enforced the use of `PresenceValidators` (`validates :post_ids, presence: true`) and may mean that some properties that are required are incorrectly marked as optional.


### 🎩 🎩 🎩 🎩 🎩

<img width="3008" alt="image" src="https://github.com/Shopify/maintenance_tasks/assets/12289606/d5ec5796-0200-4a1c-ba08-11184fc34073">

