### PR TITLE
Persist `cursor` on `Run` after job error

### DIFF
--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -127,6 +127,7 @@ module MaintenanceTasks
       @ticker.persist if defined?(@ticker)
 
       if defined?(@run)
+        @run.cursor = cursor_position
         @run.persist_error(error)
 
         task_context = {

--- a/test/dummy/app/tasks/maintenance/error_task.rb
+++ b/test/dummy/app/tasks/maintenance/error_task.rb
@@ -3,11 +3,11 @@
 module Maintenance
   class ErrorTask < MaintenanceTasks::Task
     def collection
-      [1, 2]
+      [1, 2, 3, 4, 5]
     end
 
     def process(input)
-      raise ArgumentError, "Something went wrong" if input == 2
+      raise ArgumentError, "Something went wrong" if input == 3
     end
   end
 end


### PR DESCRIPTION
It looks like `on_shutdown` is not being executed when the job errors out so we end up not persisting the `cursor_position` on the `Run` when error happens.

It wasn't an issue before because `errored` was a final state and not persisting `cursor` wasn't harmful but now I'm doing it for a few reasons:

- Non-essential: It is just helpful to have `cursor` being accurate for debugging purposes
- Since we allow errored runs to be resumed (https://github.com/Shopify/maintenance_tasks/pull/854) we must ensure `cursor` position is accurate so the resumed job starts from the first unsuccessful cursor position 
