### PR TITLE
Allow resuming errored task runs

### DIFF
--- a/app/validators/maintenance_tasks/run_status_validator.rb
+++ b/app/validators/maintenance_tasks/run_status_validator.rb
@@ -60,6 +60,9 @@ module MaintenanceTasks
       # interrupted -> errored occurs when the task is deleted while it is
       #   interrupted.
       "interrupted" => ["running", "pausing", "cancelling", "errored"],
+      # errored -> enqueued occurs when the task is retried after encounting an
+      #   error.
+      "errored" => ["enqueued"],
     }
 
     # Validate whether a transition from one Run status

--- a/app/views/maintenance_tasks/runs/_run.html.erb
+++ b/app/views/maintenance_tasks/runs/_run.html.erb
@@ -22,6 +22,8 @@
     <% if run.paused? %>
       <%= button_to 'Resume', resume_task_run_path(@task, run), method: :put, class: 'button is-primary', disabled: @task.deleted? %>
       <%= button_to 'Cancel', cancel_task_run_path(@task, run), method: :put, class: 'button is-danger' %>
+    <% elsif run.errored? %>
+      <%= button_to 'Resume', resume_task_run_path(@task, run), method: :put, class: 'button is-primary', disabled: @task.deleted? %>
     <% elsif run.cancelling? %>
       <% if run.stuck? %>
         <%= button_to 'Cancel', cancel_task_run_path(@task, run), method: :put, class: 'button is-danger', disabled: @task.deleted? %>

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -191,6 +191,11 @@ module MaintenanceTasks
       assert_text "ArgumentError"
       assert_text "Something went wrong"
       assert_text "app/tasks/maintenance/error_task.rb:10:in `process'"
+
+      click_on "Resume"
+
+      assert_text "Enqueued"
+      assert_text "Waiting to start."
     end
 
     test "errors for double enqueue are shown" do

--- a/test/validators/maintenance_tasks/run_status_validator_test.rb
+++ b/test/validators/maintenance_tasks/run_status_validator_test.rb
@@ -21,7 +21,7 @@ module MaintenanceTasks
       assert_no_invalid_transitions([:enqueued, :interrupted], :running)
     end
 
-    test "run can go from paused to enqueued" do
+    test "run can go from paused or errored to enqueued" do
       paused_run = Run.create!(
         task_name: "Maintenance::UpdatePostsTask",
         status: :paused,
@@ -30,7 +30,15 @@ module MaintenanceTasks
 
       assert paused_run.valid?
 
-      assert_no_invalid_transitions([:paused], :enqueued)
+      errored_run = Run.create!(
+        task_name: "Maintenance::UpdatePostsTask",
+        status: :errored,
+      )
+      errored_run.status = :enqueued
+
+      assert errored_run.valid?
+
+      assert_no_invalid_transitions([:paused, :errored], :enqueued)
     end
 
     test "run can go from running, cancelling or pausing to succeeded" do


### PR DESCRIPTION
Allows clicking "Resume" on an errored run to resume the run from the errored point, preserving progress. This is useful for transient errors, like those from infrastructure, which have not yet been anticipated.

I'm not sure this is quite right, but I wanted to throw up some code to discuss 🙏

Fixes #851.