### PR TITLE
Fix Chrome headless

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -22,14 +22,12 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   driven_by :selenium, using: :headless_chrome do |options|
     options.add_argument("--disable-dev-shm-usage")
-    options.add_preference(
-      :download,
-      default_directory: "test/dummy/tmp/downloads",
-    )
+    options.add_argument("--headless=new")
   end
 
   setup do
     travel_to Time.zone.local(2020, 1, 9, 9, 41, 44)
+    page.driver.browser.download_path = "test/dummy/tmp/downloads"
   end
 
   teardown do

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -13,6 +13,11 @@ Capybara::Selenium::Driver.load_selenium
 
 if Rails::VERSION::MAJOR < 7
   Selenium::WebDriver.logger.ignore(:browser_options)
+  if Rails::VERSION::MINOR < 1
+    require "action_dispatch/system_testing/browser"
+    # prevent Rails from adding --headless at the end of the arguments, overriding --headless=new
+    ActionDispatch::SystemTesting::Browser.redefine_method(:options) { capabilities }
+  end
 elsif Rails.gem_version < Gem::Version.new("7.1")
   Selenium::WebDriver.logger.ignore(:capabilities)
 end


### PR DESCRIPTION
With Chrome 120, the default headless is now a different binary, causing Selenium to fail to inject its extensions, we can't get logs, etc. See more in https://github.com/SeleniumHQ/selenium/pull/13271

Instead of waiting for a new release of `selenium-webdriver` that includes the fix to continue using the old headless, or configuring Selenium to use an older version of Chrome, this moves to the new headless Chrome.

I had two issues doing that:
1. The preferences to configure the download path does not seem respected by the new headless Chrome, but I found that Selenium had [some code in place to configure the download path](https://github.com/SeleniumHQ/selenium/blob/selenium-4.16.0/rb/lib/selenium/webdriver/common/driver_extensions/downloads_files.rb), so I used that instead.
  Unfortunately the method seems deprecated in the Chrome DevTools Protocol: https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-setDownloadBehavior ([permalink](https://github.com/ChromeDevTools/devtools-protocol/blob/b545613c589e9552862dd85d8fe4f300850c9551/tot/Page/index.html#L4328)) but for now that should do it.
3. Rails 6.0 was adding `--headless` after our `--headless=new`, so we were still seeing the problems with 6.0, I monkey-patched the problematic method.