### PR TITLE
Require minimum Rails version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "debug"
 gem "mocha"
 gem "puma"
 if !@rails_gem_requirement
-  gem "rails"
+  gem "rails", ">= 6.1"
   ruby ">= 3.2.0"
 else
   # causes Dependabot to ignore the next line and update the previous gem "rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,7 +285,7 @@ DEPENDENCIES
   maintenance_tasks!
   mocha
   puma
-  rails
+  rails (>= 6.1)
   rubocop
   rubocop-shopify
   selenium-webdriver

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,6 +40,8 @@ elsif ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActiveSupport::TestCase.fixtures(:all)
 end
 
+JobIteration::Deprecation.behavior = :silence
+
 module Warning
   class << self
     def warn(message)


### PR DESCRIPTION
Dependabot somehow resolves Rails to 0.9.5 when upgrading job-iteration, and downgrades the Rails frameworks to 7.2.2.1. This makes sure this can't happen.

I also had to silence the JobIteration deprecator so that this is mergeable.