### PR TITLE
send active support notifications on run events

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,8 @@ Usage example:
   time_running = payload[:time_running]
   started_at = payload[:started_at]
   ended_at = payload[:ended_at]
+rescue => e
+  Rails.logger.error(e)
 end
 
 ActiveSupport::Notifications.subscribe("errored.maintenance_tasks") do |*, payload|
@@ -487,6 +489,8 @@ ActiveSupport::Notifications.subscribe("errored.maintenance_tasks") do |*, paylo
   error_message = error[:message]
   error_class = error[:class]
   error_backtrace = error[:backtrace]
+rescue => e
+  Rails.logger.error(e)
 end
 
 # or
@@ -501,6 +505,8 @@ class MaintenanceTasksInstrumenter < ActiveSupport::Subscriber
 
     SlackNotifier.broadcast(SLACK_CHANNEL,
       "Job #{task_name} was started by #{metadata[:user_email]}} with arguments #{arguments.to_s.truncate(255)}")
+  rescue => e
+    Rails.logger.error(e)
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -458,11 +458,11 @@ end
 If you are interested in actioning a specific task event, please refer to the [Using Task Callbacks](#using-task-callbacks) section below. However, if you want to subscribe to all events, irrespective of the task, you can use the following Active Support notifications:
 
 ```ruby
-maintenance_tasks.enqueued    # This event is published when a task has been enqueued by the user.
-maintenance_tasks.succeeded   # This event is published when a task has finished without any errors.
-maintenance_tasks.cancelled   # This event is published when the user explicitly halts the execution of a task.
-maintenance_tasks.paused      # This event is published when a task is paused by the user in the middle of its run.
-maintenance_tasks.errored     # This event is published when the task's code produces an unhandled exception.
+enqueued.maintenance_tasks    # This event is published when a task has been enqueued by the user.
+succeeded.maintenance_tasks   # This event is published when a task has finished without any errors.
+cancelled.maintenance_tasks   # This event is published when the user explicitly halts the execution of a task.
+paused.maintenance_tasks      # This event is published when a task is paused by the user in the middle of its run.
+errored.maintenance_tasks     # This event is published when the task's code produces an unhandled exception.
 ```
 
 These notifications offer a way to monitor the lifecycle of maintenance tasks in your application.
@@ -470,7 +470,7 @@ These notifications offer a way to monitor the lifecycle of maintenance tasks in
 Usage example:
 
  ```ruby
- ActiveSupport::Notifications.subscribe("maintenance_tasks.succeeded") do |*, payload|
+ ActiveSupport::Notifications.subscribe("succeeded.maintenance_tasks") do |*, payload|
   task_name = payload[:task_name]
   arguments = payload[:arguments]
   metadata = payload[:metadata]
@@ -481,7 +481,7 @@ Usage example:
   ended_at = payload[:ended_at]
 end
 
-ActiveSupport::Notifications.subscribe("maintenance_tasks.errored") do |*, payload|
+ActiveSupport::Notifications.subscribe("errored.maintenance_tasks") do |*, payload|
   task_name = payload[:task_name]
   error = payload[:error]
   error_message = error[:message]

--- a/README.md
+++ b/README.md
@@ -449,10 +449,13 @@ module Maintenance
     def process(post)
       post.update!(content: "updated content")
     end
+  end
+end
+```
 
 ### Subscribing to instrumentation events
 
-If you are interested in actioning a specific task event, please refer to the `Task Callbacks` section below. However, if you want to subscribe to all events, irrespective of the task, you can use the following Active Support notifications:
+If you are interested in actioning a specific task event, please refer to the [Using Task Callbacks](#using-task-callbacks) section below. However, if you want to subscribe to all events, irrespective of the task, you can use the following Active Support notifications:
 
 ```ruby
 maintenance_tasks.enqueued    # This event is published when a task has been enqueued by the user.
@@ -476,6 +479,14 @@ Usage example:
   time_running = payload[:time_running]
   started_at = payload[:started_at]
   ended_at = payload[:ended_at]
+end
+
+ActiveSupport::Notifications.subscribe("maintenance_tasks.errored") do |*, payload|
+  task_name = payload[:task_name]
+  error = payload[:error]
+  error_message = error[:message]
+  error_class = error[:class]
+  error_backtrace = error[:backtrace]
 end
 
 # or

--- a/README.md
+++ b/README.md
@@ -467,11 +467,15 @@ These notifications offer a way to monitor the lifecycle of maintenance tasks in
 Usage example:
 
  ```ruby
- ActiveSupport::Notifications.subscribe("maintenance_tasks.enqueued") do |*, payload|
-  run = payload[:run]
-  run.task_name
-  run.arguments
-  run.metadata
+ ActiveSupport::Notifications.subscribe("maintenance_tasks.succeeded") do |*, payload|
+  task_name = payload[:task_name]
+  arguments = payload[:arguments]
+  metadata = payload[:metadata]
+  job_id = payload[:job_id]
+  run_id = payload[:run_id]
+  time_running = payload[:time_running]
+  started_at = payload[:started_at]
+  ended_at = payload[:ended_at]
 end
 
 # or
@@ -480,8 +484,12 @@ class MaintenanceTasksInstrumenter < ActiveSupport::Subscriber
   attach_to :maintenance_tasks
 
   def enqueued(event)
-    run = event.payload[:run]
-    SlackNotifier.broadcast(SLACK_CHANNEL, "Job #{run.task_name} was started by #{run.metadata[:user_email]}} with arguments #{run.arguments.to_s.truncate(255)}")
+    task_name = event.payload[:task_name]
+    arguments = event.payload[:arguments]
+    metadata = event.payload[:metadata]
+
+    SlackNotifier.broadcast(SLACK_CHANNEL,
+      "Job #{task_name} was started by #{metadata[:user_email]}} with arguments #{arguments.to_s.truncate(255)}")
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -537,21 +537,6 @@ end
 If any of the other callbacks cause an exception, it will be handled by the
 error handler, and will cause the task to stop running.
 
-Callback behaviour can be shared across all tasks using an initializer.
-
-```ruby
-# config/initializer/maintenance_tasks.rb
-Rails.autoloaders.main.on_load("MaintenanceTasks::Task") do
-  MaintenanceTasks::Task.class_eval do
-    after_start(:notify)
-
-    private
-
-    def notify; end
-  end
-end
-```
-
 ### Considerations when writing Tasks
 
 Maintenance Tasks relies on the queue adapter configured for your application to

--- a/README.md
+++ b/README.md
@@ -467,8 +467,7 @@ These notifications offer a way to monitor the lifecycle of maintenance tasks in
 Usage example:
 
  ```ruby
- ActiveSupport::Notifications.subscribe("maintenance_tasks.enqueued") do |*args|
-  payload = args.last
+ ActiveSupport::Notifications.subscribe("maintenance_tasks.enqueued") do |*, payload|
   run = payload[:run]
   run.task_name
   run.arguments

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -455,7 +455,7 @@ module MaintenanceTasks
     private
 
     def instrument_status_change
-      return if status.nil? || !status_previously_changed?
+      return unless status_previously_changed? || id_previously_changed?
       return if running? || pausing? || cancelling? || interrupted?
 
       attr = {

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -458,7 +458,24 @@ module MaintenanceTasks
       return if status.nil? || !status_previously_changed?
       return if running? || pausing? || cancelling? || interrupted?
 
-      ActiveSupport::Notifications.instrument("maintenance_tasks.#{status}", run: self)
+      attr = {
+        run_id: id,
+        job_id: job_id,
+        task_name: task_name,
+        arguments: arguments,
+        metadata: metadata,
+        time_running: time_running,
+        started_at: started_at,
+        ended_at: ended_at,
+      }
+
+      attr[:error] = {
+        message: error_message,
+        class: error_class,
+        backtrace: backtrace,
+      } if errored?
+
+      ActiveSupport::Notifications.instrument("maintenance_tasks.#{status}", attr)
     rescue
       nil
     end

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -476,8 +476,6 @@ module MaintenanceTasks
       } if errored?
 
       ActiveSupport::Notifications.instrument("#{status}.maintenance_tasks", attr)
-    rescue
-      nil
     end
 
     def run_task_callbacks(callback)

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -456,6 +456,7 @@ module MaintenanceTasks
 
     def instrument_status_change
       return if status.nil? || !status_previously_changed?
+      return if running? || pausing? || cancelling? || interrupted?
 
       ActiveSupport::Notifications.instrument("maintenance_tasks.#{status}", run: self)
     rescue

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -475,7 +475,7 @@ module MaintenanceTasks
         backtrace: backtrace,
       } if errored?
 
-      ActiveSupport::Notifications.instrument("maintenance_tasks.#{status}", attr)
+      ActiveSupport::Notifications.instrument("#{status}.maintenance_tasks", attr)
     rescue
       nil
     end

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -499,7 +499,9 @@ module MaintenanceTasks
       JobIteration.stubs(interruption_adapter: -> { true })
 
       # Simulate cancel happening after we've already checked @run.cancelling?
-      @run.expects(:cancelling?).twice.with do
+      @run.expects(:cancelling?).at_least(2).with do
+        next true if caller.any?(/`instrument_status_change'\z/) # avoid endless loop
+
         Run.find(@run.id).cancel
       end.returns(false).then.returns(true)
 
@@ -512,7 +514,9 @@ module MaintenanceTasks
       JobIteration.stubs(interruption_adapter: -> { true })
 
       # Simulate pause happening after we've already checked @run.pausing?
-      @run.expects(:pausing?).twice.with do
+      @run.expects(:pausing?).at_least(2).with do
+        next true if caller.any?(/`instrument_status_change'\z/) # avoid endless loop
+
         Run.find(@run.id).pausing!
       end.returns(false).then.returns(true)
 

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -74,9 +74,7 @@ module MaintenanceTasks
       )
       run.status = :interrupted
       run.task.expects(:after_interrupt_callback)
-      assert_notification_for("interrupted", run: run) do
-        run.persist_transition
-      end
+      run.persist_transition
     end
 
     test "#persist_transition calls the complete callback" do
@@ -712,7 +710,6 @@ module MaintenanceTasks
       end
       yield
       ActiveSupport::Notifications.unsubscribe(notification)
-
       assert_equal(expected_payload, payload)
     end
 

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -620,6 +620,12 @@ module MaintenanceTasks
       end
     end
 
+    test "#create defaults to the enqueued status" do
+      run = Run.create!(task_name: "Maintenance::CallbackTestTask")
+      assert_predicate(run, :enqueued?)
+      assert_equal(expected_notification(run), Notifier.payload.fetch("enqueued.maintenance_tasks"))
+    end
+
     test "#task returns Task instance for Run" do
       run = Run.new(task_name: "Maintenance::UpdatePostsTask")
       assert_kind_of Maintenance::UpdatePostsTask, run.task


### PR DESCRIPTION
closes https://github.com/Shopify/maintenance_tasks/issues/747

# Why 

Callbacks on the task are not meant to be used for instrumentation across all tasks. `Task` callbacks also don't have access to the `Run` object, preventing this logic from accessing the metadata or other information stored on the run. This makes it difficult to set notifications for status changes, for instance to send slack messages when a job is completed

# What

Send [active support notifications](https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html) on the Run status changes

```
      maintenance_tasks.enqueued,    # The task has been enqueued by the user.
      maintenance_tasks.succeeded,   # The task finished without error.
      maintenance_tasks.cancelled,   # The user explicitly halted the task's execution.
      maintenance_tasks.paused,      # The task was paused in the middle of the run by the user.
      maintenance_tasks.errored,     # The task code produced an unhandled exception.
 ```
 
 # Example
 
 ```ruby
 ActiveSupport::Notifications.subscribe("maintenance_tasks.succeeded") do |*args|
        payload = args.last
        run = payload[:run]
        run.task_name
        run.arguments
        run.metadata
end

 ActiveSupport::Notifications.subscribe("maintenance_tasks.errored") do |*args|
        payload = args.last
        run = payload[:run]
        run.task_name
        run.arguments
        run.error_message
        run.error_class
end

# or

class MaintenanceTasksInstrumenter < ActiveSupport::Subscriber
  attach_to :maintenance_tasks
  
  def enqueued(event)
    run = event.payload[:run]
    SlackNotifier.broadcast(SLACK_CHANNEL, "Job #{run.task_name} was started by #{run.metadata[:user_email]}} with arguments #{run.arguments.to_s.truncate(255)}")
  end
  
  def errored(event)
    run = event.payload[:run]
    SlackNotifier.broadcast(SLACK_CHANNEL, "Job #{run.task_name} halted with an error")
  end
  
  def succeeded(event)
    run = event.payload[:run]
    # do something anytime a maintenance task succeeds
    SlackNotifier.broadcast(SLACK_CHANNEL, "Job #{run.task_name} completed successfully")
  end
  
  ...
end
 ```
 