### PR TITLE
Move default task build_enumerator logic back into the job

### DIFF
--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -260,7 +260,7 @@ module MaintenanceTasks
       self.class.collection_builder_strategy.count(self)
     end
 
-    # Default enumeration builder. You may override this method to return any
+    # Default enumerator builder. You may override this method to return any
     # Enumerator yielding pairs of `[item, item_cursor]`.
     #
     # @param cursor [String, nil] cursor position to resume from, or nil on
@@ -268,47 +268,7 @@ module MaintenanceTasks
     #
     # @return [Enumerator]
     def enumerator_builder(cursor:)
-      collection = self.collection
-
-      job_iteration_builder = JobIteration::EnumeratorBuilder.new(nil)
-
-      case collection
-      when :no_collection
-        job_iteration_builder.build_once_enumerator(cursor: nil)
-      when ActiveRecord::Relation
-        job_iteration_builder.active_record_on_records(collection, cursor: cursor, columns: cursor_columns)
-      when ActiveRecord::Batches::BatchEnumerator
-        if collection.start || collection.finish
-          raise ArgumentError, <<~MSG.squish
-            #{self.class.name}#collection cannot support
-            a batch enumerator with the "start" or "finish" options.
-          MSG
-        end
-
-        # For now, only support automatic count based on the enumerator for
-        # batches
-        job_iteration_builder.active_record_on_batch_relations(
-          collection.relation,
-          cursor: cursor,
-          batch_size: collection.batch_size,
-          columns: cursor_columns,
-        )
-      when Array
-        job_iteration_builder.build_array_enumerator(collection, cursor: cursor&.to_i)
-      when BatchCsvCollectionBuilder::BatchCsv
-        JobIteration::CsvEnumerator.new(collection.csv).batches(
-          batch_size: collection.batch_size,
-          cursor: cursor&.to_i,
-        )
-      when CSV
-        JobIteration::CsvEnumerator.new(collection).rows(cursor: cursor&.to_i)
-      else
-        raise ArgumentError, <<~MSG.squish
-          #{self.class.name}#collection must be either an
-          Active Record Relation, ActiveRecord::Batches::BatchEnumerator,
-          Array, or CSV.
-        MSG
-      end
+      nil
     end
   end
 end

--- a/test/dummy/app/tasks/maintenance/custom_enumerating_task.rb
+++ b/test/dummy/app/tasks/maintenance/custom_enumerating_task.rb
@@ -12,7 +12,8 @@ module Maintenance
       3
     end
 
-    def process(_)
+    def process(letter)
+      Rails.logger.debug("letter: #{letter}")
     end
   end
 end


### PR DESCRIPTION
Tasks can still define `#build_enumerator` to override the default and supply a custom enumerator for their task, but we shouldn't have all of the Job Iteration enumerator logic moved into the Task class.

Adds additional documentation for writing tests for tasks that use custom enumerators.