### PR TITLE
Bump Bundler from 2.6.9 to 2.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,4 +334,4 @@ RUBY VERSION
    ruby 3.3.6p108
 
 BUNDLED WITH
-   2.6.9
+   2.7.1


### PR DESCRIPTION
Upgrades the version of Bundler used from 2.6.9 to 2.7.1. The inspiration for doing so is to pick up fixes in order to silence the deluge of warnings that appear when running tests/RuboCop while on Bundler 2.6.8 with Ruby 3.4.5; see below.

- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.7.0
- https://github.com/rubygems/rubygems/releases/tag/bundler-v2.7.1

<img width="2688" height="1572" alt="Screenshot From 2025-08-04 17-33-22" src="https://github.com/user-attachments/assets/018a6dac-2590-40c4-8952-abf4f4c71128" />

Meanwhile on Bundler 2.7.1 with Ruby 3.4.5. :tophat: :tophat: :tophat: 

<img width="2688" height="1572" alt="Screenshot From 2025-08-04 17-33-42" src="https://github.com/user-attachments/assets/f3d6f56d-ec5a-4308-a3c3-db9f18afebc8" />
