### PR TITLE
Raise minimum required Ruby version from 3.1 to 3.2 as the former is EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,17 +24,12 @@ jobs:
         - gemfiles/rails_7_2.gemfile
         - Gemfile # current minor release
         - gemfiles/rails_main.gemfile
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4"]
         database: [sqlite]
         include:
         - gemfile: "gemfiles/postgresql.gemfile"
           ruby: 3.4
           database: postgres
-        exclude:
-        - gemfile: Gemfile
-          ruby: 3.1
-        - gemfile: "gemfiles/rails_main.gemfile"
-          ruby: 3.1
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
       DB: ${{ matrix.database }}

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary = "A Rails engine for queuing and managing maintenance tasks"
   spec.license = "MIT"
 
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 3.2"
 
   spec.metadata = {
     "source_code_uri" =>


### PR DESCRIPTION
Proposing we raise the minimum supported Ruby version from 3.1 to 3.2 as the former is EOL. As a bonus, allows us to clean up the CI configuration a little bit.

> Ruby 3.1
>
> status: eol
> release date: 2021-12-25
> normal maintenance until: 2024-04-01
> EOL: 2025-03-26

Source: https://www.ruby-lang.org/en/downloads/branches/