### PR TITLE
Avoid loading all tasks to validate a `Run#task_name`

### DIFF
--- a/test/models/maintenance_tasks/runner_test.rb
+++ b/test/models/maintenance_tasks/runner_test.rb
@@ -61,7 +61,7 @@ module MaintenanceTasks
           end
 
           assert_equal(
-            "Validation failed: Task name is not included in the list",
+            "Validation failed: Task name must be the name of an existing Task.",
             error.message,
           )
         end


### PR DESCRIPTION
Currently, creating a `Run` record validates that its `task_name` belongs to the list returned by `Task.available_tasks`.

Generating this list requires the gem to browse through the task namespace(s) to find and load all tasks in the application (see `Task#load_constants`).

Although in most situations this should not be a problem, the Shopify monolith defines a relatively large amount of maintenance tasks, which take a considerable amount of time to load.

Loading all tasks is only absolutely necessary when the application wants to display a list of all tasks. In any other scenario, for example testing a single task, it should not be necessary to load all tasks.

This commit makes that possible by making use of `Task.named` to confirm that the task name is valid.
Because `available_tasks` relies on `.descendants`, and `Task.named` uses ` < Task` to test inheritance, I don't think this will have any unintended effect on the gem's behaviour.
