### PR TITLE
Prevent sqlite3 2.0 except for Rails edge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "capybara"
 gem "debug"
 gem "mocha"
 gem "puma"
-if defined?(@rails_gem_requirement) && @rails_gem_requirement
+if @rails_gem_requirement
   # causes Dependabot to ignore the next line and update the next gem "rails"
   rails = "rails"
   gem rails, @rails_gem_requirement
@@ -20,5 +20,11 @@ gem "rubocop"
 gem "rubocop-shopify"
 gem "selenium-webdriver"
 gem "sprockets-rails"
-gem "sqlite3"
+if @sqlite3_requirement
+  # causes Dependabot to ignore the next line and update the next gem "sqlite3"
+  sqlite3 = "sqlite3"
+  gem sqlite3, @sqlite3_requirement
+else
+  gem "sqlite3"
+end
 gem "yard"

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 @rails_gem_requirement = "~> 6.0.0"
+@sqlite3_requirement = "~> 1.4"
 
 eval_gemfile "../Gemfile"

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 @rails_gem_requirement = "~> 6.1.0"
+@sqlite3_requirement = "~> 1.4"
 
 eval_gemfile "../Gemfile"

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 @rails_gem_requirement = "~> 7.0.4"
+@sqlite3_requirement = "~> 1.4"
 
 eval_gemfile "../Gemfile"


### PR DESCRIPTION
Fix #1007 

Dependabot will still try to update sqlite3 in Gemfile.lock and that will still fail, but that will happen whether or not we set a requirement there.

We can then ignore the major entirely, but we'll need to remember to bump sqlite3 once Rails 7.2 ships and is in Gemfile.lock.