### PR TITLE
Do not use hash-based syntax to mount an engine

### DIFF
--- a/lib/generators/maintenance_tasks/install_generator.rb
+++ b/lib/generators/maintenance_tasks/install_generator.rb
@@ -10,7 +10,7 @@ module MaintenanceTasks
 
     # Mounts the engine in the host application's config/routes.rb
     def mount_engine
-      route("mount MaintenanceTasks::Engine => \"/maintenance_tasks\"")
+      route("mount MaintenanceTasks::Engine, at: \"/maintenance_tasks\"")
     end
 
     # Copies engine migrations to host application and migrates the database

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  mount MaintenanceTasks::Engine => "/maintenance_tasks"
+  mount MaintenanceTasks::Engine, at: "/maintenance_tasks"
   resources :posts
   root to: "posts#index"
 end

--- a/test/lib/generators/maintenance_tasks/install_generator_test.rb
+++ b/test/lib/generators/maintenance_tasks/install_generator_test.rb
@@ -27,7 +27,7 @@ module MaintenanceTasks
 
         assert_file("config/routes.rb") do |contents|
           assert_match(
-            %r{mount MaintenanceTasks::Engine => "/maintenance_tasks"},
+            %r{mount MaintenanceTasks::Engine, at: "/maintenance_tasks"},
             contents,
           )
         end


### PR DESCRIPTION
Hash syntax was deprecated in https://github.com/rails/rails/pull/52422

This PR addresses deprecation by using `at:` keyword argument instead as the deprecation suggests. 