### PR TITLE
Fix dropdown options from not rendering views with proc, lamda, symbol inclusion options

### DIFF
--- a/test/dummy/app/tasks/maintenance/params_task.rb
+++ b/test/dummy/app/tasks/maintenance/params_task.rb
@@ -17,9 +17,22 @@ module Maintenance
     attribute :date_attr, :date
     attribute :time_attr, :time
     attribute :boolean_attr, :boolean
-    attribute :enum_attr, :integer
 
-    validates_inclusion_of :enum_attr, in: [100, 200, 300], allow_nil: true
+    # Dropdown options with supported scenarios
+    attribute :integer_dropdown_attr, :integer
+    attribute :boolean_dropdown_attr, :boolean
+
+    validates_inclusion_of :integer_dropdown_attr, in: [100, 200, 300], allow_nil: true
+    validates_inclusion_of :boolean_dropdown_attr, within: [true, false], allow_nil: true
+
+    # Dropdown options with unsupported scenarios
+    attribute :text_integer_attr, :integer
+    attribute :text_integer_attr2, :integer
+    attribute :text_integer_attr3, :integer
+
+    validates_inclusion_of :text_integer_attr, in: proc { [100, 200, 300] }, allow_nil: true
+    validates_inclusion_of :text_integer_attr2, in: :undefined_symbol, allow_nil: true
+    validates_inclusion_of :text_integer_attr3, in: (100..), allow_nil: true
 
     class << self
       attr_accessor :fast_task

--- a/test/helpers/maintenance_tasks/tasks_helper_test.rb
+++ b/test/helpers/maintenance_tasks/tasks_helper_test.rb
@@ -91,14 +91,19 @@ module MaintenanceTasks
         csv_file_download_path(run)
     end
 
+    test "#resolve_inclusion_value resolves inclusion validator for task attributes" do
+      assert_match "Select a value", markup("integer_dropdown_attr").squish
+
+      assert_match "Select a value", markup("boolean_dropdown_attr").squish
+
+      ["text_integer_attr", "text_integer_attr2", "text_integer_attr3"].each do |text_integer_attr|
+        refute_match "Select a value", markup(text_integer_attr).squish
+      end
+    end
+
     test "#parameter_field adds information about datetime fields when Time.zone_default is not set" do
       with_zone_default(nil) do
-        markup = render(inline: <<~TEMPLATE)
-          <%= fields_for(Maintenance::ParamsTask.new) do |form| %>
-            <%= parameter_field(form, 'datetime_attr') %>
-          <% end %>
-        TEMPLATE
-        assert_match "UTC", markup
+        assert_match "UTC", markup("datetime_attr")
       end
     end
 
@@ -111,12 +116,7 @@ module MaintenanceTasks
 
     test "#parameter_field adds information about datetime fields when Time.zone_default is set" do
       with_zone_default(Time.find_zone!("EST")) do # ignored
-        markup = render(inline: <<~TEMPLATE)
-          <%= fields_for(Maintenance::ParamsTask.new) do |form| %>
-            <%= parameter_field(form, 'datetime_attr') %>
-          <% end %>
-        TEMPLATE
-        assert_match Time.now.zone.to_s, markup
+        assert_match Time.now.zone.to_s, markup("datetime_attr")
       end
     end
 
@@ -143,6 +143,14 @@ module MaintenanceTasks
       yield
     ensure
       Time.zone_default = zone
+    end
+
+    def markup(attribute)
+      render(inline: <<~TEMPLATE)
+        <%= fields_for(Maintenance::ParamsTask.new) do |form| %>
+          <%= parameter_field(form, '#{attribute}') %>
+        <% end %>
+      TEMPLATE
     end
   end
 end

--- a/test/models/maintenance_tasks/task_data_show_test.rb
+++ b/test/models/maintenance_tasks/task_data_show_test.rb
@@ -87,7 +87,11 @@ module MaintenanceTasks
           "date_attr",
           "time_attr",
           "boolean_attr",
-          "enum_attr",
+          "integer_dropdown_attr",
+          "boolean_dropdown_attr",
+          "text_integer_attr",
+          "text_integer_attr2",
+          "text_integer_attr3",
         ],
         TaskDataShow.new("Maintenance::ParamsTask").parameter_names,
       )

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -114,10 +114,25 @@ module MaintenanceTasks
       boolean_field = page.find_field("task[boolean_attr]")
       assert_equal("input", boolean_field.tag_name)
       assert_equal("checkbox", boolean_field[:type])
-      enum_field = page.find_field("task[enum_attr]")
-      assert_equal("select", enum_field.tag_name)
-      enum_field_options = enum_field.find_all("option").map { |option| option[:value] }
-      assert_equal(["", "100", "200", "300"], enum_field_options)
+
+      integer_dropdown_field = page.find_field("task[integer_dropdown_attr]")
+      assert_equal("select", integer_dropdown_field.tag_name)
+      assert_equal("select-one", integer_dropdown_field[:type])
+      integer_dropdown_field_options = integer_dropdown_field.find_all("option").map { |option| option[:value] }
+      assert_equal(["", "100", "200", "300"], integer_dropdown_field_options)
+
+      boolean_dropdown_field = page.find_field("task[boolean_dropdown_attr]")
+      assert_equal("select", boolean_dropdown_field.tag_name)
+      assert_equal("select-one", boolean_dropdown_field[:type])
+      boolean_dropdown_field_options = boolean_dropdown_field.find_all("option").map { |option| option[:value] }
+      assert_equal(["", "true", "false"], boolean_dropdown_field_options)
+
+      ["text_integer_attr", "text_integer_attr2", "text_integer_attr3"].each do |text_integer_attr|
+        text_integer_dropdown_field = page.find_field("task[#{text_integer_attr}]")
+        assert_equal("input", text_integer_dropdown_field.tag_name)
+        assert_equal("number", text_integer_dropdown_field[:type])
+        assert_empty(text_integer_dropdown_field[:step])
+      end
     end
 
     test "view a Task with multiple pages of Runs" do


### PR DESCRIPTION
Super excited about this [dropdown feature](https://github.com/Shopify/maintenance_tasks/pull/925)! -- but I noticed for example `validates_inclusion_of`'s`:in` also supports proc, lambda, or symbol, so would like to ~~extend on this feature~~ fix these types as the views aren't rendering when they are passed.

This allows you to write:
```ruby
attribute :type, :string
validates_inclusion_of :type, in: ->(_record) { ['new', 'old'] }
```