### PR TITLE
Introduce MaintenanceTasks::Task.report_on

### DIFF
--- a/README.md
+++ b/README.md
@@ -1017,6 +1017,30 @@ Note that `context` may be empty if the Task produced an error before any
 context could be gathered (for example, if deserializing the job to process
 your Task failed).
 
+#### Reporting errors during iteration
+
+By default, errors raised during task iteration will be raised to the application
+and iteration will stop. However, you may want to handle some errors and continue
+iteration. `MaintenanceTasks::Task.report_on` can be used to rescue certain
+exceptions and report them to the Rails error reporter.
+
+```ruby
+class MyTask < MaintenanceTasks::Task
+  report_on(MyException)
+end
+```
+
+`MaintenanceTasks::Task` also includes `ActiveSupport::Rescuable` which you can use
+to implement custom error handling.
+
+```ruby
+class MyTask < MaintenanceTasks::Task
+  rescue_from(MyException) do |exception|
+    handle(exception)
+  end
+end
+```
+
 #### Customizing the maintenance tasks module
 
 `MaintenanceTasks.tasks_module` can be configured to define the module in which

--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -112,7 +112,7 @@ module MaintenanceTasks
       end
     rescue => error
       @errored_element = input
-      raise error
+      raise error unless @task.rescue_with_handler(error)
     end
 
     def before_perform


### PR DESCRIPTION
By default any errors encountered while processing an iteration will be raised and the task with error. In our app we noticed a lot developers writing very similar code to rescue some exceptions, report them and moving on to the next iteration. So, let's introduce a helper to make this easier.

We introduced a `report_on` method to `MaintenanceTask::Tasks`. Exceptions passed to this method will be rescued during iteration and reported the rails error reporter, then iteration will continue.