### PR TITLE
add a CHANGELOG.html file that redirects to the actual changelog

### DIFF
--- a/CHANGELOG.html
+++ b/CHANGELOG.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; URL='https://github.com/Shopify/maintenance_tasks/releases'" />

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" =>
       "https://github.com/Shopify/maintenance_tasks/tree/v#{spec.version}",
     "allowed_push_host" => "https://rubygems.org",
+    "changelog_uri" => "https://github.com/Shopify/maintenance_tasks/blob/main/CHANGELOG.html",
   }
 
   spec.files = Dir["{app,config,db,lib}/**/*", "LICENSE.md", "README.md"]


### PR DESCRIPTION
Re [issue #965](https://github.com/Shopify/maintenance_tasks/issues/965) 

I didn't realize that you already have awesome change documentation - just not in the location that has become standard for Ruby gems. 

This small change will make your existing changelog more discoverable -- both from RubyGems.org, as well as when someone browses your project.

Hope this helps

cheers