### PR TITLE
Provide context when running MaintenanceTasks.metadata proc

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    maintenance_tasks (2.3.0)
+    maintenance_tasks (2.3.1)
       actionpack (>= 6.0)
       activejob (>= 6.0)
       activerecord (>= 6.0)

--- a/README.md
+++ b/README.md
@@ -840,8 +840,8 @@ or email of the user who performed the maintenance task.
 
 ```ruby
 # config/initializers/maintenance_tasks.rb
-MaintenanceTasks.metadata = -> do
- { user_email: current_user.email }
+MaintenanceTasks.metadata = ->(context) do
+ { user_email: context.current_user.email }
 end
 ```
 

--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -14,7 +14,7 @@ module MaintenanceTasks
         name: params.fetch(:task_id),
         csv_file: params[:csv_file],
         arguments: params.fetch(:task_arguments, {}).permit!.to_h,
-        metadata: MaintenanceTasks.metadata&.call,
+        metadata: MaintenanceTasks.metadata&.call(self),
         &block
       )
       redirect_to(task_path(task))

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "maintenance_tasks"
-  spec.version = "2.3.0"
+  spec.version = "2.3.1"
   spec.author = "Shopify Engineering"
   spec.email = "gems@shopify.com"
   spec.homepage = "https://github.com/Shopify/maintenance_tasks"

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -21,8 +21,8 @@ module MaintenanceTasks
       assert_equal "enqueued", run.status
     end
 
-    test "run a Task and log the user email" do
-      MaintenanceTasks.metadata = -> { { user_email: "michael.elfassy@shopify.com" } }
+    test "run a Task and log the provided metadata" do
+      MaintenanceTasks.metadata = ->(context) { { user_email: "michael.elfassy@shopify.com" } }
       visit(maintenance_tasks_path)
 
       assert_difference("Run.count") do


### PR DESCRIPTION
Attempting to follow the [instructions](https://github.com/Shopify/maintenance_tasks/blob/main/README.md#metadata) to pass metadata from the `RunsController` and running into a `NoMethodError` because the proc is evaluated in the context where it is defined.

This change passes the instance of the controller into the proc so that it is evaluated in the correct context.

If anyone has thoughts on how to write a better test for this please share!