### PR TITLE
Lock GitHub Actions dependencies to SHAs for security and predictability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,9 @@ jobs:
       DB: ${{ matrix.database }}
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@829114fc20da43a41d27359103ec7a63020954d4 # v1.255.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-issue-stale: 60
           exempt-issue-labels: "Blocked"


### PR DESCRIPTION
### What is this PR doing?

Locks the three GitHub Actions dependencies to specific versions via said versions' SHAs.

<img width="2880" height="1920" alt="image" src="https://github.com/user-attachments/assets/721c6249-a51d-4fd3-b8d8-85e058195956" />

### Why is this PR doing such?

1. Locking to SHAs is best practice for security and sanity as we know which version is being used. Without doing Actions will simply use whatever latest version is available, a silent bump of sorts. For example, actions/checkout just released a [v4.3.0](https://github.com/actions/checkout/releases/tag/v4.3.0) today, which will be used automatically.
~2. With locking to SHAs we should receive (albeit somewhat rare) Dependabot upgrade PRs for said Actions dependencies which version is in use will be explicit and thus can be updated explicitly. For example, [actions/checkout v5.0.0](https://github.com/actions/checkout/releases/tag/v5.0.0) was just released today. After this PR I expect we'll receive a bump PR to such.~ We should receive bumps even without locking but such would only be for major versions. Actions would use latest version for a given major versions per run thus minor and patch versions automatically bump transiently.

#### Reference

- https://github.com/actions/checkout/releases/tag/v4.3.0
- https://github.com/ruby/setup-ruby/releases/tag/v1.255.0
- https://github.com/actions/stale/releases/tag/v9.1.0