### PR TITLE
Ensure task_context is never nil when error_handler is called

### DIFF
--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -166,6 +166,7 @@ module MaintenanceTasks
     end
 
     def on_error(error)
+      task_context = {}
       @ticker.persist if defined?(@ticker)
 
       if defined?(@run)
@@ -177,8 +178,6 @@ module MaintenanceTasks
           started_at: @run.started_at,
           ended_at: @run.ended_at,
         }
-      else
-        task_context = {}
       end
       errored_element = @errored_element if defined?(@errored_element)
     ensure


### PR DESCRIPTION
If `@run.persist_error(error)` raises an error, `task_context` is never assigned and then is `nil` when `MaintenanceTasks.error_handler` is `call`ed.