### PR TITLE
Use bin/rails secret in bin/production

### DIFF
--- a/bin/production
+++ b/bin/production
@@ -3,7 +3,7 @@
 set -ex
 
 export RAILS_ENV=production
-SECRET_KEY_BASE="$(bin/rails app:secret)"
+SECRET_KEY_BASE="$(bin/rails secret)"
 export SECRET_KEY_BASE
 
 bin/rails app:assets:precompile


### PR DESCRIPTION
Fix:
```
$ bin/production
+ export RAILS_ENV=production
+ RAILS_ENV=production
++ bin/rails app:secret
+ SECRET_KEY_BASE='Unrecognized command "app:secret" (Rails::Command::UnrecognizedCommandError)
Did you mean?  app:db:reset'
```

Now:
```
$ bin/production
+ export RAILS_ENV=production
+ RAILS_ENV=production
++ bin/rails secret
+ SECRET_KEY_BASE=aec0d54abaeba02918b23da4e2ebbd08286e0dbc43ef488c03fb819cce8e7301a372b897783855d4fc253690ede1d8ed6756649167d65f41ab07952c15a994be
+ export SECRET_KEY_BASE
+ bin/rails app:assets:precompile
+ DISABLE_DATABASE_ENVIRONMENT_CHECK=true
+ bin/rails db:setup
Created database 'db/production.sqlite3'
+ RAILS_SERVE_STATIC_FILES=true
+ bin/rails server
=> Booting Puma
=> Rails 7.1.3.3 application starting in production
=> Run `bin/rails server --help` for more startup options
Puma starting in single mode...
* Puma version: 6.4.2 (ruby 3.3.0-p0) ("The Eagle of Durango")
*  Min threads: 5
*  Max threads: 5
*  Environment: production
*          PID: 33466
* Listening on http://0.0.0.0:1030
Use Ctrl-C to stop
```

Most likely broke in a preview Rails upgrade, but I didn't investigate more than this.