### PR TITLE
Support UUID primary keys

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -68,6 +68,13 @@ module MaintenanceTasks
       with_attached_csv_file if ActiveStorage::Attachment.table_exists?
     end
 
+    scope :last_completed_per_task, -> do
+      subquery = completed
+                   .select('task_name, MAX(ended_at) AS latest_ended_at')
+                   .group(:task_name)
+      joins("INNER JOIN (#{subquery.to_sql}) latest_runs ON latest_runs.task_name = maintenance_tasks_runs.task_name AND latest_runs.latest_ended_at = maintenance_tasks_runs.ended_at")
+    end
+
     validates_with RunStatusValidator, on: :update
 
     if MaintenanceTasks.active_storage_service.present?

--- a/app/models/maintenance_tasks/task_data_index.rb
+++ b/app/models/maintenance_tasks/task_data_index.rb
@@ -33,8 +33,7 @@ module MaintenanceTasks
           task_names.delete(run.task_name)
         end
 
-        completed_runs = Run.completed.where(task_name: task_names)
-        last_runs = Run.with_attached_csv.where(id: completed_runs.select("MAX(id) as id").group(:task_name))
+        last_runs = Run.with_attached_csv.last_completed_per_task.where(task_name: task_names)
         task_names.map do |task_name|
           last_run = last_runs.find { |run| run.task_name == task_name }
           tasks << TaskDataIndex.new(task_name, last_run)


### PR DESCRIPTION
The current listing of completed tasks assumes the primary key is an integer. 

See relevant issue
https://github.com/Shopify/maintenance_tasks/issues/462

This change is intended to support any primary key and adapter. 

Instead of getting the latest completed by MAX(id), we instead:
1. Group the completed tasks by task name and select the latest ended_at (should always be set on completed tasks)
2. Join back on task_name and latest_ended_at date for the full result

There could be a slight performance impact over the MAX(id) version I believe.

The tests appear to be covered by the tasks_tests.rb

