### PR TITLE
Ignore URI::RFC3986_PARSER.escape deprecation warning

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,9 +48,9 @@ module Warning
   class << self
     def warn(message)
       return super if message.start_with?("Rack::Handler is deprecated")
-      # To be removed once warning is fixed in selenium-webdriver
+      # To be removed once warnings are fixed in selenium-webdriver and sprockets.
       # This is noisy, so ignoring completely for now.
-      return if message.match?("URI::RFC3986_PARSER.escape is obsoleted.")
+      return if message.match?("URI::RFC3986_PARSER.(un)?escape is obsoleted.")
 
       raise message.to_s
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,6 +48,9 @@ module Warning
   class << self
     def warn(message)
       return super if message.start_with?("Rack::Handler is deprecated")
+      # To be removed once warning is fixed in selenium-webdriver
+      # This is noisy, so ignoring completely for now.
+      return if message.match?("URI::RFC3986_PARSER.escape is obsoleted.")
 
       raise message.to_s
     end


### PR DESCRIPTION
`uri` switched the default parser from RFC2396 to RFC3986. The new parser emits a deprecation warning on a few methods and delegates them to RFC2396. See https://github.com/ruby/uri/pull/114.

The selenium-webdriver gem [calls `URI::RFC3986_PARSER.escape`][webdriver-callsite], which is now deprecated. Until this is fixed in `selenium-webdriver`, ignore the warning.

Fixes failing weekly CI build: https://github.com/Shopify/maintenance_tasks/actions/runs/11769507051/job/32815543032

[webdriver-callsite]: https://github.com/SeleniumHQ/selenium/blob/trunk/rb/lib/selenium/webdriver/remote/bridge.rb#L679