### PR TITLE
Add Rails 7.1 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gemfile: [Gemfile, gemfiles/rails_6_0.gemfile, gemfiles/rails_6_1.gemfile, gemfiles/rails_7_0.gemfile, gemfiles/rails_edge.gemfile]
+        gemfile: [Gemfile, gemfiles/rails_6_0.gemfile, gemfiles/rails_6_1.gemfile, gemfiles/rails_7_0.gemfile, gemfiles/rails_7_1.gemfile, gemfiles/rails_edge.gemfile]
         ruby: ["3.0", "3.1", "3.2"]
         database: [sqlite]
         include:

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+@rails_gem_requirement = "~> 7.1.2"
+
+eval_gemfile "../Gemfile"


### PR DESCRIPTION
Rails 7.1 and edge are not the same anymore and we should be explicitly testing against it