### PR TITLE
Expose Run Id to Task Instance

### DIFF
--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -114,6 +114,7 @@ module MaintenanceTasks
     def before_perform
       @run = arguments.first
       @task = @run.task
+      @task.run_id = @run.id
       if @task.has_csv_content?
         @task.csv_content = @run.csv_file.download
       end

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -29,6 +29,8 @@ module MaintenanceTasks
 
     define_callbacks :start, :complete, :error, :cancel, :pause, :interrupt
 
+    attr_accessor :run_id
+
     class << self
       # Finds a Task with the given name.
       #

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -31,6 +31,12 @@ module MaintenanceTasks
       assert_no_enqueued_jobs
     end
 
+    test ".perform sets the run_id on the task instance" do
+      TaskJob.perform_now(@run)
+
+      assert_equal @run.id, @run.task.run_id
+    end
+
     test ".perform doesn't run a cancelled job" do
       freeze_time
       TaskJob.perform_later(@run)


### PR DESCRIPTION
The Run record contains a lot of information that's interesting to a Task, including
metadata, the id, the status of the run, etc.

It's been previously rejected to expose the whole instance of the Run on the Task, so
in this case we're exposing only the ID. That gives us a unique identifier for the
execution of a given Task instance, without tying it explicitly to the Run object, but
also allowing interested parties to fetch that information if they so desire.
