### PR TITLE
Allow force pause, when stuck pausing

### DIFF
--- a/app/controllers/maintenance_tasks/runs_controller.rb
+++ b/app/controllers/maintenance_tasks/runs_controller.rb
@@ -35,6 +35,14 @@ module MaintenanceTasks
       redirect_to(task_path(@run.task_name), alert: error.message)
     end
 
+    # Forces paused state to be set, used if stuck
+    def force_pause
+      @run.paused!
+      redirect_to(task_path(@run.task_name))
+    rescue ActiveRecord::RecordInvalid => error
+      redirect_to(task_path(@run.task_name), alert: error.message)
+    end
+
     # Updates a Run status to cancelling.
     def cancel
       @run.cancel

--- a/app/views/maintenance_tasks/runs/_run.html.erb
+++ b/app/views/maintenance_tasks/runs/_run.html.erb
@@ -29,6 +29,7 @@
     <% elsif run.pausing? %>
       <%= button_to 'Pausing', pause_task_run_path(@task, run), method: :put, class: 'button is-warning', disabled: true %>
       <%= button_to 'Cancel', cancel_task_run_path(@task, run), method: :put, class: 'button is-danger' %>
+      <%= button_to 'Force pause', force_pause_task_run_path(@task, run), method: :put, class: 'button is-danger' %>
     <% elsif run.active? %>
       <%= button_to 'Pause', pause_task_run_path(@task, run), method: :put, class: 'button is-warning', disabled: @task.deleted? %>
       <%= button_to 'Cancel', cancel_task_run_path(@task, run), method: :put, class: 'button is-danger' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ MaintenanceTasks::Engine.routes.draw do
         put "pause"
         put "cancel"
         put "resume"
+        put "force_pause"
       end
     end
   end


### PR DESCRIPTION
## Background

If your pause action dies, it can get locked on "Pausing". The user, short of hacking the console or cancelling the whole task, doesn't have recourse.

Whilst in "Pausing" state, this creates a "Force pause" action that called `paused!` on the run.

![image](https://github.com/Shopify/maintenance_tasks/assets/7865030/59c21822-ef75-4b42-ba25-027c388ee569)
![image](https://github.com/Shopify/maintenance_tasks/assets/7865030/ad75558c-718e-483f-9a5e-0ab4d546af2d)

## For Reviewers

Should I pair this with some further tests, is there anything I'm not considering?