### PR TITLE
Don't use deprecated enum syntax

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -33,7 +33,11 @@ module MaintenanceTasks
     ]
     COMPLETED_STATUSES = [:succeeded, :errored, :cancelled]
 
-    enum status: STATUSES.to_h { |status| [status, status.to_s] }
+    if Rails.gem_version >= Gem::Version.new("7.0.alpha")
+      enum :status, STATUSES.to_h { |status| [status, status.to_s] }
+    else
+      enum status: STATUSES.to_h { |status| [status, status.to_s] }
+    end
 
     validate :task_name_belongs_to_a_valid_task, on: :create
     validate :csv_attachment_presence, on: :create


### PR DESCRIPTION
Fixes #968

Rails 7.2 will deprecate 
```ruby
enum status: [:pending, :failure, :success]
```
in favor of:
```ruby
enum :status, [:pending, :failure, :success]
```
to avoid issues around the options that could conflict with the enum's values, see https://github.com/rails/rails/pull/50987.

I decided to use a guard against the Rails version instead of simply checking the method's arity in order to make it easier to grep in the future when we remove support for Rails 6.1 (the new syntax was added in 7.0).