### PR TITLE
Require logger before running Rails commands

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,9 @@ rescue LoadError
   puts "You must `gem install bundler` and `bundle install` to run rake tasks"
 end
 
+# Only necessary for activesupport <= 7.0 and concurrent-ruby >= 1.3.5
+require "logger" # https://github.com/rails/rails/issues/54260
+
 require "rdoc/task"
 RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = "rdoc"

--- a/bin/rails
+++ b/bin/rails
@@ -12,4 +12,7 @@ APP_PATH = File.expand_path("../test/dummy/config/application", __dir__)
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
+# Only necessary for activesupport <= 7.0 and concurrent-ruby >= 1.3.5
+require "logger" # https://github.com/rails/rails/issues/54260
+
 require "rails/engine/commands"

--- a/test/dummy/Rakefile
+++ b/test/dummy/Rakefile
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# Only necessary for activesupport <= 7.0 and concurrent-ruby >= 1.3.5
+require "logger" # https://github.com/rails/rails/issues/54260
+
 require_relative "config/application"
 
 Rails.application.load_tasks

--- a/test/dummy/bin/rails
+++ b/test/dummy/bin/rails
@@ -3,4 +3,8 @@
 
 APP_PATH = File.expand_path("../config/application", __dir__)
 require_relative "../config/boot"
+
+# Only necessary for activesupport <= 7.0 and concurrent-ruby >= 1.3.5
+require "logger" # https://github.com/rails/rails/issues/54260
+
 require "rails/commands"


### PR DESCRIPTION
This is only necessary because concurrent-ruby 1.6.5 doesn't require "logger" anymore and ActiveSupport::LoggerThreadSafeLevel < 7.1 references Logger without requiring it first.