### PR TITLE
Add support for accepting query parameters as arguments

### DIFF
--- a/app/models/maintenance_tasks/task_data_show.rb
+++ b/app/models/maintenance_tasks/task_data_show.rb
@@ -79,12 +79,23 @@ module MaintenanceTasks
       end
     end
 
+    # @param params [Hash] query parameter
+    #
     # @return [MaintenanceTasks::Task, nil] an instance of the Task class.
     # @return [nil] if the Task file was deleted.
-    def new
+    def new(params = {})
       return if deleted?
 
-      MaintenanceTasks::Task.named(name).new
+      task = MaintenanceTasks::Task.named(name).new
+      if params.present?
+        begin
+          default_parameters = params.to_h.stringify_keys.slice(*task.attributes.stringify_keys.keys)
+          task.assign_attributes(default_parameters)
+        rescue ActionController::UnfilteredParameters
+          nil
+        end
+      end
+      task
     end
 
     private

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -15,7 +15,7 @@
     <% parameter_names = @task.parameter_names %>
     <% if parameter_names.any? %>
       <div class="block">
-        <%= fields_for :task, @task.new do |ff| %>
+        <%= fields_for :task, @task.new(params) do |ff| %>
           <% parameter_names.each do |parameter_name| %>
             <div class="field">
               <%= ff.label parameter_name, parameter_name, class: "label is-family-monospace" %>

--- a/test/models/maintenance_tasks/task_data_show_test.rb
+++ b/test/models/maintenance_tasks/task_data_show_test.rb
@@ -109,5 +109,25 @@ module MaintenanceTasks
     test "#new returns nil for a deleted Task" do
       assert_nil TaskDataShow.new("Maintenance::DoesNotExist").new
     end
+
+    test "#new returns a Task instance with parameters" do
+      params = { post_ids: "123" }
+      task = TaskDataShow.new("Maintenance::ParamsTask").new(params)
+      assert_kind_of Task, task
+      assert_equal "123", task.post_ids
+    end
+
+    test "#new returns a Task instance without parameters" do
+      task = TaskDataShow.new("Maintenance::ParamsTask").new
+      assert_kind_of Task, task
+      assert_nil task.post_ids
+    end
+
+    test "#new ignores unspecified parameters" do
+      params = { post_ids: "123", unspecified_param: "value" }
+      task = TaskDataShow.new("Maintenance::ParamsTask").new(params)
+      assert_equal "123", task.post_ids
+      assert_not_respond_to task, :unspecified_param
+    end
   end
 end


### PR DESCRIPTION
Ref. https://github.com/Shopify/maintenance_tasks/pull/1046

## Purpose
This pull request adds the ability to launch the Maintenance Task screen with default values populated via query parameters. This enhancement aims to streamline the process of executing maintenance tasks by eliminating the need for manual copying and pasting of task-related data.

## Background
Maintenance tasks are typically one-off or as-needed tasks, rather than regular occurrences. They are usually ephemeral, meaning they are used briefly and then deleted.
Currently, when our internal directors need to run a specific maintenance task from a spreadsheet, they have to manually copy the relevant information and paste it into the system. This process is repetitive and prone to errors.
To address this issue, we want to enable launching the Maintenance Task screen directly with the necessary data pre-populated by passing it as query parameters in the URL. This way, directors can simply click on a link to open the screen with the desired task information loaded, saving time and reducing the chances of mistakes.
However, for complex data or scenarios that require dependent destruction, directors may prefer to input data one by one instead of using a pre-created list or CSV file for bulk input. In such cases, they would like to create a URL from a spreadsheet for each individual task, execute it, and then delete the task upon completion.
Implementation

Added support for accepting arbitrary query parameters when launching the Maintenance Task screen
If a query parameter is provided, the screen will populate the corresponding field with its value

For example, if the post_ids parameter is provided, the screen will populate the post IDs field with its value


The screen can now be launched with default values by constructing a URL like: localhost:3000/maintenance_tasks/tasks/Maintenance::ParamsTask?post_ids=1,2,3

## Benefits

Simplifies the process of executing maintenance tasks by eliminating manual copy-pasting of data
Reduces the chances of human error when inputting task-related information
Saves time for directors and improves their workflow efficiency
Allows for flexible passing of data through arbitrary query parameters
Supports one-by-one data input and execution for complex data or dependent destruction scenarios

## Example Usage
To launch the Maintenance Task screen with default values:

Construct the URL with the desired query parameters, e.g., localhost:3000/maintenance_tasks/tasks/Maintenance::ParamsTask?post_ids=1,2,3
Click on the URL or open it in a browser
The Maintenance Task screen will open with the specified data pre-populated in the corresponding fields

Please let me know if you have any questions or feedback regarding this enhancement. I look forward to discussing it further!