### PR TITLE
Show Run#metadata in the web UI

### DIFF
--- a/app/views/maintenance_tasks/runs/_arguments.html.erb
+++ b/app/views/maintenance_tasks/runs/_arguments.html.erb
@@ -1,22 +1,4 @@
-<% if run.arguments.present? %>
-  <div class="table-container">
-    <h6 class="title is-6">Arguments:</h6>
-    <table class="table">
-      <tbody>
-        <% run.arguments.transform_values(&:to_s).each do |key, value| %>
-          <tr>
-            <td class="is-family-monospace"><%= key %></td>
-            <td>
-              <% next if value.empty? %>
-              <% if value.include?("\n") %>
-                <pre><%= value %></pre>
-              <% else %>
-                <code><%= value %></code>
-              <% end %>
-            </td>
-          </tr>
-          <% end %>
-      </tbody>
-    </table>
-  </div>
+<% if arguments.present? %>
+  <h6 class="title is-6">Arguments:</h6>
+  <%= render "maintenance_tasks/runs/serializable", serializable: arguments %>
 <% end %>

--- a/app/views/maintenance_tasks/runs/_metadata.html.erb
+++ b/app/views/maintenance_tasks/runs/_metadata.html.erb
@@ -1,0 +1,4 @@
+<% if metadata.present? %>
+  <h6 class="title is-6">Metadata:</h6>
+  <%= render "maintenance_tasks/runs/serializable", serializable: metadata %>
+<% end %>

--- a/app/views/maintenance_tasks/runs/_run.html.erb
+++ b/app/views/maintenance_tasks/runs/_run.html.erb
@@ -16,7 +16,9 @@
 
   <%= render "maintenance_tasks/runs/csv", run: run %>
   <%= tag.hr if run.csv_file.present? && run.arguments.present? %>
-  <%= render "maintenance_tasks/runs/arguments", run: run %>
+  <%= render "maintenance_tasks/runs/arguments", arguments: run.arguments %>
+  <%= tag.hr if run.csv_file.present? || run.arguments.present? && run.metadata.present? %>
+  <%= render "maintenance_tasks/runs/metadata", metadata: run.metadata %>
 
   <div class="buttons">
     <% if run.paused? %>

--- a/app/views/maintenance_tasks/runs/_serializable.html.erb
+++ b/app/views/maintenance_tasks/runs/_serializable.html.erb
@@ -1,0 +1,26 @@
+<% if serializable.present? %>
+  <% case serializable %>
+  <% when Hash %>
+    <div class="table-container">
+      <table class="table">
+        <tbody>
+          <% serializable.transform_values(&:to_s).each do |key, value| %>
+            <tr>
+              <td class="is-family-monospace"><%= key %></td>
+              <td>
+                <% next if value.empty? %>
+                <% if value.include?("\n") %>
+                  <pre><%= value %></pre>
+                <% else %>
+                  <code><%= value %></code>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <code><%= serializable.inspect %></code>
+  <% end %>
+<% end %>

--- a/app/views/maintenance_tasks/tasks/_task.html.erb
+++ b/app/views/maintenance_tasks/tasks/_task.html.erb
@@ -21,6 +21,8 @@
 
     <%= render "maintenance_tasks/runs/csv", run: run %>
     <%= tag.hr if run.csv_file.present? && run.arguments.present? %>
-    <%= render "maintenance_tasks/runs/arguments", run: run %>
+    <%= render "maintenance_tasks/runs/arguments", arguments: run.arguments %>
+    <%= tag.hr if run.csv_file.present? || run.arguments.present? && run.metadata.present? %>
+    <%= render "maintenance_tasks/runs/metadata", metadata: run.metadata %>
   <% end %>
 </div>

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -32,11 +32,30 @@ module MaintenanceTasks
         assert_title("Maintenance::UpdatePostsTask")
         assert_text("Enqueued")
         assert_text("Waiting to start.")
+        assert_text("Metadata")
+        assert_table do |table|
+          table.assert_text("user_email")
+          table.assert_text("michael.elfassy@shopify.com")
+        end
       end
       run = Run.last
       assert_equal("michael.elfassy@shopify.com", run.metadata["user_email"])
       assert_equal("Maintenance::UpdatePostsTask", run.task_name)
       assert_equal("enqueued", run.status)
+    ensure
+      MaintenanceTasks.metadata = nil
+    end
+
+    test "metadata can be non-hash" do
+      MaintenanceTasks.metadata = -> { "hello metadata" }
+      visit(maintenance_tasks_path)
+
+      assert_difference("Run.count") do
+        click_on("Maintenance::UpdatePostsTask")
+        click_on("Run")
+
+        assert_text("hello metadata")
+      end
     ensure
       MaintenanceTasks.metadata = nil
     end


### PR DESCRIPTION
As the example in the README, a common use case of metadata is to record who ran the task. By displaying metadata in the web UI, we can know who ran the task at a glance.