### PR TITLE
Don't create multiple issues for the weekly CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,10 @@ jobs:
     - name: Create issue
       if: failure() && github.event.schedule
       run: |
-        gh issue create --repo "$GITHUB_REPOSITORY" \
-          --title "Weekly CI run failed" \
-          --body "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        if [ "$(gh issue list --state=open --author='github-actions[bot]' | wc -l)" = 0 ]; then
+          gh issue create --repo "$GITHUB_REPOSITORY" \
+            --title "Weekly CI run failed" \
+            --body "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        fi
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The create issue step runs for each job in the matrix that fails, which can result in multiple issues being created in a given week.

Beyond that, if for some reason we haven't addressed one week's failures in a week's duration, we will keep getting more issues being created.

While we could add a separate job in the workflow to avoid the first issue, it will result in an additional status on all commits, skipped for most, which will also impact Shipit, which expects all statuses to be successful.

That also won't solve the second issue, so instead we query GitHub to see if any issues are open prior to opening a new one. That opens up a race condition but hopefully won't be too much of an issue.