### PR TITLE
Prepare version 2.11.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    maintenance_tasks (2.10.1)
+    maintenance_tasks (2.11.0)
       actionpack (>= 7.0)
       activejob (>= 7.0)
       activerecord (>= 7.0)

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "maintenance_tasks"
-  spec.version = "2.10.1"
+  spec.version = "2.11.0"
   spec.author = "Shopify Engineering"
   spec.email = "gems@shopify.com"
   spec.homepage = "https://github.com/Shopify/maintenance_tasks"


### PR DESCRIPTION
This version:

- compatibility with Ruby 3.4 https://github.com/Shopify/maintenance_tasks/commit/9ee7690120b4253cdb636c7f114a7c5d477e1863
- make task run timestamps consistent https://github.com/Shopify/maintenance_tasks/commit/57c7625eee54d978199048287254ecdaa8692f88
- drop support for Rails 6.1 https://github.com/Shopify/maintenance_tasks/commit/f9e15ea1f9d52b5c478f4b0fbc8ea8d3db705b92
- deprecate `MaintenanceTasks.error_handler` https://github.com/Shopify/maintenance_tasks/commit/dda3b7b75f726bc4df4bfaec7e634d2bb923777d
- `MaintenanceTasks::Task` now inherits `ActiveSupport::Rescuable` and introduced `MaintenanceTasks::Task.report_on` https://github.com/Shopify/maintenance_tasks/commit/4ea0a66dcf05fbb085f35ebd1238c7886051d5f0