### PR TITLE
Require minimum Rails version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "debug"
 gem "mocha"
 gem "puma"
 if !@rails_gem_requirement
-  gem "rails"
+  gem "rails", ">= 6.1"
   ruby ">= 3.2.0"
 else
   # causes Dependabot to ignore the next line and update the previous gem "rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,7 +285,7 @@ DEPENDENCIES
   maintenance_tasks!
   mocha
   puma
-  rails
+  rails (>= 6.1)
   rubocop
   rubocop-shopify
   selenium-webdriver


### PR DESCRIPTION
Dependabot somehow [resolves Rails to 0.9.5 when upgrading `job-iteration`](https://github.com/Shopify/maintenance_tasks/pull/1139/commits/7d0ef8da09961ab76db0e644a54286d853f5d224#diff-89cade48462044ee1b672dc5f4c3ec250fbd29effcd8932096a23c1283c6731fR157), and downgrades the Rails frameworks to 7.2.2.1. This makes sure this can't happen.