### PR TITLE
Configuration attribute to overwrite UI default refresh interval

### DIFF
--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -29,6 +29,7 @@ module MaintenanceTasks
 
     def set_refresh
       @refresh = true
+      @refresh_interval = MaintenanceTasks.default_refresh_rate.in_seconds * 1000
     end
   end
 end

--- a/app/views/layouts/maintenance_tasks/application.html.erb
+++ b/app/views/layouts/maintenance_tasks/application.html.erb
@@ -65,6 +65,7 @@
       function refresh() {
         const target = document.querySelector("[data-refresh]")
         if (!target || !target.dataset.refresh) return
+        const interval = parseInt(target.dataset.interval)
         window.setTimeout(() => {
           document.body.style.cursor = "wait"
           fetch(document.location, { headers: { "X-Requested-With": "XMLHttpRequest" } }).then(
@@ -80,7 +81,7 @@
             },
             error => location.reload()
           )
-        }, <%= MaintenanceTasks.default_refresh_rate.in_seconds * 1000 %>)
+        }, interval)
       }
       document.addEventListener('DOMContentLoaded', refresh)
     </script>

--- a/app/views/layouts/maintenance_tasks/application.html.erb
+++ b/app/views/layouts/maintenance_tasks/application.html.erb
@@ -80,7 +80,7 @@
             },
             error => location.reload()
           )
-        }, 3000)
+        }, <%= MaintenanceTasks.default_refresh_rate.in_seconds * 1000 %>)
       }
       document.addEventListener('DOMContentLoaded', refresh)
     </script>

--- a/app/views/maintenance_tasks/tasks/index.html.erb
+++ b/app/views/maintenance_tasks/tasks/index.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(data: { refresh: (defined?(@refresh) && @refresh) || "" }) do %>
+<%= tag.div(data: { refresh: (defined?(@refresh) && @refresh) || "", interval: @refresh_interval }) do %>
   <% if @available_tasks.empty? %>
     <div class="content is-large">
       <h3 class="title is-3"> The MaintenanceTasks gem has been successfully installed! </h3>

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -85,6 +85,13 @@ module MaintenanceTasks
   #  @return [ActiveSupport::Duration] the threshold in seconds after which a task is considered stuck.
   mattr_accessor :stuck_task_duration, default: 5.minutes
 
+  # @!attribute default_refresh_rate
+  #  @scope class
+  #  The duration after which the maintance tasks layout will refresh. Defaults to 3 seconds.
+  #
+  #  @return [ActiveSupport::Duration] the interval in seconds after which the page is triggered to refresh.
+  mattr_accessor :default_refresh_rate, default: 3.seconds
+
   class << self
     DEPRECATION_MESSAGE = "MaintenanceTasks.error_handler is deprecated and will be removed in the 3.0 release. " \
       "Instead, reports will be sent to the Rails error reporter. Do not set a handler and subscribe " \


### PR DESCRIPTION
By default when the maintenance_tasks UI is open in a browser, it refreshes every 3 seconds.
This is great, but sometimes a bit too ambitious. We wanted to set this to 30 seconds or even a minute in our application, but did not find a configuration parameter to do so.

Therefore I am creating this PR to add such a configuration parameter to the gem.


With the changes in this PR our main base applicaation can just specify 
```
MaintenanceTasks.default_refresh_rate = 30.seconds
```
in `initializers/maintenance_tasks.rb` and it will propagate.