### PR TITLE
fix tests using a non-production version of chrome in CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,7 @@ else
 end
 gem "rubocop"
 gem "rubocop-shopify"
-gem "selenium-webdriver", "< 4.10.1"
+gem "selenium-webdriver", "~> 4.11"
 gem "sprockets-rails"
 gem "sqlite3"
-gem "webdrivers", require: false
 gem "yard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.11.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -237,10 +237,6 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
     uri (0.12.2)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -268,10 +264,9 @@ DEPENDENCIES
   rails
   rubocop
   rubocop-shopify
-  selenium-webdriver (< 4.10.1)
+  selenium-webdriver (~> 4.11)
   sprockets-rails
   sqlite3
-  webdrivers
   yard
 
 BUNDLED WITH

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "webdrivers/chromedriver"
 require "action_dispatch/system_testing/server"
 
 ActionDispatch::SystemTesting::Server.silence_puma = true
-Webdrivers::Chromedriver.required_version = "114.0.5735.90"
 
 # Necessary so that Capybara::Selenium::DeprecationSuppressor is prepended in
 # Selenium::WebDriver::Logger before it is instantiated in


### PR DESCRIPTION
Fix errors in the test suite ex: https://github.com/Shopify/maintenance_tasks/actions/runs/5696018238/job/15440308078?pr=858

> Unable to find latest point release version for 115.0.5790. You appear to be using a non-production version of Chrome. Please set `Webdrivers::Chromedriver.required_version = <desired driver version>` to a known chromedriver version: https://chromedriver.storage.googleapis.com/index.html