### PR TITLE
Custom enumerators

### DIFF
--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -32,45 +32,7 @@ module MaintenanceTasks
 
     def build_enumerator(_run, cursor:)
       cursor ||= @run.cursor
-      collection = @task.collection
-      @enumerator = nil
-
-      @collection_enum = case collection
-      when :no_collection
-        enumerator_builder.build_once_enumerator(cursor: nil)
-      when ActiveRecord::Relation
-        enumerator_builder.active_record_on_records(collection, cursor: cursor)
-      when ActiveRecord::Batches::BatchEnumerator
-        if collection.start || collection.finish
-          raise ArgumentError, <<~MSG.squish
-            #{@task.class.name}#collection cannot support
-            a batch enumerator with the "start" or "finish" options.
-          MSG
-        end
-
-        # For now, only support automatic count based on the enumerator for
-        # batches
-        enumerator_builder.active_record_on_batch_relations(
-          collection.relation,
-          cursor: cursor,
-          batch_size: collection.batch_size,
-        )
-      when Array
-        enumerator_builder.build_array_enumerator(collection, cursor: cursor&.to_i)
-      when BatchCsvCollectionBuilder::BatchCsv
-        JobIteration::CsvEnumerator.new(collection.csv).batches(
-          batch_size: collection.batch_size,
-          cursor: cursor&.to_i,
-        )
-      when CSV
-        JobIteration::CsvEnumerator.new(collection).rows(cursor: cursor&.to_i)
-      else
-        raise ArgumentError, <<~MSG.squish
-          #{@task.class.name}#collection must be either an
-          Active Record Relation, ActiveRecord::Batches::BatchEnumerator,
-          Array, or CSV.
-        MSG
-      end
+      @collection_enum = @task.enumerator_builder(cursor: cursor)
       throttle_enumerator(@collection_enum)
     end
 

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -247,5 +247,55 @@ module MaintenanceTasks
     def count
       self.class.collection_builder_strategy.count(self)
     end
+
+    # Default enumeration builder. You may override this method to return any
+    # Enumerator yielding pairs of `[item, item_cursor]`.
+    #
+    # @param cursor [String, nil] cursor position to resume from, or nil on
+    #   initial call.
+    #
+    # @return [Enumerator]
+    def enumerator_builder(cursor:)
+      collection = self.collection
+
+      job_iteration_builder = JobIteration::EnumeratorBuilder.new(nil)
+
+      case collection
+      when :no_collection
+        job_iteration_builder.build_once_enumerator(cursor: nil)
+      when ActiveRecord::Relation
+        job_iteration_builder.active_record_on_records(collection, cursor: cursor)
+      when ActiveRecord::Batches::BatchEnumerator
+        if collection.start || collection.finish
+          raise ArgumentError, <<~MSG.squish
+            #{self.class.name}#collection cannot support
+            a batch enumerator with the "start" or "finish" options.
+          MSG
+        end
+
+        # For now, only support automatic count based on the enumerator for
+        # batches
+        job_iteration_builder.active_record_on_batch_relations(
+          collection.relation,
+          cursor: cursor,
+          batch_size: collection.batch_size,
+        )
+      when Array
+        job_iteration_builder.build_array_enumerator(collection, cursor: cursor&.to_i)
+      when BatchCsvCollectionBuilder::BatchCsv
+        JobIteration::CsvEnumerator.new(collection.csv).batches(
+          batch_size: collection.batch_size,
+          cursor: cursor&.to_i,
+        )
+      when CSV
+        JobIteration::CsvEnumerator.new(collection).rows(cursor: cursor&.to_i)
+      else
+        raise ArgumentError, <<~MSG.squish
+          #{self.class.name}#collection must be either an
+          Active Record Relation, ActiveRecord::Batches::BatchEnumerator,
+          Array, or CSV.
+        MSG
+      end
+    end
   end
 end

--- a/test/dummy/app/tasks/maintenance/custom_enumerating_task.rb
+++ b/test/dummy/app/tasks/maintenance/custom_enumerating_task.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class CustomEnumeratingTask < MaintenanceTasks::Task
+    def enumerator_builder(cursor:)
+      drop = cursor.nil? ? 0 : cursor.to_i + 1
+
+      [:a, :b, :c].lazy.with_index.drop(drop)
+    end
+
+    def count
+      3
+    end
+
+    def process(_)
+    end
+  end
+end

--- a/test/models/maintenance_tasks/task_data_index_test.rb
+++ b/test/models/maintenance_tasks/task_data_index_test.rb
@@ -9,6 +9,7 @@ module MaintenanceTasks
         "Maintenance::BatchImportPostsTask",
         "Maintenance::CallbackTestTask",
         "Maintenance::CancelledEnqueueTask",
+        "Maintenance::CustomEnumeratingTask",
         "Maintenance::EnqueueErrorTask",
         "Maintenance::ErrorTask",
         "Maintenance::ImportPostsTask",

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -9,6 +9,7 @@ module MaintenanceTasks
         "Maintenance::BatchImportPostsTask",
         "Maintenance::CallbackTestTask",
         "Maintenance::CancelledEnqueueTask",
+        "Maintenance::CustomEnumeratingTask",
         "Maintenance::EnqueueErrorTask",
         "Maintenance::ErrorTask",
         "Maintenance::ImportPostsTask",

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -25,6 +25,7 @@ module MaintenanceTasks
         "Maintenance::BatchImportPostsTask\nNew",
         "Maintenance::CallbackTestTask\nNew",
         "Maintenance::CancelledEnqueueTask\nNew",
+        "Maintenance::CustomEnumeratingTask\nNew",
         "Maintenance::EnqueueErrorTask\nNew",
         "Maintenance::ErrorTask\nNew",
         "Maintenance::Nested::NestedMore::NestedMoreTask\nNew",


### PR DESCRIPTION
This is based on the work in https://github.com/Shopify/maintenance_tasks/pull/326 and the design suggested by @adrianna-chang-shopify in [this comment](https://github.com/Shopify/maintenance_tasks/pull/326#pullrequestreview-613240141).

It allows tasks to define their own custom enumerators, in order to support use cases like iteration over external API resources, or alternative database querying strategies.

It does this by exposing an overridable `enumerator_builder` method on `Task`, whose default implementation is the existing `collection` type inspection logic.

Fixes https://github.com/Shopify/maintenance_tasks/issues/207