### PR TITLE
Avoid incrementing in-memory lock version on tick count updates

### DIFF
--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -126,11 +126,6 @@ module MaintenanceTasks
         time_running: duration,
         touch: true,
       )
-      if locking_enabled?
-        locking_column = self.class.locking_column
-        self[locking_column] += 1
-        clear_attribute_change(locking_column)
-      end
     end
 
     # Marks the run as errored and persists the error data.

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -169,17 +169,6 @@ module MaintenanceTasks
       assert_equal 12.2, run.time_running
     end
 
-    test "#persist_progress increments the lock version in memory" do
-      run = Run.create!(
-        task_name: "Maintenance::UpdatePostsTask",
-        status: :running,
-      )
-      run.persist_progress(2, 2)
-      refute_predicate run, :changed?
-      lock_version = run.lock_version
-      assert_equal run.reload.lock_version, lock_version
-    end
-
     test "#persist_error updates Run to errored, sets ended_at, and sets started_at if not yet set" do
       freeze_time
       run = Run.create!(task_name: "Maintenance::ErrorTask")


### PR DESCRIPTION
~This can lead to increased contention on writes to the `maintenance_tasks_runs` table. We mainly care about race conditions for run status updates; incrementing the lock version on every tick count update is unnecessary.~

As @etiennebarrie reminded me in the comments, this PR actually doesn't prevent increment the DB lock version, it just removes the code to keep the in-memory one in sync. This is still worth shipping since there's no real point in updating the in-memory attribute, since we immediately call `reload_status` after to refresh the lock version from the DB. We may want to re-evaluate relying on `#update_counters`.