### PR TITLE
Deprecate MaintenanceTasks.error_handler. Instead use the Rails.error…

### DIFF
--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -61,16 +61,6 @@ module MaintenanceTasks
   #     use when cleaning a Run's backtrace.
   mattr_accessor :backtrace_cleaner
 
-  # @!attribute error_handler
-  #   @scope class
-  #
-  #   The callback to perform when an error occurs in the Task.  See the
-  #   {file:README#label-Customizing+the+error+handler} for details.
-  #
-  #   @return [Proc] the callback to perform when an error occurs in the Task.
-  mattr_accessor :error_handler, default:
-    ->(_error, _task_context, _errored_element) {}
-
   # @!attribute parent_controller
   #   @scope class
   #
@@ -94,4 +84,30 @@ module MaintenanceTasks
   #
   #  @return [ActiveSupport::Duration] the threshold in seconds after which a task is considered stuck.
   mattr_accessor :stuck_task_duration, default: 5.minutes
+
+  class << self
+    DEPRECATION_MESSAGE = "MaintenanceTasks.error_handler is deprecated and will be removed in the 3.0 release. " \
+      "Instead, reports will be sent to the Rails error reporter. Do not set a handler and subscribe" \
+      "to the error reporter instead."
+    private_constant :DEPRECATION_MESSAGE
+
+    # @deprecated
+    def error_handler
+      deprecator.warn(DEPRECATION_MESSAGE)
+
+      @error_handler
+    end
+
+    # @deprecated
+    def error_handler=(proc)
+      deprecator.warn(DEPRECATION_MESSAGE)
+
+      @error_handler = proc
+    end
+
+    # @api-private
+    def deprecator
+      @deprecator ||= ActiveSupport::Deprecation.new("3.0", "MaintenanceTasks")
+    end
+  end
 end

--- a/lib/maintenance_tasks/engine.rb
+++ b/lib/maintenance_tasks/engine.rb
@@ -21,6 +21,12 @@ module MaintenanceTasks
       MaintenanceTasks.backtrace_cleaner = Rails.backtrace_cleaner
     end
 
+    if Rails.gem_version >= Gem::Version.new("7.1")
+      initializer "maintenance_tasks.deprecator" do
+        Rails.application.deprecators[:maintenance_tasks] = MaintenanceTasks.deprecator
+      end
+    end
+
     config.to_prepare do
       _ = TaskJobConcern # load this for JobIteration compatibility check
     end


### PR DESCRIPTION
Rails 7.0 introduced the [rails error reporter](https://guides.rubyonrails.org/error_reporting.html). Now that we are [dropping support for 6.1](https://github.com/Shopify/maintenance_tasks/pull/1151) we can modernize this gem and use the error reporter instead of the error handler.

This PR deprecates the error handler, and reports exceptions to the rails error reporter instead - unless the app is still setting a handler, in which case we preserve that behaviour but fire off a deprecation warning.