### PR TITLE
Add direct upload capability

### DIFF
--- a/app/assets/javascripts/maintenance_tasks.js
+++ b/app/assets/javascripts/maintenance_tasks.js
@@ -1,3 +1,4 @@
+//= require activestorage
 //= require_self
 
 function refresh() {

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -9,7 +9,7 @@
     <% if @task.csv_task? %>
       <div class="block">
         <%= form.label :csv_file %>
-        <%= form.file_field :csv_file, accept: "text/csv" %>
+        <%= form.file_field :csv_file, accept: "text/csv", direct_upload: MaintenanceTasks.direct_upload %>
       </div>
     <% end %>
     <% parameter_names = @task.parameter_names %>

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -96,4 +96,11 @@ module MaintenanceTasks
   #
   #  @return [ActiveSupport::Duration] the threshold in seconds after which a task is considered stuck.
   mattr_accessor :stuck_task_duration, default: 5.minutes
+
+  # @!attribute direct_upload
+  #  @scope class
+  #  Controls direct upload support for CSV files.
+  #
+  #  @return [Boolean] whether to enable direct upload for CSV files.
+  mattr_accessor :direct_upload, default: false
 end


### PR DESCRIPTION
Depends on https://github.com/Shopify/maintenance_tasks/pull/1029

Adds the ability to enable [direct uploads](https://guides.rubyonrails.org/v7.1/active_storage_overview.html#direct-uploads), which can help circumvent upload limits on the server.