### PR TITLE
CI improvements

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Before engaging with this community, please read and understand our
 ## Setting up development environment
 
 * The gem follows standard Rails practices:
-  * `bundle install` to install dependencies
+  * `bin/setup` to install dependencies
   * `bin/rails server` to start the server
   * `bin/rails test` to run tests
   * `bin/rails test:system` to run system tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,4 @@ jobs:
       with:
         name: screenshots
         path: test/dummy/tmp/screenshots
+        if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,6 @@ jobs:
       uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: screenshots
+        name: screenshots-${{ strategy.job-index }}
         path: test/dummy/tmp/screenshots
         if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }} / ${{ matrix.gemfile }} / ${{ matrix.database }}
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -ex
+
+bundle install
+bin/rails db:setup


### PR DESCRIPTION
I just noticed there's a warning on the workflow run summary when there's a CI failure but no screenshot to send. Here's a workflow run with the warning annotation: https://github.com/Shopify/maintenance_tasks/actions/runs/3410427916

While testing this, I noticed that if multiple jobs have the same artifact names, we get an error:
https://github.com/Shopify/maintenance_tasks/actions/runs/7260665234

Before we upgraded actions/upload-artifact in #935, that somehow worked by only saving one of the screenshots, see the artifact in https://github.com/Shopify/maintenance_tasks/actions/runs/7260773169.

https://github.com/actions/upload-artifact/tree/cf8714cfeaba5687a442b9bcb85b29e23f468dfa#not-uploading-to-the-same-artifact

I also had one run [taking forever](https://github.com/Shopify/maintenance_tasks/actions/runs/7260925008) while testing this, so I'm adding a timeout.

And finally I added a `bin/setup` which makes it easier to get setup.