### PR TITLE
Use more specific CSP directives

### DIFF
--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -7,13 +7,18 @@ module MaintenanceTasks
   class ApplicationController < MaintenanceTasks.parent_controller.constantize
     BULMA_CDN = "https://cdn.jsdelivr.net"
 
-    RUBY_SYNTAX_HIGHLIGHTING = "'sha256-2AM66zjeDBmWDHyVQs45fGjYfGmjoZBwkyy5tNwIWG0='"
-    PAGE_REFRESH_SCRIPT = "'sha256-NiHKryHWudRC2IteTqmY9v1VkaDUA/5jhgXkMTkgo2w='"
-
     content_security_policy do |policy|
-      policy.style_src_elem(BULMA_CDN, RUBY_SYNTAX_HIGHLIGHTING)
-      policy.script_src_elem(PAGE_REFRESH_SCRIPT)
+      policy.style_src_elem(
+        BULMA_CDN,
+        # <style> tag in app/views/layouts/maintenance_tasks/application.html.erb
+        "'sha256-2AM66zjeDBmWDHyVQs45fGjYfGmjoZBwkyy5tNwIWG0='",
+      )
+      policy.script_src_elem(
+        # <script> tag in app/views/layouts/maintenance_tasks/application.html.erb
+        "'sha256-NiHKryHWudRC2IteTqmY9v1VkaDUA/5jhgXkMTkgo2w='",
+      )
 
+      policy.require_trusted_types_for # disable because we use new DOMParser().parseFromString
       policy.frame_ancestors(:self)
       policy.connect_src(:self)
       policy.form_action(:self)

--- a/test/dummy/config/initializers/content_security_policy.rb
+++ b/test/dummy/config/initializers/content_security_policy.rb
@@ -20,8 +20,8 @@ Rails.application.config.content_security_policy do |policy|
   policy.manifest_src(:none)
   policy.media_src(:none)
   policy.object_src(:none)
-  # policy.prefetch_src(:none) # Unsupported in Selenium
-  # policy.require_trusted_types_for(:none) # Unsupported in Selenium
+  # policy.prefetch_src(:none) # deprecated
+  policy.require_trusted_types_for("'script'")
   policy.script_src(:none)
   policy.script_src_attr(:none)
   policy.script_src_elem(:none)
@@ -31,8 +31,10 @@ Rails.application.config.content_security_policy do |policy|
   policy.trusted_types(:none)
   policy.worker_src(:none)
 
-  # Required configuration for iframing maintenance-tasks
+  # The dummy app has a stylesheet_link_tag
   policy.style_src_elem(:self)
+
+  # Required configuration for iframing maintenance-tasks
   policy.frame_src(:self)
 
   policy.block_all_mixed_content


### PR DESCRIPTION
We wanted to try out this gem in our repo but we're using the `script-src-elem` directive in our CSP for `<script>` inline tags, which fallbacks to `script-src` if unset.

But since `script-src-elem` is not defined in maintenance-tasks, we're seeing the following error at this moment:

<img width="723" alt="image" src="https://github.com/user-attachments/assets/7288e4fd-6ff9-4f7c-b1ec-5c8a1ce81263" />

Opening this as draft for now since there are no tests yet