### PR TITLE
correct error reporting source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1011,7 +1011,7 @@ Reports to the error reporter will contain the following data:
     monitoring service, make sure you **sanitize the object** to avoid leaking
     sensitive data and **convert it to a format** that is compatible with your bug
     tracker.
-* `source`: This will be `maintenance_tasks`
+* `source`: This will be `maintenance-tasks`
 
 Note that `context` may be empty if the Task produced an error before any
 context could be gathered (for example, if deserializing the job to process


### PR DESCRIPTION
After seeing the deprecation message introduced in #1152 I began investigating how to migrate from `error_handler` to subscribing to error notifications. In the process I noticed that `README.md` disagrees with `task_job_concern.rb` in what `source` the errors will be reported with - `maintenance_tasks` vs `maintenance-tasks` https://github.com/Shopify/maintenance_tasks/blob/7505b9c64942cab305b5bec91ec2a5bb73546915/app/jobs/concerns/maintenance_tasks/task_job_concern.rb#L194