### PR TITLE
Add --parent option to generator to specify parent class

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,34 @@ module Maintenance
 end
 ```
 
+#### Customizing the parent class
+
+A custom parent class can come in handy when you need to share code between tasks:
+
+```sh-session
+bin/rails generate maintenance_tasks:task update_posts --parent post_task
+```
+
+```ruby
+# app/tasks/maintenance/update_posts_task.rb
+
+module Maintenance
+  class UpdatePostsTask < PostTask
+    ...
+  end
+end
+```
+
+A default value for this flag can be added to the generator options in Rails:
+```ruby
+# config/application.rb
+...
+    config.generators do |g|
+      g.maintenance_tasks parent: "ApplicationTask"
+    end
+...
+```
+
 #### Customizing the Batch Size
 
 When processing records from an Active Record Relation, records are fetched in

--- a/lib/generators/maintenance_tasks/task_generator.rb
+++ b/lib/generators/maintenance_tasks/task_generator.rb
@@ -19,6 +19,11 @@ module MaintenanceTasks
       default: false,
       desc: "Generate a collection-less Task."
 
+    class_option :parent,
+      type: :string,
+      default: "MaintenanceTasks::Task",
+      desc: "The parent class for the generated task."
+
     check_class_collision suffix: "Task"
 
     # Creates the Task file.
@@ -92,6 +97,10 @@ module MaintenanceTasks
 
     def no_collection?
       options[:no_collection]
+    end
+
+    def parent_class_name
+      options[:parent]
     end
   end
 end

--- a/lib/generators/maintenance_tasks/templates/csv_task.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/csv_task.rb.tt
@@ -2,7 +2,7 @@
 
 module <%= tasks_module %>
 <% module_namespacing do -%>
-  class <%= class_name %>Task < MaintenanceTasks::Task
+  class <%= class_name %>Task < <%= parent_class_name.classify %>
     csv_collection
 
     def process(row)

--- a/lib/generators/maintenance_tasks/templates/no_collection_task.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/no_collection_task.rb.tt
@@ -2,7 +2,7 @@
 
 module <%= tasks_module %>
 <% module_namespacing do -%>
-  class <%= class_name %>Task < MaintenanceTasks::Task
+  class <%= class_name %>Task < <%= parent_class_name.classify %>
     no_collection
 
     def process

--- a/lib/generators/maintenance_tasks/templates/task.rb.tt
+++ b/lib/generators/maintenance_tasks/templates/task.rb.tt
@@ -2,7 +2,7 @@
 
 module <%= tasks_module %>
 <% module_namespacing do -%>
-  class <%= class_name %>Task < MaintenanceTasks::Task
+  class <%= class_name %>Task < <%= parent_class_name.classify %>
     def collection
       # Collection to be iterated over
       # Must be Active Record Relation or Array

--- a/test/lib/generators/maintenance_tasks/task_generator_test.rb
+++ b/test/lib/generators/maintenance_tasks/task_generator_test.rb
@@ -81,6 +81,13 @@ module MaintenanceTasks
       end
     end
 
+    test "generator uses the right superclass when --parent is provided" do
+      run_generator ["sleepy", "--parent", "application_task"]
+      assert_file "app/tasks/maintenance/sleepy_task.rb" do |task|
+        assert_match(/class SleepyTask < ApplicationTask/, task)
+      end
+    end
+
     test "generator creates a collection-less Task if the --no-collection option is supplied" do
       run_generator ["sleepy", "--no-collection"]
       assert_file "app/tasks/maintenance/sleepy_task.rb" do |task|


### PR DESCRIPTION
Example:
```
bin/rails generate maintenance_tasks:task update_posts --parent application_task
```

generates:

```
module Maintenance
  class UpdatePostsTask < ApplicationTask
    ...
  end
end
```