### PR TITLE
Wrap enumerators to avoid JobIteration deprecation

### DIFF
--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -33,6 +33,7 @@ module MaintenanceTasks
     def build_enumerator(_run, cursor:)
       cursor ||= @run.cursor
       self.cursor_position = cursor
+      enumerator_builder = self.enumerator_builder
       @collection_enum = @task.enumerator_builder(cursor: cursor)
 
       @collection_enum ||= case (collection = @task.collection)
@@ -75,6 +76,9 @@ module MaintenanceTasks
         MSG
       end
 
+      unless @collection_enum.is_a?(JobIteration.enumerator_builder::Wrapper)
+        @collection_enum = enumerator_builder.wrap(enumerator_builder, @collection_enum)
+      end
       throttle_enumerator(@collection_enum)
     end
 


### PR DESCRIPTION
Fix #1132 

The new version of job-iteration makes CI fail because it adds a deprecation. This resolves the deprecation by always wrapping enumerators with `JobIteration.enumerator_builder.wrap`.