### PR TITLE
Don't raise when destroying a Run if ActiveStorage isn't installed

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -58,18 +58,20 @@ module MaintenanceTasks
 
     # Ensure ActiveStorage is in use before preloading the attachments
     scope :with_attached_csv, -> do
-      return unless defined?(ActiveStorage)
+      return unless MaintenanceTasks.active_storage_installed?
 
-      with_attached_csv_file if ActiveStorage::Attachment.table_exists?
+      with_attached_csv_file
     end
 
     validates_with RunStatusValidator, on: :update
 
-    if MaintenanceTasks.active_storage_service.present?
-      has_one_attached :csv_file,
-        service: MaintenanceTasks.active_storage_service
-    elsif respond_to?(:has_one_attached)
-      has_one_attached :csv_file
+    if MaintenanceTasks.active_storage_installed?
+      if MaintenanceTasks.active_storage_service.present?
+        has_one_attached :csv_file,
+          service: MaintenanceTasks.active_storage_service
+      else
+        has_one_attached :csv_file
+      end
     end
 
     # Sets the run status to enqueued, making sure the transition is validated
@@ -423,8 +425,7 @@ module MaintenanceTasks
     #
     # @return [ActiveStorage::Attached::One] the attached CSV file
     def csv_file
-      return unless defined?(ActiveStorage)
-      return unless ActiveStorage::Attachment.table_exists?
+      return unless MaintenanceTasks.active_storage_installed?
 
       super
     end

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -70,7 +70,7 @@ module MaintenanceTasks
       # An input to upload a CSV will be added in the form to start a Run. The
       # collection and count method are implemented.
       def csv_collection(in_batches: nil)
-        unless defined?(ActiveStorage)
+        unless MaintenanceTasks.active_storage_installed?
           raise NotImplementedError, "Active Storage needs to be installed\n"\
             "To resolve this issue run: bin/rails active_storage:install"
         end

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -89,4 +89,13 @@ module MaintenanceTasks
   #
   #   @return [Proc] generates a hash containing the metadata to be stored on the Run
   mattr_accessor :metadata, default: nil
+
+  class << self
+    # Checks if ActiveStorage in installed on the main Rails application.
+    #
+    # @return [Boolean] whether Active Storage is installed and configured.
+    def active_storage_installed?
+      defined?(ActiveStorage) && ActiveStorage::Attachment.table_exists?
+    end
+  end
 end

--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -9,7 +9,7 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  config.cache_classes = true
 
   # Do not eager load code on boot.
   config.eager_load = false

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -688,6 +688,15 @@ module MaintenanceTasks
         (Run::ACTIVE_STATUSES + Run::COMPLETED_STATUSES).sort
     end
 
+    test "#destroy does not raise for applications that do no user ActiveStorage" do
+      ActiveRecord.schema_cache_ignored_tables = [/^active_storage/]
+      Rails.application.reloader.reload!
+      Run.create!(task_name: "Maintenance::UpdatePostsTask").destroy!
+    ensure
+      ActiveRecord.schema_cache_ignored_tables = []
+      Rails.application.reloader.reload!
+    end
+
     private
 
     def count_uncached_queries(&block)


### PR DESCRIPTION
ActiveStorage is required by default in new Rails applications. In `config/application.rb`, we have:

```rb
require "rails/all"
```

This means that `defined?(ActiveStorage)` and
`respond_to?(:has_one_attached)` return true by default. However, it does not mean that ActiveStorage was _installed_ and that the database tables were created.

In the Run model, we created the association with the CSV file when ActiveStorage was _defined_ even if it wasn't _installed_:

```rb
elsif respond_to?(:has_one_attached)
  has_one_attached :csv_file
end
```

When trying to destroy a run, we were getting an error because the `has_one_attached` method creates callbacks that try to destroy attachments before we can destroy the run:

```txt
Could not find table 'active_storage_attachments'
(ActiveRecord::StatementInvalid)
```

To fix this, I extracted a method
`MaintenanceTasks.active_storage_installed?` that checks if ActiveStorage really is installed in the main application.

We can then reuse this method at other places in the code to check if ActiveStorage is installed.