### PR TITLE
feat: Add attribute descriptions to MaintenanceTasks

### DIFF
--- a/app/helpers/maintenance_tasks/tasks_helper.rb
+++ b/app/helpers/maintenance_tasks/tasks_helper.rb
@@ -199,5 +199,14 @@ module MaintenanceTasks
         validator.kind == :presence
       end
     end
+
+    # Returns the description for a given attribute
+    #
+    # @param task [MaintenanceTasks::TaskDataShow] The TaskDataShow instance.
+    # @param parameter_name [Symbol] The name of the attribute to check.
+    # @return [String, nil] the description of the attribute, if any
+    def attribute_description(task, parameter_name)
+      task.class.attribute_description(parameter_name)
+    end
   end
 end

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -33,6 +33,11 @@ module MaintenanceTasks
     # @api private
     class_attribute :masked_arguments, default: []
 
+    # The descriptions for task attributes
+    #
+    # @api private
+    class_attribute :attribute_descriptions, default: {}
+
     define_callbacks :start, :complete, :error, :cancel, :pause, :interrupt
 
     attr_accessor :metadata
@@ -53,6 +58,23 @@ module MaintenanceTasks
         end
 
         task
+      end
+
+      # Override the attribute method to support descriptions
+      def attribute(name, type = ActiveModel::Type::Value.new, **options)
+        super(name, type, **options.except(:description))
+        
+        if options[:description].present?
+          self.attribute_descriptions = attribute_descriptions.merge(name.to_s => options[:description])
+        end
+      end
+
+      # Returns the description for a given attribute
+      #
+      # @param name [String, Symbol] the name of the attribute
+      # @return [String, nil] the description of the attribute, if any
+      def attribute_description(name)
+        attribute_descriptions[name.to_s]
       end
 
       # Loads and returns a list of concrete classes that inherit

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -20,6 +20,9 @@
             <div class="cell">
               <%= ff.label parameter_name, parameter_name, class: ["label", "is-family-monospace", { "is-required": attribute_required?(ff.object, parameter_name) }] %>
               <%= parameter_field(ff, parameter_name) %>
+              <% if description = attribute_description(ff.object, parameter_name) %>
+                <p class="help is-family-monospace is-size-7"><%= description %></p>
+              <% end %>
             </div>
           <% end %>
         <% end %>

--- a/test/dummy/app/tasks/maintenance/params_task.rb
+++ b/test/dummy/app/tasks/maintenance/params_task.rb
@@ -10,7 +10,7 @@ module Maintenance
   end
 
   class ParamsTask < MaintenanceTasks::Task
-    attribute :post_ids, :string
+    attribute :post_ids, :string, description: "The IDs of the posts to update"
 
     validates :post_ids,
       presence: true,

--- a/test/helpers/maintenance_tasks/tasks_helper_test.rb
+++ b/test/helpers/maintenance_tasks/tasks_helper_test.rb
@@ -149,6 +149,11 @@ module MaintenanceTasks
       assert_not attribute_required?(task, :content)
     end
 
+    test "#attribute_description returns the description for a given attribute" do
+      task = Maintenance::ParamsTask.new
+      assert_equal "The IDs of the posts to update", attribute_description(task, :post_ids)
+    end
+
     private
 
     def with_zone_default(new_zone)


### PR DESCRIPTION
## Context

Add a new attribute to include a description for the field, enhancing context and accessibility for developers to understand how to use each input appropriately.

![CleanShot 2025-05-10 at 21 12 23@2x](https://github.com/user-attachments/assets/d3aeeddb-b937-4642-85b7-348d8eeec5a7)

- Introduced the `attribute_description` method in `TasksHelper` to retrieve descriptions of task attributes.
- Updated `Task` model to support attribute descriptions during attribute definition.
- Enhanced the `show` view to display attribute descriptions when available.
- A test for the new `attribute_description` method was added to ensure correct functionality.


