### PR TITLE
Try to fix failures related to changes in Thor 1.3.0

### DIFF
--- a/lib/maintenance_tasks/cli.rb
+++ b/lib/maintenance_tasks/cli.rb
@@ -56,6 +56,8 @@ module MaintenanceTasks
       LONGDESC
     end
 
+    commands["perform"].wrap_long_description = true if commands["perform"].respond_to?(:wrap_long_description=)
+
     private
 
     def csv_file

--- a/test/lib/maintenance_tasks/cli_test.rb
+++ b/test/lib/maintenance_tasks/cli_test.rb
@@ -102,7 +102,6 @@ module MaintenanceTasks
       OUTPUT
 
       assert_output(Regexp.union(expected_output)) do
-        Thor::Base.shell.any_instance.stubs(:terminal_width).returns(200)
         CLI.start(["help", "perform"])
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,9 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+# Don't wrap output in tests
+ENV["THOR_COLUMNS"] = "200"
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths =
   [File.expand_path("../test/dummy/db/migrate", __dir__)]


### PR DESCRIPTION
Update: please take a look at this alternative: https://github.com/Shopify/maintenance_tasks/pull/914. I think it's a better approach to the issue.

---

The release of Thor 1.3.0 introduced issues related to:
- how Thor determines the terminal width (the `#terminal_width` method moved) (https://github.com/rails/thor/pull/854)
- whether Thor wraps and indents a long description, or not (https://github.com/rails/thor/pull/739)

This PR should allow tests to pass whether Thor's version is before or after these changes:

```sh
$ rake test
# success

$ bundle update thor
# ...
# Installing thor 1.3.0 (was 1.2.2)
# ...

$ rake test
# success
```