### PR TITLE
System test robustness

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -35,6 +35,9 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   setup do
     travel_to Time.zone.local(2020, 1, 9, 9, 41, 44)
     page.driver.browser.download_path = "test/dummy/tmp/downloads"
+    unless page.driver.invalid_element_errors.include?(Selenium::WebDriver::Error::UnknownError)
+      page.driver.invalid_element_errors << Selenium::WebDriver::Error::UnknownError
+    end
   end
 
   teardown do

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -11,6 +11,14 @@ ActionDispatch::SystemTesting::Server.silence_puma = true
 # warning in Ruby 2.7.
 Capybara::Selenium::Driver.load_selenium
 
+Capybara.configure do |config|
+  # This causes flakiness when we're navigating pages because Capybara goes back to the browser to check for the
+  # visibility of the node, which doesn't exist anymore:
+  #   Selenium::WebDriver::Error::UnknownError: unknown error: unhandled inspector error:
+  #   {"code":-32000,"message":"Node with given id does not belong to the document"}
+  config.ignore_hidden_elements = false
+end
+
 if Rails.gem_version < Gem::Version.new("7.1")
   Selenium::WebDriver.logger.ignore(:capabilities)
 end

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -78,7 +78,6 @@ module MaintenanceTasks
       fill_in("task[post_ids]", with: post_id.to_s)
 
       click_on "Run"
-      fill_in("task[post_ids]", with: "42")
       perform_enqueued_jobs
 
       assert_title "Maintenance::ParamsTask"
@@ -87,7 +86,24 @@ module MaintenanceTasks
       assert_text "Arguments"
       assert_text("post_ids")
       assert_text(post_id.to_s)
-      assert has_field?("task[post_ids]", with: "42")
+    end
+
+    test "parameters are preserved from the refresh" do
+      visit maintenance_tasks_path
+
+      click_on("Maintenance::ParamsTask")
+      post_id = Post.first.id
+      fill_in("task[post_ids]", with: post_id.to_s)
+
+      click_on "Run"
+      assert_text "Enqueued"
+      fill_in("task[post_ids]", with: 42)
+
+      perform_enqueued_jobs
+      # no refresh to test the fields are preserved
+
+      assert_text "Succeeded", wait: 3 # auto-refreshes every 3 seconds
+      assert_text(post_id.to_s)
     end
 
     test "run a Task that accepts masked parameters" do
@@ -98,7 +114,6 @@ module MaintenanceTasks
       fill_in("task[post_ids]", with: post_id.to_s)
 
       click_on "Run"
-      fill_in("task[post_ids]", with: "42")
       perform_enqueued_jobs
 
       assert_title "Maintenance::ParamsTask"

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -287,14 +287,16 @@ module MaintenanceTasks
       assert_text "Validation failed: Status Cannot transition run from status enqueued to enqueued"
     end
 
-    test "errors when enqueuing are shown" do
+    test "enqueuing errors are shown" do
       visit maintenance_tasks_path
 
       click_on "Maintenance::EnqueueErrorTask"
       click_on "Run"
       assert_text "The job to perform Maintenance::EnqueueErrorTask could not be enqueued"
       assert_text "Error enqueuing"
+    end
 
+    test "enqueuing cancellations are shown" do
       visit maintenance_tasks_path
       click_on "Maintenance::CancelledEnqueueTask"
       click_on "Run"

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -243,6 +243,20 @@ module MaintenanceTasks
       assert_text "ArgumentError"
       assert_text "Something went wrong"
       assert_text %r{app/tasks/maintenance/error_task\.rb:10:in ('Maintenance::ErrorTask#|`)process'}
+    end
+
+    test "resume an errored Task" do
+      visit maintenance_tasks_path
+
+      click_on("Maintenance::ErrorTask")
+
+      click_on "Run"
+      assert_text "Enqueued"
+
+      perform_enqueued_jobs
+      page.refresh
+
+      assert_text "Errored"
 
       click_on "Resume"
 

--- a/test/system/maintenance_tasks/runs_test.rb
+++ b/test/system/maintenance_tasks/runs_test.rb
@@ -51,6 +51,7 @@ module MaintenanceTasks
       assert_difference("Run.count") do
         click_on("Maintenance::UpdatePostsTask")
         click_on("Run")
+        assert_text("Enqueued")
 
         assert_text("hello metadata")
       end
@@ -78,10 +79,13 @@ module MaintenanceTasks
       fill_in("task[post_ids]", with: post_id.to_s)
 
       click_on "Run"
+      assert_text "Enqueued"
+
       perform_enqueued_jobs
+      refresh
 
       assert_title "Maintenance::ParamsTask"
-      assert_text "Succeeded", wait: 3 # refreshes every 3 seconds
+      assert_text "Succeeded"
       assert_text "Processed 1 out of 1 item (100%)."
       assert_text "Arguments"
       assert_text("post_ids")
@@ -114,10 +118,13 @@ module MaintenanceTasks
       fill_in("task[post_ids]", with: post_id.to_s)
 
       click_on "Run"
+      assert_text "Enqueued"
+
       perform_enqueued_jobs
+      refresh
 
       assert_title "Maintenance::ParamsTask"
-      assert_text "Succeeded", wait: 3 # refreshes every 3 seconds
+      assert_text "Succeeded"
       assert_text "Processed 1 out of 1 item (100%)."
       assert_text "Arguments"
       assert_text("sensitive_content")
@@ -143,9 +150,10 @@ module MaintenanceTasks
       click_on("Maintenance::ImportPostsTask")
       attach_file("csv_file", "test/fixtures/files/sample.csv")
       click_on("Run")
+      assert_text "Enqueued"
 
       perform_enqueued_jobs
-      page.refresh
+      refresh
 
       click_on("Download CSV")
 
@@ -162,8 +170,9 @@ module MaintenanceTasks
 
       click_on("Maintenance::UpdatePostsTask")
       click_on "Run"
-      click_on "Pause"
+      assert_text "Enqueued"
 
+      click_on "Pause"
       assert_text "Pausing"
       assert_text "Pausing…"
     end
@@ -173,9 +182,13 @@ module MaintenanceTasks
 
       click_on("Maintenance::UpdatePostsInBatchesTask")
       click_on "Run"
+      assert_text "Enqueued"
+
       click_on "Pause"
+      assert_text "Pausing" # ensure page loaded
+
       perform_enqueued_jobs
-      page.refresh
+      refresh
       click_on "Resume"
 
       assert_text "Enqueued"
@@ -187,6 +200,7 @@ module MaintenanceTasks
 
       click_on("Maintenance::UpdatePostsInBatchesTask")
       click_on "Run"
+      assert_text "Enqueued"
       click_on "Cancel"
 
       assert_text "Cancelling"
@@ -198,6 +212,7 @@ module MaintenanceTasks
 
       click_on("Maintenance::UpdatePostsInBatchesTask")
       click_on "Run"
+      assert_text "Enqueued"
       click_on "Pause"
       assert_text "Pausing"
 
@@ -210,9 +225,11 @@ module MaintenanceTasks
 
       click_on("Maintenance::UpdatePostsInBatchesTask")
       click_on "Run"
-      click_on "Cancel"
+      assert_text "Enqueued"
 
+      click_on "Cancel"
       assert_text "Cancelling…"
+
       refute_button "Cancel"
 
       travel MaintenanceTasks.stuck_task_duration
@@ -234,9 +251,11 @@ module MaintenanceTasks
 
       click_on("Maintenance::ErrorTask")
 
-      perform_enqueued_jobs do
-        click_on "Run"
-      end
+      click_on "Run"
+      assert_text "Enqueued"
+
+      perform_enqueued_jobs
+      refresh
 
       assert_text "Errored"
       assert_text "Ran for less than 5 seconds until an error happened less than a minute ago."
@@ -254,7 +273,7 @@ module MaintenanceTasks
       assert_text "Enqueued"
 
       perform_enqueued_jobs
-      page.refresh
+      refresh
 
       assert_text "Errored"
 
@@ -270,11 +289,14 @@ module MaintenanceTasks
       click_on("Maintenance::UpdatePostsInBatchesTask")
 
       click_on "Run"
+      assert_text "Enqueued"
+
       click_on "Pause"
+      assert_text "Pausing"
 
       perform_enqueued_jobs
 
-      page.refresh
+      refresh
 
       url = page.current_url
       using_session(:other_tab) do
@@ -300,7 +322,9 @@ module MaintenanceTasks
       visit maintenance_tasks_path
       click_on "Maintenance::CancelledEnqueueTask"
       click_on "Run"
-      assert_text "The job to perform Maintenance::CancelledEnqueueTask could not be enqueued"
+      find(".notification") do
+        assert_text "The job to perform Maintenance::CancelledEnqueueTask could not be enqueued"
+      end
       assert_text "The job to perform Maintenance::CancelledEnqueueTask " \
         "could not be enqueued. Enqueuing has been prevented by a callback."
     end
@@ -311,6 +335,7 @@ module MaintenanceTasks
 
       url = page.current_url
       click_on "Run"
+      assert_text "Enqueued"
 
       using_session(:other_tab) do
         visit url

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -18,27 +18,27 @@ module MaintenanceTasks
 
       expected = [
         "Active Tasks",
-        "Maintenance::NoCollectionTask\nEnqueued",
-        "Maintenance::NoCollectionTask\nPaused",
-        "Maintenance::UpdatePostsTask\nPaused",
+        "Maintenance::NoCollectionTask Enqueued",
+        "Maintenance::NoCollectionTask Paused",
+        "Maintenance::UpdatePostsTask Paused",
         "New Tasks",
-        "Maintenance::BatchImportPostsTask\nNew",
-        "Maintenance::CallbackTestTask\nNew",
-        "Maintenance::CancelledEnqueueTask\nNew",
-        "Maintenance::CustomEnumeratingTask\nNew",
-        "Maintenance::EnqueueErrorTask\nNew",
-        "Maintenance::ErrorTask\nNew",
-        "Maintenance::ImportPostsWithEncodingTask\nNew",
-        "Maintenance::ImportPostsWithOptionsTask\nNew",
-        "Maintenance::Nested::NestedMore::NestedMoreTask\nNew",
-        "Maintenance::Nested::NestedTask\nNew",
-        "Maintenance::ParamsTask\nNew",
-        "Maintenance::TestTask\nNew",
-        "Maintenance::UpdatePostsInBatchesTask\nNew",
-        "Maintenance::UpdatePostsModulePrependedTask\nNew",
-        "Maintenance::UpdatePostsThrottledTask\nNew",
+        "Maintenance::BatchImportPostsTask New",
+        "Maintenance::CallbackTestTask New",
+        "Maintenance::CancelledEnqueueTask New",
+        "Maintenance::CustomEnumeratingTask New",
+        "Maintenance::EnqueueErrorTask New",
+        "Maintenance::ErrorTask New",
+        "Maintenance::ImportPostsWithEncodingTask New",
+        "Maintenance::ImportPostsWithOptionsTask New",
+        "Maintenance::Nested::NestedMore::NestedMoreTask New",
+        "Maintenance::Nested::NestedTask New",
+        "Maintenance::ParamsTask New",
+        "Maintenance::TestTask New",
+        "Maintenance::UpdatePostsInBatchesTask New",
+        "Maintenance::UpdatePostsModulePrependedTask New",
+        "Maintenance::UpdatePostsThrottledTask New",
         "Completed Tasks",
-        "Maintenance::ImportPostsTask\nSucceeded",
+        "Maintenance::ImportPostsTask Succeeded",
       ]
 
       assert_equal expected, page.all("h3").map(&:text)
@@ -66,8 +66,8 @@ module MaintenanceTasks
       assert_text "Paused"
 
       assert_equal ["Active Runs", "Previous Runs"], page.all("h4").map(&:text)
-      assert_text(/July 18, 2022 11:05\nPaused\n#\d/)
-      assert_text(/January 01, 2020 01:00\nSucceeded\n#\d/)
+      assert_text(/July 18, 2022 11:05 Paused #\d/)
+      assert_text(/January 01, 2020 01:00 Succeeded #\d/)
     end
 
     test "task with attributes renders default values on the form" do


### PR DESCRIPTION
We paired with @adrianna-chang-shopify on improving the stability of system tests.

We found a few issues related the code, but a lot of it is related to changes to Chrome 134 it seems:

https://github.com/SeleniumHQ/selenium/issues/15401
https://github.com/teamcapybara/capybara/issues/2800

Last commit is a hack to make sure Capybara retries when the element is no longer on the page because it's something it's always done, and now it just considers them unknown errors. This will need to be reverted once things have settled.