### PR TITLE
Ensure the cursor updates and the task resumes from the point of termination when Sidekiq stops the task midway.

### DIFF
--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -95,6 +95,7 @@ module MaintenanceTasks
     # @param _run [Run] the current Run, passed as an argument by Job Iteration.
     def each_iteration(input, _run)
       throw(:abort, :skip_complete_callbacks) if @run.stopping?
+      @run.cursor = cursor_position
       task_iteration(input)
       @ticker.tick
       @run.reload_status


### PR DESCRIPTION
close #1047

Update MaintenanceTasks::Run's cursor column every iteration.

This change would allow the task to resume from the point of interruption, even if it is unexpectedly terminated.


I agreed to the CLA earlier, so I think the CLA job will pass if I rerun it. 
