### PR TITLE
Remove outdated TargetRubyVersion in RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,6 @@ inherit_gem:
   rubocop-shopify: rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
   Exclude:
     - test/dummy/db/schema.rb
     - vendor/**/*


### PR DESCRIPTION
Since RuboCop 1.61, the required ruby version from the gemspec takes precedence over the version in .ruby-version.

And since v2.2.0, we don't support Ruby 2.7 so no need to keep our syntax compatible with it.