### PR TITLE
Add configurable status reload frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1255,6 +1255,42 @@ The value for `MaintenanceTasks.stuck_task_duration` must be an
 `ActiveSupport::Duration`. If no value is specified, it will default to 5
 minutes.
 
+#### Configure status reload frequency
+
+`MaintenanceTasks.status_reload_frequency` can be configured to specify how often
+the run status should be reloaded during iteration. By default, the status is
+reloaded every second, but this can be increased to improve performance. Note that increasing the reload interval impacts how quickly
+your task will stop if it is paused or interrupted.
+
+```ruby
+# config/initializers/maintenance_tasks.rb
+MaintenanceTasks.status_reload_frequency = 10.seconds  # Reload status every 10 seconds
+```
+
+Individual tasks can also override this setting using the `reload_status_every` method:
+
+```ruby
+# app/tasks/maintenance/update_posts_task.rb
+
+module Maintenance
+  class UpdatePostsTask < MaintenanceTasks::Task
+    # Reload status every 5 seconds instead of the global default
+    reload_status_every(5.seconds)
+
+    def collection
+      Post.all
+    end
+
+    def process(post)
+      post.update!(content: "New content!")
+    end
+  end
+end
+```
+
+This optimization can significantly reduce database queries, especially for short iterations.
+This is especially useful if the task doesn't need to check for cancellation/pausing very often.
+
 #### Metadata
 
 `MaintenanceTasks.metadata` can be configured to specify a proc from which to

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -37,7 +37,7 @@ module MaintenanceTasks
     # Defaults to the global MaintenanceTasks.status_reload_frequency setting.
     #
     # @api private
-    class_attribute :status_reload_frequency
+    class_attribute :status_reload_frequency, default: MaintenanceTasks.status_reload_frequency
 
     define_callbacks :start, :complete, :error, :cancel, :pause, :interrupt
 
@@ -305,13 +305,6 @@ module MaintenanceTasks
     # @return the cursor_columns.
     def cursor_columns
       nil
-    end
-
-    # Returns the configured status reload frequency, falling back to the global default.
-    #
-    # @return [ActiveSupport::Duration, Numeric] the time interval between status reloads.
-    def status_reload_frequency
-      self.class.status_reload_frequency || MaintenanceTasks.status_reload_frequency
     end
 
     # Placeholder method to raise in case a subclass fails to implement the

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -85,6 +85,14 @@ module MaintenanceTasks
   #  @return [ActiveSupport::Duration] the threshold in seconds after which a task is considered stuck.
   mattr_accessor :stuck_task_duration, default: 5.minutes
 
+  # @!attribute status_reload_frequency
+  #  @scope class
+  #  The frequency at which to reload the run status during iteration.
+  #  Defaults to 1 second, meaning reload status every second.
+  #
+  #  @return [ActiveSupport::Duration, Numeric] the time interval between status reloads.
+  mattr_accessor :status_reload_frequency, default: 1.second
+
   class << self
     DEPRECATION_MESSAGE = "MaintenanceTasks.error_handler is deprecated and will be removed in the 3.0 release. " \
       "Instead, reports will be sent to the Rails error reporter. Do not set a handler and subscribe " \

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -110,6 +110,38 @@ module MaintenanceTasks
       assert_equal 1, @run.reload.tick_count
     end
 
+    test ".perform_now respects status_reload_frequency for reloading status each iteration" do
+      freeze_time
+
+      original_frequency = MaintenanceTasks.status_reload_frequency
+      MaintenanceTasks.status_reload_frequency = 1.second
+
+      # Total of 3 posts
+      Post.create!(title: "Hello World!", content: "Something")
+
+      run = Run.create!(task_name: "Maintenance::UpdatePostsTask")
+
+      reload_status_call_count = 0
+      original_reload_status = run.method(:reload_status)
+      run.expects(:reload_status).twice.with do
+        reload_status_call_count += 1
+        original_reload_status.call
+      end
+
+      Maintenance::UpdatePostsTask.any_instance.expects(:process).times(3).with do
+        travel(0.5)
+        true
+      end
+
+      TaskJob.perform_now(run)
+
+      # We iterated 3 times, but only 2 reloads were needed because the second
+      # iteration was within the status_reload_frequency
+      assert_equal(2, reload_status_call_count)
+    ensure
+      MaintenanceTasks.status_reload_frequency = original_frequency
+    end
+
     test ".perform_now persists started_at when the job starts" do
       freeze_time
       Maintenance::TestTask.any_instance.expects(:process).once.with do

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -116,5 +116,30 @@ module MaintenanceTasks
       task = Task.new
       assert_nil task.cursor_columns
     end
+
+    test ".status_reload_frequency defaults to global configuration" do
+      task = Task.new
+      assert_equal MaintenanceTasks.status_reload_frequency, task.status_reload_frequency
+    end
+
+    test ".status_reload_frequency uses task-level override when configured" do
+      Maintenance::TestTask.reload_status_every(5.seconds)
+      task = Maintenance::TestTask.new
+      assert_equal(5.seconds, task.status_reload_frequency)
+    ensure
+      Maintenance::TestTask.status_reload_frequency = nil
+    end
+
+    test ".status_reload_frequency falls back to global when not configured at task level" do
+      original_global = MaintenanceTasks.status_reload_frequency
+      MaintenanceTasks.status_reload_frequency = 7.seconds
+
+      Maintenance::TestTask.status_reload_frequency = nil
+      task = Maintenance::TestTask.new
+      assert_equal(7.seconds, task.status_reload_frequency)
+    ensure
+      MaintenanceTasks.status_reload_frequency = original_global
+      Maintenance::TestTask.status_reload_frequency = nil
+    end
   end
 end

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -123,23 +123,13 @@ module MaintenanceTasks
     end
 
     test ".status_reload_frequency uses task-level override when configured" do
+      original_reload_frequency = Maintenance::TestTask.status_reload_frequency
       Maintenance::TestTask.reload_status_every(5.seconds)
       task = Maintenance::TestTask.new
+
       assert_equal(5.seconds, task.status_reload_frequency)
     ensure
-      Maintenance::TestTask.status_reload_frequency = nil
-    end
-
-    test ".status_reload_frequency falls back to global when not configured at task level" do
-      original_global = MaintenanceTasks.status_reload_frequency
-      MaintenanceTasks.status_reload_frequency = 7.seconds
-
-      Maintenance::TestTask.status_reload_frequency = nil
-      task = Maintenance::TestTask.new
-      assert_equal(7.seconds, task.status_reload_frequency)
-    ensure
-      MaintenanceTasks.status_reload_frequency = original_global
-      Maintenance::TestTask.status_reload_frequency = nil
+      Maintenance::TestTask.status_reload_frequency = original_reload_frequency
     end
   end
 end


### PR DESCRIPTION
In our monolith, we're noticing frequent calls to the DB to reload the status, especially on tasks that iterate very quickly. This should help reduce that load by allowing tasks to specify how often the run status should be reloaded during iteration. A global default can be configured, and the value can also be configured on a per-task basis.

Note that decreasing the reload frequency impacts how quickly your task will stop if it is paused or interrupted. This config will be primarily useful for tasks that don't need to check for cancellation/pausing very often.

I've opted to configure reloads based on time-based frequency rather than iteration-based frequency. This aligns more closely with how ticker persistence works and makes more sense than using the number of iterations, since iterations may vary in their duration.

cc @kirs this, along with the backoff for retries, should greatly reduce the number of MT queries we're seeing.
