### PR TITLE
Expose ActiveJob ability to customize the columns used to order the cursor

### DIFF
--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -109,5 +109,10 @@ module MaintenanceTasks
     ensure
       Maintenance::TestTask.throttle_conditions = []
     end
+
+    test ".cursor_columns returns nil" do
+      task = Task.new
+      assert_nil task.cursor_columns
+    end
   end
 end


### PR DESCRIPTION
`JobIteration::ActiveRecordCursor#condition` adds an `order by` clause to the relation returned by the `collection` method. It default to order on the `id` column, see `JobIteration::ActiveRecordCursor#initialize`.

Ordering on `id` only can degrade performance significantly depending on which indexes are defined.

`job-iteration` supports configuring which columns are used to order the cursor. This PR explores a way to expose this ability in the `maintenance-tasks` gem.