### PR TITLE
Make error handler proc be called with job as self

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,14 +719,14 @@ you can define an error handler:
 ```ruby
 # config/initializers/maintenance_tasks.rb
 
-MaintenanceTasks.error_handler = ->(error, task_context, _errored_element) do
+MaintenanceTasks.error_handler = ->(error, task_context, errored_element, task_job) do
   Bugsnag.notify(error) do |notification|
     notification.add_metadata(:task, task_context)
   end
 end
 ```
 
-The error handler should be a lambda that accepts three arguments:
+The error handler should be a lambda that accepts four arguments:
 
 * `error`: The exception that was raised.
 * `task_context`: A hash with additional information about the Task and the
@@ -746,9 +746,8 @@ The error handler should be a lambda that accepts three arguments:
   Record objects in order to protect sensitive data. CSV rows, on the other
   hand, are converted to strings and passed raw to Bugsnag, so make sure to
   filter any personal data from these objects before adding them to a report.
-
-The error handler is called within the context of the `TaskJob`, 
-allowing you to access detailed information about the task.
+* `task_job`: The instance of `TaskJob` that was being executed. This allows you to
+  access detailed information about the task.
 
 #### Customizing the maintenance tasks module
 

--- a/README.md
+++ b/README.md
@@ -747,6 +747,9 @@ The error handler should be a lambda that accepts three arguments:
   hand, are converted to strings and passed raw to Bugsnag, so make sure to
   filter any personal data from these objects before adding them to a report.
 
+The error handler is called within the context of the `TaskJob`, 
+allowing you to access detailed information about the task.
+
 #### Customizing the maintenance tasks module
 
 `MaintenanceTasks.tasks_module` can be configured to define the module in which

--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -177,7 +177,7 @@ module MaintenanceTasks
       end
       errored_element = @errored_element if defined?(@errored_element)
     ensure
-      MaintenanceTasks.error_handler.call(error, task_context, errored_element)
+      instance_exec(*[error, task_context, errored_element], &MaintenanceTasks.error_handler)
     end
   end
 end

--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -177,7 +177,7 @@ module MaintenanceTasks
       end
       errored_element = @errored_element if defined?(@errored_element)
     ensure
-      instance_exec(*[error, task_context, errored_element], &MaintenanceTasks.error_handler)
+      instance_exec(error, task_context, errored_element, &MaintenanceTasks.error_handler)
     end
   end
 end

--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -149,6 +149,7 @@ module MaintenanceTasks
       HEREDOC
       raise error_message
     end
+
     def reenqueue_iteration_job(should_ignore: true)
       super() unless should_ignore
       @reenqueue_iteration_job = true
@@ -177,7 +178,13 @@ module MaintenanceTasks
       end
       errored_element = @errored_element if defined?(@errored_element)
     ensure
-      instance_exec(error, task_context, errored_element, &MaintenanceTasks.error_handler)
+      error_handler = MaintenanceTasks.error_handler
+      if error_handler.arity == 4
+        error_handler.call(error, task_context, errored_element, self)
+      else
+        # For backwards compatibility. In older versions, the error_handler only took three arguments.
+        error_handler.call(error, task_context, errored_element)
+      end
     end
   end
 end

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -337,11 +337,13 @@ module MaintenanceTasks
       handled_error = nil
       handled_task_context = nil
       handled_errored_element = nil
+      handled_self_klass = nil
 
       MaintenanceTasks.error_handler = ->(error, task_context, errored_el) do
         handled_error = error
         handled_task_context = task_context
         handled_errored_element = errored_el
+        handled_self_klass = self.class
       end
 
       run = Run.create!(task_name: "Maintenance::ErrorTask")
@@ -351,6 +353,7 @@ module MaintenanceTasks
       assert_equal(ArgumentError, handled_error.class)
       assert_equal("Maintenance::ErrorTask", handled_task_context[:task_name])
       assert_equal(2, handled_errored_element)
+      assert_equal(TaskJob, handled_self_klass)
     ensure
       MaintenanceTasks.error_handler = error_handler_before
     end
@@ -375,9 +378,11 @@ module MaintenanceTasks
       error_handler_before = MaintenanceTasks.error_handler
       handled_error = nil
       handled_task_context = nil
+      handled_self_klass = nil
       MaintenanceTasks.error_handler = ->(error, task_context, _errored_el) do
         handled_error = error
         handled_task_context = task_context
+        handled_self_klass = self.class
       end
 
       RaisingTaskJob = Class.new(TaskJob) do
@@ -388,6 +393,7 @@ module MaintenanceTasks
 
       assert_equal("Uh oh!", handled_error.message)
       assert_empty(handled_task_context)
+      assert_equal(RaisingTaskJob, handled_self_klass)
     ensure
       MaintenanceTasks.error_handler = error_handler_before
     end

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -337,13 +337,13 @@ module MaintenanceTasks
       handled_error = nil
       handled_task_context = nil
       handled_errored_element = nil
-      handled_self_klass = nil
+      handled_task_job_klass = nil
 
-      MaintenanceTasks.error_handler = ->(error, task_context, errored_el) do
+      MaintenanceTasks.error_handler = ->(error, task_context, errored_el, task_job) do
         handled_error = error
         handled_task_context = task_context
         handled_errored_element = errored_el
-        handled_self_klass = self.class
+        handled_task_job_klass = task_job.class
       end
 
       run = Run.create!(task_name: "Maintenance::ErrorTask")
@@ -353,7 +353,7 @@ module MaintenanceTasks
       assert_equal(ArgumentError, handled_error.class)
       assert_equal("Maintenance::ErrorTask", handled_task_context[:task_name])
       assert_equal(2, handled_errored_element)
-      assert_equal(TaskJob, handled_self_klass)
+      assert_equal(TaskJob, handled_task_job_klass)
     ensure
       MaintenanceTasks.error_handler = error_handler_before
     end
@@ -378,11 +378,9 @@ module MaintenanceTasks
       error_handler_before = MaintenanceTasks.error_handler
       handled_error = nil
       handled_task_context = nil
-      handled_self_klass = nil
       MaintenanceTasks.error_handler = ->(error, task_context, _errored_el) do
         handled_error = error
         handled_task_context = task_context
-        handled_self_klass = self.class
       end
 
       RaisingTaskJob = Class.new(TaskJob) do
@@ -393,7 +391,6 @@ module MaintenanceTasks
 
       assert_equal("Uh oh!", handled_error.message)
       assert_empty(handled_task_context)
-      assert_equal(RaisingTaskJob, handled_self_klass)
     ensure
       MaintenanceTasks.error_handler = error_handler_before
     end


### PR DESCRIPTION
This is the same as https://github.com/Shopify/maintenance_tasks/pull/782, but updated on main, so CI passes.

Having access to the job which errorred enables richer context for error reporting. The current `task_context` and `errored_element` are helpful, but not enough. For instance, in our case, we need access to the job so we can record and provide correlation links in our error reporter.