### PR TITLE
When a task is stuck, allow directly running it without an explicit force-cancel

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -241,7 +241,7 @@ module MaintenanceTasks
     def running
       if locking_enabled?
         begin
-          running! unless stopping?
+          running! if !stopping? || stuck?
         rescue ActiveRecord::StaleObjectError
           reload_status
           retry

--- a/app/validators/maintenance_tasks/run_status_validator.rb
+++ b/app/validators/maintenance_tasks/run_status_validator.rb
@@ -32,7 +32,9 @@ module MaintenanceTasks
       #   being cancelled. See description for pausing -> succeeded.
       # cancelling -> errored occurs when the job raises an exception after the
       #   user has cancelled it.
-      "cancelling" => ["cancelled", "succeeded", "errored"],
+      # cancelling -> running occurs when a stuck job is run without an explicit
+      #   force-cancel
+      "cancelling" => ["cancelled", "succeeded", "errored", "running"],
       # running -> succeeded occurs when the task completes successfully.
       # running -> pausing occurs when a user pauses the task as
       #   it's performing.

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -45,6 +45,19 @@ module MaintenanceTasks
       end
     end
 
+    test ".perform will run a force-cancellable job that isn't cancelled" do
+      freeze_time
+      TaskJob.perform_later(@run)
+      @run.cancel
+      travel Run::STUCK_TASK_TIMEOUT
+      @run.running
+      Maintenance::TestTask.any_instance.expects(:process).at_least_once
+
+      assert_nothing_raised do
+        perform_enqueued_jobs
+      end
+    end
+
     test ".perform_now persists ended_at when the Run is cancelled" do
       freeze_time
       Maintenance::TestTask.any_instance.expects(:process).once.with do

--- a/test/validators/maintenance_tasks/run_status_validator_test.rb
+++ b/test/validators/maintenance_tasks/run_status_validator_test.rb
@@ -18,7 +18,7 @@ module MaintenanceTasks
 
       assert interrupted_run.valid?
 
-      assert_no_invalid_transitions([:enqueued, :interrupted], :running)
+      assert_no_invalid_transitions([:enqueued, :interrupted, :cancelling], :running)
     end
 
     test "run can go from paused to enqueued" do


### PR DESCRIPTION
I had suggested doing this when brainstorming fixes for maintenance tasks. Now that I've written it, I'm less convinced that it's a good idea since it requires allowing a run to transition directly from cancelling to running. I'll talk to @adrianna-chang-shopify about this soon.

So this works fine, but maybe still shouldn't be merged.