### PR TITLE
Ensure that maintenance tasks have a default max runtime

### DIFF
--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -9,6 +9,8 @@ module MaintenanceTasks
     include JobIteration::Iteration
 
     included do
+      self.job_iteration_max_job_runtime = JobIteration.max_job_runtime || 5.minutes
+
       before_perform(:before_perform)
 
       on_start(:on_start)

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -617,5 +617,9 @@ module MaintenanceTasks
 
       assert_equal 2, @run.reload.tick_total
     end
+
+    test "job_iteration_max_job_runtime defaults to 5 minutes" do
+      assert_equal 5.minutes, MaintenanceTasks::TaskJob.job_iteration_max_job_runtime
+    end
   end
 end


### PR DESCRIPTION
Prior to Shopify/job-iteration#240, the maximum runtime of an iteration was determined by reading `JobIteration.max_job_runtime` while the job was running.  After this change, the value of that variable is cached with the job when the class is loaded.

The maintenance_tasks engine sets `JobIteration.max_job_runtime` to 5 minutes in an `after_initialize` block, unless it is already configured.  Prior to the aforementioned PR, this was fine because the value was read at runtime.  However, in staging and production environments where eager loading is used, `MaintenanceTasks::TaskJob` is loaded before the `after_initialize` block is run.  If an application did not explicitly configure `JobIteration.max_job_runtime`, `MaintenanceTasks::TaskJob` will use the default value of `nil` provided by the job-iteration gem.  This means maintenance tasks will never be pre-empted.

This change explicitly sets the `job_iteration_max_job_runtime` class attribute on `MaintenanceTasks::TaskJob`.  If `JobIteration.max_job_runtime` has been configured, it uses that, otherwise, it defaults to 5 minutes.

I did not remove the `after_initialize` block, as applications that are not using eager loading may depend on the existing behaviour.