### PR TITLE
Fix statically resolving renders in Task#show

### DIFF
--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -44,7 +44,7 @@
 
     <h4 class="title is-4">Active Runs</h4>
 
-    <%= render @task.active_runs %>
+    <%= render partial: "maintenance_tasks/runs/run", collection: @task.active_runs %>
   <% end %>
 
   <% if @runs_page.records.present? %>
@@ -52,7 +52,7 @@
 
     <h4 class="title is-4">Previous Runs</h4>
 
-    <%= render @runs_page.records %>
+    <%= render partial: "maintenance_tasks/runs/run", collection: @runs_page.records %>
 
     <%= link_to "Next page", task_path(@task, cursor: @runs_page.next_cursor) unless @runs_page.last? %>
   <% end %>


### PR DESCRIPTION
Rails tries to parse `render` calls in partials to generate a tree of dependencies that should be included in the cache key for a template/partial. The `RenderParser` is also used by gems such as ActionView::Precompiler and LooseErbs for similar purposes (identifying template/partial dependencies).

Currently, `render @task.active_runs` and `render @runs_page.records` cannot be resolved by the `RenderParser` (this is a documented shortcoming of the `RenderParser`).

This commit makes the two partial dependencies explicit as recommended in the `ActionView::CacheHelper` docs. This should not change the behavior of the renders, but it does enable the `RenderParser` to identify the partials being rendered.