### PR TITLE
Use an existing method for validating params in ParamsTask

### DIFF
--- a/test/dummy/app/tasks/maintenance/params_task.rb
+++ b/test/dummy/app/tasks/maintenance/params_task.rb
@@ -31,7 +31,7 @@ module Maintenance
     attribute :text_integer_attr3, :integer
 
     validates_inclusion_of :text_integer_attr, in: proc { [100, 200, 300] }, allow_nil: true
-    validates_inclusion_of :text_integer_attr2, in: :undefined_symbol, allow_nil: true
+    validates_inclusion_of :text_integer_attr2, in: :some_method, allow_nil: true
     validates_inclusion_of :text_integer_attr3, in: (100..), allow_nil: true
 
     class << self
@@ -49,6 +49,10 @@ module Maintenance
     end
 
     private
+
+    def some_method
+      [100, 200, 300]
+    end
 
     def post_ids_array
       post_ids.split(",")


### PR DESCRIPTION
While I was debugging some changes for #1116, I noticed that if anything is entered in `text_integer_attr2`, we get a 500 error.