### PR TITLE
Expose Run instance on Task

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -443,6 +443,7 @@ module MaintenanceTasks
     def task
       @task ||= begin
         task = Task.named(task_name).new
+        task.run = self
         if task.attribute_names.any? && arguments.present?
           task.assign_attributes(arguments)
         end

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -191,6 +191,9 @@ module MaintenanceTasks
       end
     end
 
+    # The Run that is currently being executed.
+    attr_accessor :run
+
     # The contents of a CSV file to be processed by a Task.
     #
     # @return [String] the content of the CSV file to process.

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -631,6 +631,11 @@ module MaintenanceTasks
       assert_kind_of Maintenance::UpdatePostsTask, run.task
     end
 
+    test "#task sets run on the Task instance" do
+      run = Run.new(task_name: "Maintenance::UpdatePostsTask")
+      assert_equal(run, run.task.run)
+    end
+
     test "#validate_task_arguments instantiates Task and assigns arguments if Task has parameters" do
       run = Run.new(
         task_name: "Maintenance::ParamsTask",


### PR DESCRIPTION
Expose Run instance on Task.

This is basically the same as #924, so all credit goes to @shalvah. I'm opening a new PR since the old one was closed and I'm hoping a new PR will be more visible to the maintainers (but also happy to close this PR in favor of the old one).

We've been using this in our codebase via the following monkey patch:
```ruby
require "maintenance_tasks"

module MaintenanceTasks
  class Run < ApplicationRecord
    module SetTaskRunPatch
      def task
        super.tap do |task|
          task.run ||= self
        end
      end
    end

    prepend SetTaskRunPatch
  end

  class Task
    attr_accessor :run
  end
end
```

This enables us to do some interesting stuff like exposing a logger to tasks and storing the log output on the Run instances, or adding the run ID to our error contexts, etc.
