### PR TITLE
Add back error reporting code example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1047,6 +1047,25 @@ Note that `context` may be empty if the Task produced an error before any
 context could be gathered (for example, if deserializing the job to process your
 Task failed).
 
+Here's an example custom subscriber to the Rails error reporter for integrating
+with an exception monitoring service (Bugsnag):
+
+```ruby
+# config/initializers/maintenance_tasks.rb
+
+class MaintenanceTasksErrorSubscriber
+  def report(error, handled:, severity:, context:, source: nil)
+    return unless source == "maintenance-tasks"
+
+    Bugsnag.notify(error) do |notification|
+      notification.add_metadata(:task, context)
+    end
+  end
+end
+
+Rails.error.subscribe(MaintenanceTasksErrorSubscriber.new)
+```
+
 #### Reporting errors during iteration
 
 By default, errors raised during task iteration will be raised to the


### PR DESCRIPTION
Ref: https://github.com/Shopify/maintenance_tasks/pull/1152

One 'gotcha' of Rails' error reporting subscribers is that they're 'global' i.e. all reported errors are reported to all subscribers, and it's up to the user to filter them as needed for custom per-source handling. This wasn't something users needed to think about when using `MaintenanceTasks.error_handler` - only errors reported by the gem would make their way through to your handling logic.

For this reason, I think providing an example on how to filter by the source would be beneficial to users migrating from the deprecated API.