### PR TITLE
Allow for report options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1047,11 +1047,11 @@ your Task failed).
 By default, errors raised during task iteration will be raised to the application
 and iteration will stop. However, you may want to handle some errors and continue
 iteration. `MaintenanceTasks::Task.report_on` can be used to rescue certain
-exceptions and report them to the Rails error reporter.
+exceptions and report them to the Rails error reporter. Any keyword arguments are passed to [report](https://api.rubyonrails.org/classes/ActiveSupport/ErrorReporter.html#method-i-report):
 
 ```ruby
 class MyTask < MaintenanceTasks::Task
-  report_on(MyException)
+  report_on(MyException, OtherException, severity: :info, context: {task_name: "my_task"})
 end
 ```
 

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -219,12 +219,14 @@ module MaintenanceTasks
       # continue iteration.
       #
       # @param exceptions list of exceptions to rescue and report
-      def report_on(*exceptions)
+      # @param report_options [Hash] optionally, supply additional options for `Rails.error.report`.
+      #   By default: <code>{ source: "maintenance_tasks" }</code> or (Rails <v7.1) <code>{ handled: true }</code>.
+      def report_on(*exceptions, **report_options)
         rescue_from(*exceptions) do |exception|
           if Rails.gem_version >= Gem::Version.new("7.1")
-            Rails.error.report(exception, source: "maintenance_tasks")
+            Rails.error.report(exception, source: "maintenance_tasks", **report_options)
           else
-            Rails.error.report(exception, handled: true)
+            Rails.error.report(exception, handled: true, **report_options)
           end
         end
       end


### PR DESCRIPTION
This PR allows for adding options to report_on that are passed to `Rails.error.report`.

An example (for a Rails 7.0 application, ie that doesn't pass `source` to log subscribers):
```ruby
module Maintenance
  class SomeTask < MaintenanceTasks::Task
    report_on(ActiveRecord::RecordNotFound,
      severity: :info, context: {source: "maintenance_tasks"})
....
```