### PR TITLE
Rename `Task.available_tasks` to `.load_all` and deprecate

### DIFF
--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -41,13 +41,25 @@ module MaintenanceTasks
         task
       end
 
-      # Returns a list of concrete classes that inherit from the Task
-      # superclass.
+      # Loads and returns a list of concrete classes that inherit
+      # from the Task superclass.
+      #
+      # @return [Array<Class>] the list of classes.
+      def load_all
+        load_constants
+        descendants
+      end
+
+      # Loads and returns a list of concrete classes that inherit
+      # from the Task superclass.
       #
       # @return [Array<Class>] the list of classes.
       def available_tasks
-        load_constants
-        descendants
+        warn(<<~MSG.squish, category: :deprecated)
+          MaintenanceTasks::Task.available_tasks is deprecated and will be
+          removed from maintenance-tasks 3.0.0. Use .load_all instead.
+        MSG
+        load_all
       end
 
       # Make this Task a task that handles CSV.

--- a/app/models/maintenance_tasks/task_data_index.rb
+++ b/app/models/maintenance_tasks/task_data_index.rb
@@ -25,7 +25,7 @@ module MaintenanceTasks
       def available_tasks
         tasks = []
 
-        task_names = Task.available_tasks.map(&:name)
+        task_names = Task.load_all.map(&:name)
 
         active_runs = Run.with_attached_csv.active.where(task_name: task_names)
         active_runs.each do |run|

--- a/lib/maintenance_tasks/cli.rb
+++ b/lib/maintenance_tasks/cli.rb
@@ -52,7 +52,7 @@ module MaintenanceTasks
 
         Available Tasks:
 
-        #{Task.available_tasks.map(&:name).sort.join("\n\n")}
+        #{Task.load_all.map(&:name).sort.join("\n\n")}
       LONGDESC
     end
 

--- a/test/lib/maintenance_tasks/cli_test.rb
+++ b/test/lib/maintenance_tasks/cli_test.rb
@@ -87,7 +87,7 @@ module MaintenanceTasks
 
     test "`help perform` loads all tasks and displays them" do
       Task
-        .expects(:available_tasks)
+        .expects(:load_all)
         .at_least_once
         .returns([stub(name: "Task1"), stub(name: "Task2")])
 

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 module MaintenanceTasks
   class TaskTest < ActiveSupport::TestCase
-    test ".available_tasks returns list of tasks that inherit from the Task superclass" do
+    test ".load_all returns list of tasks that inherit from the Task superclass" do
       expected = [
         "Maintenance::BatchImportPostsTask",
         "Maintenance::CallbackTestTask",
@@ -23,7 +23,18 @@ module MaintenanceTasks
         "Maintenance::UpdatePostsThrottledTask",
       ]
       assert_equal expected,
-        MaintenanceTasks::Task.available_tasks.map(&:name).sort
+        MaintenanceTasks::Task.load_all.map(&:name).sort
+    end
+
+    test ".available_tasks raises a deprecation warning before calling .load_all" do
+      expected_warning =
+        "MaintenanceTasks::Task.available_tasks is deprecated and will be " \
+          "removed from maintenance-tasks 3.0.0. Use .load_all instead.\n"
+
+      Warning.expects(:warn).with(expected_warning, category: :deprecated)
+      Task.expects(:load_all)
+
+      Task.available_tasks
     end
 
     test ".named returns the task based on its name" do


### PR DESCRIPTION
`Task.available_tasks` not only returns all descendants of the `Task` class, it also `require`s all files in the application that may be defining such class.

`available_tasks` does not carry explicit meaning of how heavy the operation could be, so this renames it to `load_all`, which should be better at communicating that, and deprecates the old name.

I'll have to adjust this PR once https://github.com/Shopify/maintenance_tasks/pull/877 is merged.