### PR TITLE
Mark tasks as being abstract to hide them from the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1017,6 +1017,17 @@ marked as fully cancelled, allowing you to run it again.
 If you are stuck in `pausing` and wish to preserve your tasks's position
 (instead of cancelling and rerunning), you may click "Force pause".
 
+### Hide tasks
+
+If you want a task to not appear it in the list, mark it as being abstract.
+E.g.:
+
+```rb
+class ApplicationTask < MaintenanceTasks::Task
+  self.abstract_class = true
+end
+```
+
 ### Configuring the gem
 
 There are a few configurable options for the gem. Custom configurations should

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -38,6 +38,10 @@ module MaintenanceTasks
     attr_accessor :metadata
 
     class << self
+      # Set this to +true+ if this is an abstract class. This will not appear
+      # as a task in the list.
+      attr_accessor :abstract_class
+
       # Finds a Task with the given name.
       #
       # @param name [String] the name of the Task to be found.
@@ -61,7 +65,7 @@ module MaintenanceTasks
       # @return [Array<Class>] the list of classes.
       def load_all
         load_constants
-        descendants
+        descendants.reject(&:abstract_class)
       end
 
       # Loads and returns a list of concrete classes that inherit

--- a/test/dummy/app/tasks/maintenance/application_task.rb
+++ b/test/dummy/app/tasks/maintenance/application_task.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class ApplicationTask < MaintenanceTasks::Task
+    self.abstract_class = true
+  end
+end

--- a/test/dummy/app/tasks/maintenance/inherit_from_abstract_class_task.rb
+++ b/test/dummy/app/tasks/maintenance/inherit_from_abstract_class_task.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class InheritFromAbstractClassTask < ApplicationTask
+    no_collection
+
+    def process
+      # Task only exists to verify it is correctly loaded when inheriting.
+    end
+  end
+end

--- a/test/models/maintenance_tasks/task_data_index_test.rb
+++ b/test/models/maintenance_tasks/task_data_index_test.rb
@@ -15,6 +15,7 @@ module MaintenanceTasks
         "Maintenance::ImportPostsTask",
         "Maintenance::ImportPostsWithEncodingTask",
         "Maintenance::ImportPostsWithOptionsTask",
+        "Maintenance::InheritFromAbstractClassTask",
         "Maintenance::Nested::NestedMore::NestedMoreTask",
         "Maintenance::Nested::NestedTask",
         "Maintenance::NoCollectionTask",

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -4,7 +4,8 @@ require "test_helper"
 
 module MaintenanceTasks
   class TaskTest < ActiveSupport::TestCase
-    test ".load_all returns list of tasks that inherit from the Task superclass" do
+    test ".load_all returns list of tasks that inherit from the Task superclass, " \
+         "excluding abstract classes, ordered alphabetically by name" do
       expected = [
         "Maintenance::BatchImportPostsTask",
         "Maintenance::CallbackTestTask",
@@ -15,6 +16,7 @@ module MaintenanceTasks
         "Maintenance::ImportPostsTask",
         "Maintenance::ImportPostsWithEncodingTask",
         "Maintenance::ImportPostsWithOptionsTask",
+        "Maintenance::InheritFromAbstractClassTask",
         "Maintenance::Nested::NestedMore::NestedMoreTask",
         "Maintenance::Nested::NestedTask",
         "Maintenance::NoCollectionTask",


### PR DESCRIPTION
Hi there! Thanks for maintaining maintenance tasks ✨ 

This patch lets you inherit from tasks that only serve as parents without including them in the list. We can mark them as being abstract like so:

```rb
class ApplicationTask < MaintenanceTasks::Task
  self.abstract_class = true
end
```