### PR TITLE
Prepare to 2.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    maintenance_tasks (2.1.1)
+    maintenance_tasks (2.2.0)
       actionpack (>= 6.0)
       activejob (>= 6.0)
       activerecord (>= 6.0)

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -9,6 +9,8 @@ Gem::Specification.new do |spec|
   spec.summary = "A Rails engine for queuing and managing maintenance tasks"
   spec.license = "MIT"
 
+  spec.required_ruby_version = ">= 3.0"
+
   spec.metadata = {
     "source_code_uri" =>
       "https://github.com/Shopify/maintenance_tasks/tree/v#{spec.version}",

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "maintenance_tasks"
-  spec.version = "2.1.1"
+  spec.version = "2.2.0"
   spec.author = "Shopify Engineering"
   spec.email = "gems@shopify.com"
   spec.homepage = "https://github.com/Shopify/maintenance_tasks"


### PR DESCRIPTION
Releasing this diff https://github.com/Shopify/maintenance_tasks/compare/v2.1.1...260702f72f244e5d77122fb190a707d5d1157946

Main feature is the `parent_controller` controller configuration but support to Ruby 2.7 was also removed.

There are a few bug fixes that I'll list in the releases notes as well.