### PR TITLE
Add direct upload

### DIFF
--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -9,7 +9,7 @@
     <% if @task.csv_task? %>
       <div class="block">
         <%= form.label :csv_file %>
-        <%= form.file_field :csv_file, accept: "text/csv" %>
+        <%= form.file_field :csv_file, accept: "text/csv", direct_upload: Rails.application.config.respond_to?(:assets) %>
       </div>
     <% end %>
     <% parameter_names = @task.parameter_names %>


### PR DESCRIPTION
Adds the ability to enable [direct uploads](https://guides.rubyonrails.org/v7.1/active_storage_overview.html#direct-uploads), which can help circumvent upload limits on the server. This is helpful when attempting to upload larger CSV files without having to play with the [max size of 20mb](https://github.com/ShopifyRestricted/gcp-chef/blob/872b0394b27f44825f1f65722892d882f88582e8/cookbooks/nginx/templates/default/nginx.conf.erb#L56)

re-attempts https://github.com/Shopify/maintenance_tasks/pull/1031