### PR TITLE
Show Run#id in the web UI

### DIFF
--- a/app/views/maintenance_tasks/runs/_run.html.erb
+++ b/app/views/maintenance_tasks/runs/_run.html.erb
@@ -2,6 +2,7 @@
   <h5 class="title is-5">
     <%= time_tag run.created_at, title: run.created_at.utc.iso8601 %>
     <%= status_tag run.status %>
+    <span class="is-pulled-right" title="Run ID">#<%= run.id %></span>
   </h5>
 
   <%= progress run %>

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -63,9 +63,8 @@ module MaintenanceTasks
       assert_text "Paused"
 
       assert_equal ["Active Runs", "Previous Runs"], page.all("h4").map(&:text)
-      runs = page.all("h5").map(&:text)
-      assert_includes runs, "July 18, 2022 11:05\nPaused"
-      assert_includes runs, "January 01, 2020 01:00\nSucceeded"
+      assert_text(/July 18, 2022 11:05\nPaused\n#\d/)
+      assert_text(/January 01, 2020 01:00\nSucceeded\n#\d/)
     end
 
     test "task with attributes renders default values on the form" do


### PR DESCRIPTION
It makes correlating runs and errors from an error reporting system easier.