### PR TITLE
Introduce `list` command in CLI

### DIFF
--- a/lib/maintenance_tasks/cli.rb
+++ b/lib/maintenance_tasks/cli.rb
@@ -15,6 +15,12 @@ module MaintenanceTasks
     end
 
     desc "perform [TASK NAME]", "Runs the given Maintenance Task"
+    long_desc <<~DESC
+      `maintenance_tasks perform` will run the Maintenance Task specified by
+      the [TASK NAME] argument.
+
+      Use `maintenance_tasks list` to get a list of all available tasks.
+    DESC
 
     # Specify the CSV file to process for CSV Tasks
     desc = "Supply a CSV file to be processed by a CSV Task, "\
@@ -41,19 +47,14 @@ module MaintenanceTasks
       say_status(:error, error.message, :red)
     end
 
-    # `long_desc` only allows us to use a static string as "long description".
-    # By redefining the `#long_description` method on the "perform" Command
-    # object instead, we make it dynamic, thus delaying the task loading
-    # process until it's actually required.
-    commands["perform"].define_singleton_method(:long_description) do
-      <<~LONGDESC
-        `maintenance_tasks perform` will run the Maintenance Task specified by
-        the [TASK NAME] argument.
+    desc "list", "Load and list all available tasks."
 
-        Available Tasks:
-
-        #{Task.load_all.map(&:name).sort.join("\n\n")}
-      LONGDESC
+    # Command to list all available Tasks.
+    #
+    # It needs to use `Task.load_all` in order to load all the tasks available
+    # in the project before displaying them.
+    def list
+      say(Task.load_all.map(&:name).sort.join("\n"))
     end
 
     private

--- a/test/lib/maintenance_tasks/cli_test.rb
+++ b/test/lib/maintenance_tasks/cli_test.rb
@@ -86,17 +86,14 @@ module MaintenanceTasks
     end
 
     test "`list` loads all tasks and displays them" do
-      Task
-        .expects(:load_all)
-        .at_least_once
-        .returns([stub(name: "Task1"), stub(name: "Task2")])
+      Task.expects(:load_all).returns([stub(name: "Task1"), stub(name: "Task2")])
 
       expected_output = <<~OUTPUT
         Task1
         Task2
       OUTPUT
 
-      assert_output(Regexp.union(expected_output)) do
+      assert_output(expected_output) do
         CLI.start(["list"])
       end
     end

--- a/test/lib/maintenance_tasks/cli_test.rb
+++ b/test/lib/maintenance_tasks/cli_test.rb
@@ -102,7 +102,6 @@ module MaintenanceTasks
       OUTPUT
 
       assert_output(Regexp.union(expected_output)) do
-        Thor::Base.shell.any_instance.stubs(:terminal_width).returns(200)
         CLI.start(["help", "perform"])
       end
     end

--- a/test/lib/maintenance_tasks/cli_test.rb
+++ b/test/lib/maintenance_tasks/cli_test.rb
@@ -85,18 +85,6 @@ module MaintenanceTasks
       end
     end
 
-    test "`help perform` invites the user to use `maintenance_tasks list` with proper rewrapping" do
-      expected_output = <<~OUTPUT.indent(2)
-        `maintenance_tasks perform` will run the Maintenance Task specified by the [TASK NAME] argument.
-
-        Use `maintenance_tasks list` to get a list of all available tasks.
-      OUTPUT
-
-      assert_output(Regexp.union(expected_output)) do
-        CLI.start(["help", "perform"])
-      end
-    end
-
     test "`list` loads all tasks and displays them" do
       Task
         .expects(:load_all)

--- a/test/lib/maintenance_tasks/cli_test.rb
+++ b/test/lib/maintenance_tasks/cli_test.rb
@@ -85,24 +85,31 @@ module MaintenanceTasks
       end
     end
 
-    test "`help perform` loads all tasks and displays them" do
+    test "`help perform` invites the user to use `maintenance_tasks list` with proper rewrapping" do
+      expected_output = <<~OUTPUT.indent(2)
+        `maintenance_tasks perform` will run the Maintenance Task specified by the [TASK NAME] argument.
+
+        Use `maintenance_tasks list` to get a list of all available tasks.
+      OUTPUT
+
+      assert_output(Regexp.union(expected_output)) do
+        CLI.start(["help", "perform"])
+      end
+    end
+
+    test "`list` loads all tasks and displays them" do
       Task
         .expects(:load_all)
         .at_least_once
         .returns([stub(name: "Task1"), stub(name: "Task2")])
 
-      expected_output = <<~OUTPUT.indent(2)
-        `maintenance_tasks perform` will run the Maintenance Task specified by the [TASK NAME] argument.
-
-        Available Tasks:
-
+      expected_output = <<~OUTPUT
         Task1
-
         Task2
       OUTPUT
 
       assert_output(Regexp.union(expected_output)) do
-        CLI.start(["help", "perform"])
+        CLI.start(["list"])
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,10 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+# Force Thor CLI to output on 200 columns, ignoring
+# the size of the actual terminal running the tests.
+ENV["THOR_COLUMNS"] = "200"
+
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths =
   [File.expand_path("../test/dummy/db/migrate", __dir__)]


### PR DESCRIPTION
This is an alternative to https://github.com/Shopify/maintenance_tasks/pull/913, which I actually prefer.

A couple months ago, in https://github.com/Shopify/maintenance_tasks/pull/877, I did some weird stuff in order to defer task loading when it's actually necessary. The issue was that we needed the list of all tasks to set the long description of the `perform` command.

I realized that it might actually allow us to keep code more standard and simple, if instead of that, we provided a `list` command that loads and lists all available tasks.

## Pros

- The CLI still doesn't need to load all tasks at "boot". (the original goal of #877)
- We don't need to use meta-programming to `define_singleton_method :long_description`, which relies on not-so-public APIs, and as shown by the release of Thor 1.3.0, is brittle.
- The output of `help perform` does not flood the terminal anymore. If I ran `maintenance_tasks help perform`, chances are I wanted to see what it does, parameters it takes and its syntax. These things were pushed off screen when there are a lot of tasks available.
- The `list` command is purely made to output a list of tasks, no indentation, no empty lines in between. It's more favorable to exporting the list to a text file or grepping for something.
- It works the same for the new Thor 1.3.0 and older versions. No weird version switching.

## Cons

- I can only think of one: CLI behaviour changes: `maintenance_tasks help perform` will not return the task list anymore. Anyone relying on that will have to update what they do.


I like this approach better than the one I had first which was trying to work around the issue in complicated ways.

Merging this will close #913 as it'll be unnecessary.