### PR TITLE
Upgrade bundler from 2.6.3 to 2.6.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,4 +332,4 @@ RUBY VERSION
    ruby 3.3.6p108
 
 BUNDLED WITH
-   2.6.3
+   2.6.9


### PR DESCRIPTION
Simple maintenance PR to upgrade `bundler` version to latest to pick up a bunch of fixes and improvements.
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.6.4
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.6.5
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.6.6
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.6.7
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.6.8
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.6.9

Note, I do kind of expect a v2.6.10 or v2.7.0 to be released at some point soon re: v2.6.9 being released in May but at the same time, could be a while so, might as well get up to date. :man_shrugging: 