### PR TITLE
Upgrade all migrations from Rails 6 to Rails 7

### DIFF
--- a/db/migrate/20201211151756_create_maintenance_tasks_runs.rb
+++ b/db/migrate/20201211151756_create_maintenance_tasks_runs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
+class CreateMaintenanceTasksRuns < ActiveRecord::Migration[7.0]
   def change
     create_table(:maintenance_tasks_runs, id: primary_key_type) do |t|
       t.string(:task_name, null: false)

--- a/db/migrate/20210219212931_change_cursor_to_string.rb
+++ b/db/migrate/20210219212931_change_cursor_to_string.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeCursorToString < ActiveRecord::Migration[6.0]
+class ChangeCursorToString < ActiveRecord::Migration[7.0]
   # This migration will clear all existing data in the cursor column with MySQL.
   # Ensure no Tasks are paused when this migration is deployed, or they will be resumed from the start.
   # Running tasks are able to gracefully handle this change, even if interrupted.

--- a/db/migrate/20210225152418_remove_index_on_task_name.rb
+++ b/db/migrate/20210225152418_remove_index_on_task_name.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveIndexOnTaskName < ActiveRecord::Migration[6.0]
+class RemoveIndexOnTaskName < ActiveRecord::Migration[7.0]
   def up
     change_table(:maintenance_tasks_runs) do |t|
       t.remove_index(:task_name)

--- a/db/migrate/20210517131953_add_arguments_to_maintenance_tasks_runs.rb
+++ b/db/migrate/20210517131953_add_arguments_to_maintenance_tasks_runs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddArgumentsToMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
+class AddArgumentsToMaintenanceTasksRuns < ActiveRecord::Migration[7.0]
   def change
     add_column(:maintenance_tasks_runs, :arguments, :text)
   end

--- a/db/migrate/20211210152329_add_lock_version_to_maintenance_tasks_runs.rb
+++ b/db/migrate/20211210152329_add_lock_version_to_maintenance_tasks_runs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddLockVersionToMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
+class AddLockVersionToMaintenanceTasksRuns < ActiveRecord::Migration[7.0]
   def change
     add_column(
       :maintenance_tasks_runs,

--- a/db/migrate/20220706101937_change_runs_tick_columns_to_bigints.rb
+++ b/db/migrate/20220706101937_change_runs_tick_columns_to_bigints.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ChangeRunsTickColumnsToBigints < ActiveRecord::Migration[6.0]
+class ChangeRunsTickColumnsToBigints < ActiveRecord::Migration[7.0]
   def up
     change_table(:maintenance_tasks_runs, bulk: true) do |t|
       t.change(:tick_count, :bigint)

--- a/db/migrate/20220713131925_add_index_on_task_name_and_status_to_runs.rb
+++ b/db/migrate/20220713131925_add_index_on_task_name_and_status_to_runs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddIndexOnTaskNameAndStatusToRuns < ActiveRecord::Migration[6.0]
+class AddIndexOnTaskNameAndStatusToRuns < ActiveRecord::Migration[7.0]
   def change
     remove_index(
       :maintenance_tasks_runs,

--- a/db/migrate/20230622035229_add_metadata_to_runs.rb
+++ b/db/migrate/20230622035229_add_metadata_to_runs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddMetadataToRuns < ActiveRecord::Migration[6.0]
+class AddMetadataToRuns < ActiveRecord::Migration[7.0]
   def change
     add_column(:maintenance_tasks_runs, :metadata, :text)
   end

--- a/test/dummy/db/migrate/20200923173403_create_posts.rb
+++ b/test/dummy/db/migrate/20200923173403_create_posts.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreatePosts < ActiveRecord::Migration[6.0]
+class CreatePosts < ActiveRecord::Migration[7.0]
   def change
     create_table(:posts) do |t|
       t.string(:title)


### PR DESCRIPTION
Upgrade all migrations from Rails 6 to Rails 7 partially as a form of maintenance but primarily, specifically to pick up Postgres `timestamptz` support which I believe was added/released in Rails 7.1 via https://github.com/rails/rails/commit/75c406d774cbc4debf0d672a59a1e726b64cd57c.

Why not upgrade straight to Rails 8.0 migrations? As `maintenance_tasks` supports Rails 7, 7.1, and 7.2, I'm fairly certain we cannot upgrade to 8.0 as Rails 7 doesn't know about/support such. Thus, 7.0 is the latest we can upgrade to until we drop support for Rails 7.x which likely won't be until at least August 2026 re: 7.2's security support EOL. ([source](https://endoflife.date/rails))

Resolves https://github.com/Shopify/maintenance_tasks/issues/1219