### PR TITLE
Drop support for no-longer-supported Rails 7.0 and clean up ✨

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         gemfile:
-        - gemfiles/rails_7_0.gemfile
         - gemfiles/rails_7_1.gemfile
         - gemfiles/rails_7_2.gemfile
         - Gemfile # current minor release

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "debug"
 gem "mocha"
 gem "puma"
 if !@rails_gem_requirement
-  gem "rails", ">= 7.0"
+  gem "rails", ">= 7.1"
   ruby ">= 3.2.0"
 else
   # causes Dependabot to ignore the next line and update the previous gem "rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,12 @@ PATH
   remote: .
   specs:
     maintenance_tasks (2.12.0)
-      actionpack (>= 7.0)
-      activejob (>= 7.0)
-      activerecord (>= 7.0)
+      actionpack (>= 7.1)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
       csv
       job-iteration (>= 1.3.6)
-      railties (>= 7.0)
+      railties (>= 7.1)
       zeitwerk (>= 2.6.2)
 
 GEM
@@ -320,7 +320,7 @@ DEPENDENCIES
   maintenance_tasks!
   mocha
   puma
-  rails (>= 7.0)
+  rails (>= 7.1)
   rubocop
   rubocop-shopify
   selenium-webdriver

--- a/Rakefile
+++ b/Rakefile
@@ -6,9 +6,6 @@ rescue LoadError
   puts "You must `gem install bundler` and `bundle install` to run rake tasks"
 end
 
-# Only necessary for activesupport <= 7.0 and concurrent-ruby >= 1.3.5
-require "logger" # https://github.com/rails/rails/issues/54260
-
 require "rdoc/task"
 RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = "rdoc"

--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -193,10 +193,8 @@ module MaintenanceTasks
       if MaintenanceTasks.instance_variable_get(:@error_handler)
         errored_element = task_context.delete(:errored_element)
         MaintenanceTasks.error_handler.call(error, task_context.except(:run_id, :tick_count), errored_element)
-      elsif Rails.gem_version >= Gem::Version.new("7.1")
-        Rails.error.report(error, context: task_context, source: "maintenance-tasks")
       else
-        Rails.error.report(error, handled: true, context: task_context)
+        Rails.error.report(error, context: task_context, source: "maintenance-tasks")
       end
     end
 

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -44,15 +44,9 @@ module MaintenanceTasks
 
     attr_readonly :task_name
 
-    if Rails.gem_version >= Gem::Version.new("7.1.alpha")
-      serialize :backtrace, coder: YAML
-      serialize :arguments, coder: JSON
-      serialize :metadata, coder: JSON
-    else
-      serialize :backtrace
-      serialize :arguments, JSON
-      serialize :metadata, JSON
-    end
+    serialize :backtrace, coder: YAML
+    serialize :arguments, coder: JSON
+    serialize :metadata, coder: JSON
 
     scope :active, -> { where(status: ACTIVE_STATUSES) }
     scope :completed, -> { where(status: COMPLETED_STATUSES) }

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -238,11 +238,7 @@ module MaintenanceTasks
       #   By default: <code>{ source: "maintenance_tasks" }</code> or (Rails <v7.1) <code>{ handled: true }</code>.
       def report_on(*exceptions, **report_options)
         rescue_from(*exceptions) do |exception|
-          if Rails.gem_version >= Gem::Version.new("7.1")
-            Rails.error.report(exception, source: "maintenance_tasks", **report_options)
-          else
-            Rails.error.report(exception, handled: true, **report_options)
-          end
+          Rails.error.report(exception, source: "maintenance_tasks", **report_options)
         end
       end
 

--- a/bin/rails
+++ b/bin/rails
@@ -12,7 +12,4 @@ APP_PATH = File.expand_path("../test/dummy/config/application", __dir__)
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
-# Only necessary for activesupport <= 7.0 and concurrent-ruby >= 1.3.5
-require "logger" # https://github.com/rails/rails/issues/54260
-
 require "rails/engine/commands"

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-@rails_gem_requirement = "~> 7.0.4"
-@sqlite3_requirement = "~> 1.4"
-
-eval_gemfile "../Gemfile"
-gem "bigdecimal"
-gem "drb"
-gem "mutex_m"

--- a/lib/maintenance_tasks/engine.rb
+++ b/lib/maintenance_tasks/engine.rb
@@ -21,10 +21,8 @@ module MaintenanceTasks
       MaintenanceTasks.backtrace_cleaner = Rails.backtrace_cleaner
     end
 
-    if Rails.gem_version >= Gem::Version.new("7.1")
-      initializer "maintenance_tasks.deprecator" do
-        Rails.application.deprecators[:maintenance_tasks] = MaintenanceTasks.deprecator
-      end
+    initializer "maintenance_tasks.deprecator" do
+      Rails.application.deprecators[:maintenance_tasks] = MaintenanceTasks.deprecator
     end
 
     config.to_prepare do

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = ["maintenance_tasks"]
 
-  minimum_rails_version = "7.0"
+  minimum_rails_version = "7.1"
   spec.add_dependency("actionpack", ">= #{minimum_rails_version}")
   spec.add_dependency("activejob", ">= #{minimum_rails_version}")
   spec.add_dependency("activerecord", ">= #{minimum_rails_version}")

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -19,10 +19,6 @@ Capybara.configure do |config|
   config.ignore_hidden_elements = false
 end
 
-if Rails.gem_version < Gem::Version.new("7.1")
-  Selenium::WebDriver.logger.ignore(:capabilities)
-end
-
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include ActiveJob::TestHelper
 

--- a/test/dummy/Rakefile
+++ b/test/dummy/Rakefile
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# Only necessary for activesupport <= 7.0 and concurrent-ruby >= 1.3.5
-require "logger" # https://github.com/rails/rails/issues/54260
-
 require_relative "config/application"
 
 Rails.application.load_tasks

--- a/test/dummy/bin/rails
+++ b/test/dummy/bin/rails
@@ -4,7 +4,4 @@
 APP_PATH = File.expand_path("../config/application", __dir__)
 require_relative "../config/boot"
 
-# Only necessary for activesupport <= 7.0 and concurrent-ruby >= 1.3.5
-require "logger" # https://github.com/rails/rails/issues/54260
-
 require "rails/commands"

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -774,38 +774,5 @@ module MaintenanceTasks
       assert_equal(report.context.slice(:more), { more: true })
       assert_equal(report.severity, :info)
     end
-
-    private
-
-    if Rails.gem_version < Gem::Version.new("7.1.0")
-      Report = Struct.new(:exception, :handled, :severity, :context, :source, keyword_init: true)
-
-      def assert_error_reported(error = nil, &block)
-        reporter = Class.new do
-          def reports
-            @reports ||= []
-          end
-
-          def report(exception, **kwargs)
-            reports << Report.new(exception: exception, **kwargs)
-          end
-        end.new
-
-        Rails.error.subscribe(reporter)
-
-        yield
-
-        if error
-          report = reporter.reports.detect { |report| report.exception.is_a?(error) }
-          assert(report, "No #{error} reported!")
-          report
-        else
-          assert_not_empty(reporter.reports, "No errors reported!")
-          reporter.reports.first
-        end
-      ensure
-        Rails.error.instance_variable_get(:@subscribers).delete(reporter)
-      end
-    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,7 +46,6 @@ module Warning
       # To be removed once warnings are fixed in selenium-webdriver and sprockets.
       # This is noisy, so ignoring completely for now.
       return if message.match?("URI::RFC3986_PARSER.(un)?escape is obsolete.")
-      return if Rails.gem_version < "7.1" && message.match?(/the block passed to .* may be ignored/)
 
       raise message.to_s
     end


### PR DESCRIPTION
Proposing we drop support for Rails 7.0 (not 7.1 nor 7.2, _yet_) as it's no longer supported as of over 3 months ago. Doing so additionally allows us to clean up quite a few `if >= 7.1` type conditionals. ([Rails EOL info source](https://endoflife.date/rails))

<img width="1100" height="639" alt="image" src="https://github.com/user-attachments/assets/0e5519d5-75e9-4834-8023-9803fb40ff32" />