### PR TITLE
Support UUID primary keys

### DIFF
--- a/app/models/maintenance_tasks/task_data_index.rb
+++ b/app/models/maintenance_tasks/task_data_index.rb
@@ -34,7 +34,8 @@ module MaintenanceTasks
         end
 
         completed_runs = Run.completed.where(task_name: task_names)
-        last_runs = Run.with_attached_csv.where(id: completed_runs.select("MAX(id) as id").group(:task_name))
+        last_runs = Run.with_attached_csv
+          .where(created_at: completed_runs.select("MAX(created_at) as created_at").group(:task_name))
         task_names.map do |task_name|
           last_run = last_runs.find { |run| run.task_name == task_name }
           tasks << TaskDataIndex.new(task_name, last_run)

--- a/db/migrate/20201211151756_create_maintenance_tasks_runs.rb
+++ b/db/migrate/20201211151756_create_maintenance_tasks_runs.rb
@@ -2,7 +2,7 @@
 
 class CreateMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
   def change
-    create_table(:maintenance_tasks_runs) do |t|
+    create_table(:maintenance_tasks_runs, id: primary_key_type) do |t|
       t.string(:task_name, null: false)
       t.datetime(:started_at)
       t.datetime(:ended_at)
@@ -19,5 +19,13 @@ class CreateMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
       t.index(:task_name)
       t.index([:task_name, :created_at], order: { created_at: :desc })
     end
+  end
+
+  private
+
+  def primary_key_type
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    setting || :primary_key
   end
 end

--- a/test/fixtures/maintenance_tasks/runs.yml
+++ b/test/fixtures/maintenance_tasks/runs.yml
@@ -64,3 +64,13 @@ import_posts_task_succeeded:
   created_at: '01 Jan 2020 01:00:00'
   started_at: '01 Jan 2020 01:00:25'
   ended_at: '01 Jan 2020 01:00:36'
+
+import_posts_task_succeeded_old:
+  task_name: Maintenance::ImportPostsTask
+  tick_count: 10
+  tick_total: 10
+  job_id: '123abc'
+  status: 'succeeded'
+  created_at: '01 Jan 2020 00:20:00'
+  started_at: '01 Jan 2020 00:40:36'
+  ended_at: '01 Jan 2020 00:52:19'

--- a/test/models/maintenance_tasks/task_data_index_test.rb
+++ b/test/models/maintenance_tasks/task_data_index_test.rb
@@ -30,6 +30,13 @@ module MaintenanceTasks
       assert_equal expected, TaskDataIndex.available_tasks.map(&:name)
     end
 
+    test ".available_tasks assigns related run by most recent created completed run" do
+      tasks = TaskDataIndex.available_tasks
+      task = tasks.find { |task| task.name == "Maintenance::ImportPostsTask" }
+
+      assert_equal maintenance_tasks_runs(:import_posts_task_succeeded), task.related_run
+    end
+
     test "#new sets last_run if one is passed as an argument" do
       run = Run.create!(task_name: "Maintenance::UpdatePostsTask")
       task_data = TaskDataIndex.new("Maintenance::UpdatePostsTask", run)


### PR DESCRIPTION
This solve 2 issues in apps using UUID as primary keys:

When using `maintenance_tasks_runs` table with integer ids we get an error when uploading a CSV to task because it will try to save an integer ID into active storage attachment table (polymorphic association with records).

We could change manually the migration to use UUID as primary key but we face another problem when listing completed runs because the code uses `completed_runs.select("MAX(id) as id")...` and we get the error: `ERROR: function max(uuid) does not exist`. So I changed to use created_at instead id.