### PR TITLE
Add `MaintenanceTasks.stuck_task_duration ` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,6 +897,15 @@ controller class which **must inherit** from `ActionController::Base`.
 
 If no value is specified, it will default to `"ActionController::Base"`.
 
+#### Configure time after which the task will be considered stuck
+
+To specify a time duration after which a task is considered stuck if it has not been updated,
+you can configure `MaintenanceTasks.stuck_task_duration`. This duration should account for
+job infrastructure events that may prevent the maintenance tasks job from being executed and cancelling the task.
+
+The value for `MaintenanceTasks.stuck_task_duration` must be an `ActiveSupport::Duration`.
+If no value is specified, it will default to 5 minutes.
+
 ### Metadata
 
 `MaintenanceTasks.metadata` can be configured to specify a proc from which to

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -32,7 +32,6 @@ module MaintenanceTasks
       :cancelled,
     ]
     COMPLETED_STATUSES = [:succeeded, :errored, :cancelled]
-    STUCK_TASK_TIMEOUT = 5.minutes
 
     enum status: STATUSES.to_h { |status| [status, status.to_s] }
 
@@ -342,7 +341,7 @@ module MaintenanceTasks
     #
     # @return [Boolean] whether the Run is stuck.
     def stuck?
-      (cancelling? || pausing?) && updated_at <= STUCK_TASK_TIMEOUT.ago
+      (cancelling? || pausing?) && updated_at <= MaintenanceTasks.stuck_task_duration.ago
     end
 
     # Performs validation on the task_name attribute.

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -89,4 +89,11 @@ module MaintenanceTasks
   #
   #   @return [Proc] generates a hash containing the metadata to be stored on the Run
   mattr_accessor :metadata, default: nil
+
+  # @!attribute stuck_task_duration
+  #  @scope class
+  #  The duration after which a task is considered stuck and can be force cancelled.
+  #
+  #  @return [ActiveSupport::Duration] the threshold in seconds after which a task is considered stuck.
+  mattr_accessor :stuck_task_duration, default: 5.minutes
 end

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -35,7 +35,7 @@ module MaintenanceTasks
       freeze_time
       TaskJob.perform_later(@run)
       @run.cancel
-      travel Run::STUCK_TASK_TIMEOUT
+      travel MaintenanceTasks.stuck_task_duration
       @run.cancel # force cancel the Run
       assert_predicate @run, :cancelled?
       Maintenance::TestTask.any_instance.expects(:process).never

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -527,7 +527,7 @@ module MaintenanceTasks
       )
       refute_predicate run, :stuck?
 
-      travel Run::STUCK_TASK_TIMEOUT
+      travel MaintenanceTasks.stuck_task_duration
       assert_predicate run, :stuck?
     end
 
@@ -538,7 +538,7 @@ module MaintenanceTasks
           task_name: "Maintenance::UpdatePostsTask",
           status: status,
         )
-        travel Run::STUCK_TASK_TIMEOUT
+        travel MaintenanceTasks.stuck_task_duration
         refute_predicate run, :stuck?
       end
     end
@@ -554,7 +554,7 @@ module MaintenanceTasks
       assert_predicate run, :cancelling?
       assert_nil run.ended_at
 
-      travel Run::STUCK_TASK_TIMEOUT
+      travel MaintenanceTasks.stuck_task_duration
       run.cancel
       assert_predicate run, :cancelled?
       assert_equal Time.now, run.ended_at
@@ -646,7 +646,7 @@ module MaintenanceTasks
       assert_predicate run, :pausing?
       assert_nil run.ended_at
 
-      travel Run::STUCK_TASK_TIMEOUT
+      travel MaintenanceTasks.stuck_task_duration
       run.pause
       assert_predicate run, :paused?
     end

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -182,7 +182,7 @@ module MaintenanceTasks
       assert_text "Cancelling…"
       refute_button "Cancel"
 
-      travel Run::STUCK_TASK_TIMEOUT
+      travel MaintenanceTasks.stuck_task_duration
 
       refresh
       click_on "Cancel"


### PR DESCRIPTION
Having `STUCK_TASK_TIMEOUT` as a constant is not helpful since the actual value will be highly dependent on the job infrastructure of the applications. Simple setups may consider the task being stuck after no updates for ~ 1 minute while more complex and distributed systems with job retries and backoffs may legitimately prefer higher threshold to account for natural delays in a distributed system

It's a breaking change for applications that relied on  `STUCK_TASK_TIMEOUT` though the fix is going to be pretty straightforward. 

### What reviewers should focus on

Is `MaintenanceTasks` module a right place for the config to live? One common alternative would be to define it on the `Task` class which will allow redefining it on per-task basis. But I don't think this would make sense and the behavior is job-infra specific rather than task-specific.  