### PR TITLE
Add support for bounded enumerables and stateless Procs in inclusion validation

### DIFF
--- a/app/helpers/maintenance_tasks/tasks_helper.rb
+++ b/app/helpers/maintenance_tasks/tasks_helper.rb
@@ -102,8 +102,9 @@ module MaintenanceTasks
     end
 
     # Resolves values covered by the inclusion validator for a task attribute.
-    # Only Arrays are supported, option types such as:
-    # Procs, lambdas, symbols, and Range are not supported and return nil.
+    # Only Arrays are supported.
+    # Procs and lambdas are also supported, but only if they take no arguments and return an Array.
+    # Option types such as Symbols, and Range are not supported and return nil.
     #
     # Returned values are used to populate a dropdown list of options.
     #
@@ -118,6 +119,7 @@ module MaintenanceTasks
       return unless inclusion_validator
 
       in_option = inclusion_validator.options[:in] || inclusion_validator.options[:within]
+      in_option = in_option.call if in_option.is_a?(Proc) && in_option.arity.zero?
       in_option if in_option.is_a?(Array)
     end
 

--- a/test/dummy/app/tasks/maintenance/params_task.rb
+++ b/test/dummy/app/tasks/maintenance/params_task.rb
@@ -27,10 +27,12 @@ module Maintenance
 
     # Dropdown options with unsupported scenarios
     attribute :text_integer_attr_proc_no_arg, :integer
+    attribute :text_integer_attr_proc_arg, :integer
     attribute :text_integer_attr_undefined_symbol, :integer
     attribute :text_integer_attr_unbounded_range, :integer
 
     validates_inclusion_of :text_integer_attr_proc_no_arg, in: proc { [100, 200, 300] }, allow_nil: true
+    validates_inclusion_of :text_integer_attr_proc_arg, in: proc { |_task| [100, 200, 300] }, allow_nil: true
     validates_inclusion_of :text_integer_attr_undefined_symbol, in: :undefined_symbol, allow_nil: true
     validates_inclusion_of :text_integer_attr_unbounded_range, in: (100..), allow_nil: true
 

--- a/test/dummy/app/tasks/maintenance/params_task.rb
+++ b/test/dummy/app/tasks/maintenance/params_task.rb
@@ -30,11 +30,15 @@ module Maintenance
     attribute :text_integer_attr_proc_arg, :integer
     attribute :text_integer_attr_undefined_symbol, :integer
     attribute :text_integer_attr_unbounded_range, :integer
+    attribute :text_integer_attr_bounded_range, :integer
+    attribute :text_integer_attr_enumerable, :integer
 
     validates_inclusion_of :text_integer_attr_proc_no_arg, in: proc { [100, 200, 300] }, allow_nil: true
     validates_inclusion_of :text_integer_attr_proc_arg, in: proc { |_task| [100, 200, 300] }, allow_nil: true
     validates_inclusion_of :text_integer_attr_undefined_symbol, in: :undefined_symbol, allow_nil: true
     validates_inclusion_of :text_integer_attr_unbounded_range, in: (100..), allow_nil: true
+    validates_inclusion_of :text_integer_attr_bounded_range, in: (100..120), allow_nil: true
+    validates_inclusion_of :text_integer_attr_enumerable, in: (100..120).step(5), allow_nil: true
 
     class << self
       attr_accessor :fast_task

--- a/test/dummy/app/tasks/maintenance/params_task.rb
+++ b/test/dummy/app/tasks/maintenance/params_task.rb
@@ -26,13 +26,13 @@ module Maintenance
     validates_inclusion_of :boolean_dropdown_attr, within: [true, false], allow_nil: true
 
     # Dropdown options with unsupported scenarios
-    attribute :text_integer_attr, :integer
-    attribute :text_integer_attr2, :integer
-    attribute :text_integer_attr3, :integer
+    attribute :text_integer_attr_proc_no_arg, :integer
+    attribute :text_integer_attr_undefined_symbol, :integer
+    attribute :text_integer_attr_unbounded_range, :integer
 
-    validates_inclusion_of :text_integer_attr, in: proc { [100, 200, 300] }, allow_nil: true
-    validates_inclusion_of :text_integer_attr2, in: :undefined_symbol, allow_nil: true
-    validates_inclusion_of :text_integer_attr3, in: (100..), allow_nil: true
+    validates_inclusion_of :text_integer_attr_proc_no_arg, in: proc { [100, 200, 300] }, allow_nil: true
+    validates_inclusion_of :text_integer_attr_undefined_symbol, in: :undefined_symbol, allow_nil: true
+    validates_inclusion_of :text_integer_attr_unbounded_range, in: (100..), allow_nil: true
 
     class << self
       attr_accessor :fast_task

--- a/test/helpers/maintenance_tasks/tasks_helper_test.rb
+++ b/test/helpers/maintenance_tasks/tasks_helper_test.rb
@@ -92,12 +92,19 @@ module MaintenanceTasks
     end
 
     test "#resolve_inclusion_value resolves inclusion validator for task attributes" do
-      assert_match "Select a value", markup("integer_dropdown_attr").squish
+      [
+        "integer_dropdown_attr",
+        "boolean_dropdown_attr",
+      ].each do |attribute|
+        assert_match "Select a value", markup(attribute).squish
+      end
 
-      assert_match "Select a value", markup("boolean_dropdown_attr").squish
-
-      ["text_integer_attr", "text_integer_attr2", "text_integer_attr3"].each do |text_integer_attr|
-        refute_match "Select a value", markup(text_integer_attr).squish
+      [
+        "text_integer_attr_proc_no_arg",
+        "text_integer_attr_undefined_symbol",
+        "text_integer_attr_unbounded_range",
+      ].each do |attribute|
+        refute_match "Select a value", markup(attribute).squish
       end
     end
 

--- a/test/helpers/maintenance_tasks/tasks_helper_test.rb
+++ b/test/helpers/maintenance_tasks/tasks_helper_test.rb
@@ -95,12 +95,13 @@ module MaintenanceTasks
       [
         "integer_dropdown_attr",
         "boolean_dropdown_attr",
+        "text_integer_attr_proc_no_arg",
       ].each do |attribute|
         assert_match "Select a value", markup(attribute).squish
       end
 
       [
-        "text_integer_attr_proc_no_arg",
+        "text_integer_attr_proc_arg",
         "text_integer_attr_undefined_symbol",
         "text_integer_attr_unbounded_range",
       ].each do |attribute|

--- a/test/helpers/maintenance_tasks/tasks_helper_test.rb
+++ b/test/helpers/maintenance_tasks/tasks_helper_test.rb
@@ -96,6 +96,8 @@ module MaintenanceTasks
         "integer_dropdown_attr",
         "boolean_dropdown_attr",
         "text_integer_attr_proc_no_arg",
+        "text_integer_attr_bounded_range",
+        "text_integer_attr_enumerable",
       ].each do |attribute|
         assert_match "Select a value", markup(attribute).squish
       end

--- a/test/models/maintenance_tasks/task_data_show_test.rb
+++ b/test/models/maintenance_tasks/task_data_show_test.rb
@@ -93,6 +93,8 @@ module MaintenanceTasks
           "text_integer_attr_proc_arg",
           "text_integer_attr_undefined_symbol",
           "text_integer_attr_unbounded_range",
+          "text_integer_attr_bounded_range",
+          "text_integer_attr_enumerable",
         ],
         TaskDataShow.new("Maintenance::ParamsTask").parameter_names,
       )

--- a/test/models/maintenance_tasks/task_data_show_test.rb
+++ b/test/models/maintenance_tasks/task_data_show_test.rb
@@ -89,9 +89,9 @@ module MaintenanceTasks
           "boolean_attr",
           "integer_dropdown_attr",
           "boolean_dropdown_attr",
-          "text_integer_attr",
-          "text_integer_attr2",
-          "text_integer_attr3",
+          "text_integer_attr_proc_no_arg",
+          "text_integer_attr_undefined_symbol",
+          "text_integer_attr_unbounded_range",
         ],
         TaskDataShow.new("Maintenance::ParamsTask").parameter_names,
       )

--- a/test/models/maintenance_tasks/task_data_show_test.rb
+++ b/test/models/maintenance_tasks/task_data_show_test.rb
@@ -90,6 +90,7 @@ module MaintenanceTasks
           "integer_dropdown_attr",
           "boolean_dropdown_attr",
           "text_integer_attr_proc_no_arg",
+          "text_integer_attr_proc_arg",
           "text_integer_attr_undefined_symbol",
           "text_integer_attr_unbounded_range",
         ],

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -128,6 +128,18 @@ module MaintenanceTasks
       integer_dropdown_field_options = integer_dropdown_field.find_all("option").map { |option| option[:value] }
       assert_equal(["", "100", "200", "300"], integer_dropdown_field_options)
 
+      integer_dropdown_field = page.find_field("task[text_integer_attr_bounded_range]")
+      assert_equal("select", integer_dropdown_field.tag_name)
+      assert_equal("select-one", integer_dropdown_field[:type])
+      integer_dropdown_field_options = integer_dropdown_field.find_all("option").map { |option| option[:value] }
+      assert_equal([""] + (100..120).to_a.map(&:to_s), integer_dropdown_field_options)
+
+      integer_dropdown_field = page.find_field("task[text_integer_attr_enumerable]")
+      assert_equal("select", integer_dropdown_field.tag_name)
+      assert_equal("select-one", integer_dropdown_field[:type])
+      integer_dropdown_field_options = integer_dropdown_field.find_all("option").map { |option| option[:value] }
+      assert_equal(["", "100", "105", "110", "115", "120"], integer_dropdown_field_options)
+
       boolean_dropdown_field = page.find_field("task[boolean_dropdown_attr]")
       assert_equal("select", boolean_dropdown_field.tag_name)
       assert_equal("select-one", boolean_dropdown_field[:type])

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -128,7 +128,11 @@ module MaintenanceTasks
       boolean_dropdown_field_options = boolean_dropdown_field.find_all("option").map { |option| option[:value] }
       assert_equal(["", "true", "false"], boolean_dropdown_field_options)
 
-      ["text_integer_attr", "text_integer_attr2", "text_integer_attr3"].each do |text_integer_attr|
+      [
+        "text_integer_attr_proc_no_arg",
+        "text_integer_attr_undefined_symbol",
+        "text_integer_attr_unbounded_range",
+      ].each do |text_integer_attr|
         text_integer_dropdown_field = page.find_field("task[#{text_integer_attr}]")
         assert_equal("input", text_integer_dropdown_field.tag_name)
         assert_equal("number", text_integer_dropdown_field[:type])

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -122,6 +122,12 @@ module MaintenanceTasks
       integer_dropdown_field_options = integer_dropdown_field.find_all("option").map { |option| option[:value] }
       assert_equal(["", "100", "200", "300"], integer_dropdown_field_options)
 
+      integer_dropdown_field = page.find_field("task[text_integer_attr_proc_no_arg]")
+      assert_equal("select", integer_dropdown_field.tag_name)
+      assert_equal("select-one", integer_dropdown_field[:type])
+      integer_dropdown_field_options = integer_dropdown_field.find_all("option").map { |option| option[:value] }
+      assert_equal(["", "100", "200", "300"], integer_dropdown_field_options)
+
       boolean_dropdown_field = page.find_field("task[boolean_dropdown_attr]")
       assert_equal("select", boolean_dropdown_field.tag_name)
       assert_equal("select-one", boolean_dropdown_field[:type])
@@ -129,9 +135,9 @@ module MaintenanceTasks
       assert_equal(["", "true", "false"], boolean_dropdown_field_options)
 
       [
-        "text_integer_attr_proc_no_arg",
         "text_integer_attr_undefined_symbol",
         "text_integer_attr_unbounded_range",
+        "text_integer_attr_proc_arg",
       ].each do |text_integer_attr|
         text_integer_dropdown_field = page.find_field("task[#{text_integer_attr}]")
         assert_equal("input", text_integer_dropdown_field.tag_name)


### PR DESCRIPTION
Add support for a few variations of inclusion constraints.

The motivating factor behind this is to be able to resolve to a list of classes that can only be resolved at runtime.

For example, this is not stable, it depends in which order the classes are loaded:
```rb
validates :model, inclusion: { in: ActiveRecord::Base.descendants.map(&:name) }
```

It needs a lambda:
```rb
validates :model, inclusion: { in: ->() { ActiveRecord::Base.descendants.map(&:name) } }
```

However, stateful lambda are prohibited, because they depend on the task instance:
```rb
validates :model, inclusion: { in: ->() { |task| task.some_method } }
```

---

While at it, this PR also adds support for bounded enumerables:
```rb
validates :timeout, inclusion: { in: (0..30).step(5) }
```

---

See the update test and comments for a full explanation.