### PR TITLE
Avoid loading all tasks when first loading the CLI

### DIFF
--- a/lib/maintenance_tasks/cli.rb
+++ b/lib/maintenance_tasks/cli.rb
@@ -16,15 +16,6 @@ module MaintenanceTasks
 
     desc "perform [TASK NAME]", "Runs the given Maintenance Task"
 
-    long_desc <<-LONGDESC
-      `maintenance_tasks perform` will run the Maintenance Task specified by the
-      [TASK NAME] argument.
-
-      Available Tasks:
-
-      #{MaintenanceTasks::Task.available_tasks.join("\n\n")}
-    LONGDESC
-
     # Specify the CSV file to process for CSV Tasks
     desc = "Supply a CSV file to be processed by a CSV Task, "\
       "--csv path/to/csv/file.csv"
@@ -48,6 +39,21 @@ module MaintenanceTasks
       say_status(:success, "#{task.name} was enqueued.", :green)
     rescue => error
       say_status(:error, error.message, :red)
+    end
+
+    # `long_desc` only allows us to use a static string as "long description".
+    # By redefining the `#long_description` method on the "perform" Command
+    # object instead, we make it dynamic, thus delaying the task loading
+    # process until it's actually required.
+    commands["perform"].define_singleton_method(:long_description) do
+      <<~LONGDESC
+        `maintenance_tasks perform` will run the Maintenance Task specified by
+        the [TASK NAME] argument.
+
+        Available Tasks:
+
+        #{Task.available_tasks.map(&:name).sort.join("\n\n")}
+      LONGDESC
     end
 
     private

--- a/test/lib/maintenance_tasks/cli_test.rb
+++ b/test/lib/maintenance_tasks/cli_test.rb
@@ -2,7 +2,6 @@
 
 require "test_helper"
 require "maintenance_tasks/cli"
-require "io/console/size"
 
 module MaintenanceTasks
   class CLITest < ActiveSupport::TestCase
@@ -92,7 +91,7 @@ module MaintenanceTasks
         .at_least_once
         .returns([stub(name: "Task1"), stub(name: "Task2")])
 
-      expected_output = Regexp.escape(<<~OUTPUT.indent(2))
+      expected_output = <<~OUTPUT.indent(2)
         `maintenance_tasks perform` will run the Maintenance Task specified by the [TASK NAME] argument.
 
         Available Tasks:
@@ -102,7 +101,7 @@ module MaintenanceTasks
         Task2
       OUTPUT
 
-      assert_output(/#{expected_output}/) do
+      assert_output(Regexp.union(expected_output)) do
         Thor::Base.shell.any_instance.stubs(:terminal_width).returns(200)
         CLI.start(["help", "perform"])
       end


### PR DESCRIPTION
Loading all tasks is only necessary when displaying the long description for the `perform` task. Any other operation from the CLI (such as displaying the general help message or performing a task) should not load all tasks.
