### PR TITLE
Adding disable-gpu flag

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -9,7 +9,7 @@ ActionDispatch::SystemTesting::Server.silence_puma = true
 # Selenium::WebDriver::Logger before it is instantiated in
 # Selenium::WebDriver.logger to prevent an uninitialized instance variable
 # warning in Ruby 2.7.
-# Capybara::Selenium::Driver.load_selenium
+Capybara::Selenium::Driver.load_selenium
 
 if Rails::VERSION::MAJOR < 7
   Selenium::WebDriver.logger.ignore(:browser_options)


### PR DESCRIPTION
Before disabling this flag on MacOs: Runtime was: 90+ seconds 
After this change MacOs: Runtime down to 17.80s: 

The disable gpu flag was added to `application_system_test_case.rb` application system test case
- Fixes slow system specs on MacOs


- Closes: https://github.com/Shopify/maintenance_tasks/issues/990