### PR TITLE
Reference query params to set task attribute values

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,12 @@ to run. Since arguments are specified in the user interface via text area
 inputs, it’s important to check that they conform to the format your Task
 expects, and to sanitize any inputs if necessary.
 
+You can set values by specifying a query param with the same key as the attribute
+name. For example the `UpdatePostsViaParamsTask` task above accepts an
+`updated_content` attribute, so navigating to
+`/maintenance_tasks/tasks/Maintenance::UpdatePostsViaParamsTask?updated_content=foo`
+would prefill the text area with "foo".
+
 #### Validating Task Parameters
 
 Task attributes can be validated using Active Model Validations. Attributes are

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -20,7 +20,7 @@
             <div class="field">
               <%= ff.label parameter_name, parameter_name, class: "label is-family-monospace" %>
               <div class="control">
-                <%= parameter_field(ff, parameter_name) %>
+                <%= parameter_field(ff, parameter_name, params[parameter_name]) %>
               </div>
             </div>
           <% end %>

--- a/test/helpers/maintenance_tasks/tasks_helper_test.rb
+++ b/test/helpers/maintenance_tasks/tasks_helper_test.rb
@@ -149,10 +149,10 @@ module MaintenanceTasks
       Time.zone_default = zone
     end
 
-    def markup(attribute)
+    def markup(attribute, default_value = nil)
       render(inline: <<~TEMPLATE)
         <%= fields_for(Maintenance::ParamsTask.new) do |form| %>
-          <%= parameter_field(form, '#{attribute}') %>
+          <%= parameter_field(form, '#{attribute}', #{default_value ? default_value.to_s : nil}) %>
         <% end %>
       TEMPLATE
     end

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -88,34 +88,43 @@ module MaintenanceTasks
 
       content_field = page.find_field("task[content]")
       assert_equal("textarea", content_field.tag_name)
+      assert_equal("default content", content_field.value)
       integer_field = page.find_field("task[integer_attr]")
       assert_equal("input", integer_field.tag_name)
       assert_equal("number", integer_field[:type])
       assert_empty(integer_field[:step])
+      assert_equal("111222333", integer_field.value)
       big_integer_field = page.find_field("task[big_integer_attr]")
       assert_equal("input", big_integer_field.tag_name)
       assert_equal("number", big_integer_field[:type])
       assert_empty(big_integer_field[:step])
+      assert_equal("111222333", big_integer_field.value)
       float_field = page.find_field("task[float_attr]")
       assert_equal("input", float_field.tag_name)
       assert_equal("number", float_field[:type])
       assert_equal("any", float_field[:step])
+      assert_equal("12.34", float_field.value)
       decimal_field = page.find_field("task[decimal_attr]")
       assert_equal("input", decimal_field.tag_name)
       assert_equal("number", decimal_field[:type])
       assert_equal("any", decimal_field[:step])
+      assert_equal("12.34", decimal_field.value)
       datetime_field = page.find_field("task[datetime_attr]")
       assert_equal("input", datetime_field.tag_name)
       assert_equal("datetime-local", datetime_field[:type])
+      assert_equal("", datetime_field.value)
       date_field = page.find_field("task[date_attr]")
       assert_equal("input", date_field.tag_name)
       assert_equal("date", date_field[:type])
+      assert_equal("", date_field.value)
       time_field = page.find_field("task[time_attr]")
       assert_equal("input", time_field.tag_name)
       assert_equal("time", time_field[:type])
+      assert_equal("", time_field.value)
       boolean_field = page.find_field("task[boolean_attr]")
       assert_equal("input", boolean_field.tag_name)
       assert_equal("checkbox", boolean_field[:type])
+      assert_nil(boolean_field[:checked])
 
       [
         "integer_dropdown_attr",
@@ -135,6 +144,78 @@ module MaintenanceTasks
       assert_equal("input", text_integer_field.tag_name)
       assert_equal("number", text_integer_field[:type])
       assert_empty(text_integer_field[:step])
+      assert_equal("", text_integer_field.value)
+    end
+
+
+    test "task with attributes renders correct field tags on the form with values from query params" do
+      visit maintenance_tasks.task_path("Maintenance::ParamsTask", params: {
+        content: "string content",
+        integer_attr: 12,
+        big_integer_attr: 123456789,
+        float_attr: 12.34,
+        decimal_attr: 43.21,
+        datetime_attr: "1984-01-01T12:34:56",
+        date_attr: "1984-01-01",
+        time_attr: "12:34:56",
+        boolean_attr: "true",
+        integer_dropdown_attr: "200",
+        boolean_dropdown_attr: "false",
+      })
+
+      content_field = page.find_field("task[content]")
+      assert_equal("textarea", content_field.tag_name)
+      assert_equal("string content", content_field.value)
+      integer_field = page.find_field("task[integer_attr]")
+      assert_equal("input", integer_field.tag_name)
+      assert_equal("number", integer_field[:type])
+      assert_empty(integer_field[:step])
+      assert_equal("12", integer_field.value)
+      big_integer_field = page.find_field("task[big_integer_attr]")
+      assert_equal("input", big_integer_field.tag_name)
+      assert_equal("number", big_integer_field[:type])
+      assert_empty(big_integer_field[:step])
+      assert_equal("123456789", big_integer_field.value)
+      float_field = page.find_field("task[float_attr]")
+      assert_equal("input", float_field.tag_name)
+      assert_equal("number", float_field[:type])
+      assert_equal("any", float_field[:step])
+      assert_equal("12.34", float_field.value)
+      decimal_field = page.find_field("task[decimal_attr]")
+      assert_equal("input", decimal_field.tag_name)
+      assert_equal("number", decimal_field[:type])
+      assert_equal("any", decimal_field[:step])
+      assert_equal("43.21", decimal_field.value)
+      datetime_field = page.find_field("task[datetime_attr]")
+      assert_equal("input", datetime_field.tag_name)
+      assert_equal("datetime-local", datetime_field[:type])
+      assert_equal("1984-01-01T12:34:56", datetime_field.value)
+      date_field = page.find_field("task[date_attr]")
+      assert_equal("input", date_field.tag_name)
+      assert_equal("date", date_field[:type])
+      assert_equal("1984-01-01", date_field.value)
+      time_field = page.find_field("task[time_attr]")
+      assert_equal("input", time_field.tag_name)
+      assert_equal("time", time_field[:type])
+      assert_equal("12:34:56", time_field.value)
+      boolean_field = page.find_field("task[boolean_attr]")
+      assert_equal("input", boolean_field.tag_name)
+      assert_equal("checkbox", boolean_field[:type])
+      assert_equal("true", boolean_field[:checked])
+
+      integer_dropdown_field = page.find_field("task[integer_dropdown_attr]")
+      assert_equal("select", integer_dropdown_field.tag_name)
+      assert_equal("select-one", integer_dropdown_field[:type])
+      assert_equal("200", integer_dropdown_field.value)
+      integer_dropdown_field_options = integer_dropdown_field.find_all("option").map { |option| option[:value] }
+      assert_equal(["100", "200", "300"], integer_dropdown_field_options)
+
+      boolean_dropdown_field = page.find_field("task[boolean_dropdown_attr]")
+      assert_equal("select", boolean_dropdown_field.tag_name)
+      assert_equal("select-one", boolean_dropdown_field[:type])
+      assert_equal("false", boolean_dropdown_field.value)
+      boolean_dropdown_field_options = boolean_dropdown_field.find_all("option").map { |option| option[:value] }
+      assert_equal(["true", "false"], boolean_dropdown_field_options)
     end
 
     test "view a Task with multiple pages of Runs" do


### PR DESCRIPTION
It can be useful to link to a maintenance task with task values pre-populated. For example if in an internal app we want to be able to run a maintenance task on a customer, linking to `/maintenance_tasks/tasks/Maintenance::CustomerTask?customer_id=123` from the `/internal/customers/123` route and having the attribute filled in makes it easier and less error prone.

This PR sets the attribute field value if there's a corresponding query param with the same name.
If no query param is provided then we'll continue to respect the default values set on the task attribute.

Here's an example with some prefilled values via query param:
<img width="1786" alt="Screenshot 2024-11-09 at 9 48 40 PM" src="https://github.com/user-attachments/assets/6977c805-a437-4168-b46f-0125312aa6b0">
