### PR TITLE
Exclude Ruby 3.1 for Rails main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
         - gemfile: "gemfiles/postgresql.gemfile"
           ruby: 3.3
           database: postgres
+        exclude:
+        - gemfile: "gemfiles/rails_main.gemfile"
+          ruby: 3.1
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
       DB: ${{ matrix.database }}


### PR DESCRIPTION
Fix #1087 