### PR TITLE
Feature: Include optional output method to maintenance tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,38 @@ module Maintenance
 end
 ```
 
+### Task Output
+
+Maintenance Tasks can store and collect task outputs, which is displayed on the Web UI.
+
+How the output is stored depends entirely on the Task implementation, being it on the primary database, logs, cache, file system, etc.
+
+To use this feature, define the `output` reader and writer methods, then write the output in the `process` method or in a callback.
+
+The task methods have access to a subset of the `Run` instance information in the `run_data` method.
+
+```ruby
+module Maintenance
+  class CacheOutputTask < MaintenanceTasks::Task
+    def collection
+      [1, 2]
+    end
+
+    def process(item)
+      self.output = output.to_s + "Processing item #{item}.\n"
+    end
+
+    def output=(message)
+      SomeStorage.write("maintenance-tasks:#{run_data.id}", message)
+    end
+
+    def output
+      SomeStorage.read("maintenance-tasks:#{run_data.id}")
+    end
+  end
+end
+```
+
 ### Subscribing to instrumentation events
 
 If you are interested in actioning a specific task event, please refer to the

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -427,7 +427,7 @@ module MaintenanceTasks
         end
 
         task.metadata = metadata
-        task.run_data = RunData.new(**attributes.symbolize_keys.slice(*RunData.members))
+        task.run_data = -> { RunData.new(**attributes.symbolize_keys.slice(*RunData.members)) }
 
         task
       rescue ActiveModel::UnknownAttributeError

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -33,6 +33,9 @@ module MaintenanceTasks
     ]
     COMPLETED_STATUSES = [:succeeded, :errored, :cancelled]
 
+    # struct to hold a subset of a Run fields
+    RunData = Struct.new(:id, :cursor, keyword_init: true)
+
     enum :status, STATUSES.to_h { |status| [status, status.to_s] }
 
     after_save :instrument_status_change
@@ -424,6 +427,8 @@ module MaintenanceTasks
         end
 
         task.metadata = metadata
+        task.run_data = RunData.new(**attributes.symbolize_keys.slice(*RunData.members))
+
         task
       rescue ActiveModel::UnknownAttributeError
         task

--- a/app/models/maintenance_tasks/run.rb
+++ b/app/models/maintenance_tasks/run.rb
@@ -60,6 +60,8 @@ module MaintenanceTasks
 
     validates_with RunStatusValidator, on: :update
 
+    delegate :output, to: :task
+
     if MaintenanceTasks.active_storage_service.present?
       has_one_attached :csv_file,
         service: MaintenanceTasks.active_storage_service

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -314,6 +314,13 @@ module MaintenanceTasks
       raise NoMethodError, "#{self.class.name} must implement `process`."
     end
 
+    # Placeholder method for task output implementation.
+    #
+    # @return [String, nil]
+    def output
+      nil
+    end
+
     # Total count of iterations to be performed, delegated to the strategy.
     #
     # @return [Integer, nil]

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -41,7 +41,9 @@ module MaintenanceTasks
 
     define_callbacks :start, :complete, :error, :cancel, :pause, :interrupt
 
-    attr_accessor :metadata, :run_data
+    attr_accessor :metadata
+
+    attr_writer :run_data
 
     class << self
       # Finds a Task with the given name.
@@ -337,6 +339,15 @@ module MaintenanceTasks
     # @return [Enumerator]
     def enumerator_builder(cursor:)
       nil
+    end
+
+    # Call and return the @run_data proc created by the task instance
+    #
+    # @return [Run::RunData, nil]
+    def run_data
+      return @run_data.call if @run_data.respond_to?(:call)
+
+      @run_data
     end
   end
 end

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -41,7 +41,7 @@ module MaintenanceTasks
 
     define_callbacks :start, :complete, :error, :cancel, :pause, :interrupt
 
-    attr_accessor :metadata
+    attr_accessor :metadata, :run_data
 
     class << self
       # Finds a Task with the given name.

--- a/app/views/maintenance_tasks/runs/_output.html.erb
+++ b/app/views/maintenance_tasks/runs/_output.html.erb
@@ -1,0 +1,7 @@
+<% if output.present? %>
+  <div class="content">
+    <h6 class="title is-6">Task Output</h6>
+    <pre class="box has-background-light"><%= output %></pre>
+  </div>
+  <hr>
+<% end %>

--- a/app/views/maintenance_tasks/runs/_run.html.erb
+++ b/app/views/maintenance_tasks/runs/_run.html.erb
@@ -26,6 +26,7 @@
   <%= render "maintenance_tasks/runs/arguments", arguments: run.masked_arguments %>
   <%= tag.hr if run.csv_file.present? || run.arguments.present? && run.metadata.present? %>
   <%= render "maintenance_tasks/runs/metadata", metadata: run.metadata %>
+  <%= render "maintenance_tasks/runs/output", output: run.output unless run.output.nil? %>
 
   <div class="buttons">
     <% if run.paused? %>

--- a/test/dummy/app/tasks/maintenance/cache_output_task.rb
+++ b/test/dummy/app/tasks/maintenance/cache_output_task.rb
@@ -2,7 +2,7 @@
 
 module Maintenance
   class CacheOutputTask < MaintenanceTasks::Task
-    @cache = ""
+    @cache = {}
 
     class << self
       attr_accessor :cache
@@ -13,15 +13,15 @@ module Maintenance
     end
 
     def process(number)
-      self.output = output.to_s + "Completed number #{number} on run #{run_data.id}.\n"
+      self.output = output.to_s + "Completed number #{number}.\n"
     end
 
     def output=(message)
-      self.class.cache = message
+      self.class.cache[run_data.id] = message
     end
 
     def output
-      self.class.cache
+      self.class.cache[run_data.id]
     end
   end
 end

--- a/test/dummy/app/tasks/maintenance/cache_output_task.rb
+++ b/test/dummy/app/tasks/maintenance/cache_output_task.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class CacheOutputTask < MaintenanceTasks::Task
+    @cache = ""
+
+    class << self
+      attr_accessor :cache
+    end
+
+    def collection
+      [1, 2]
+    end
+
+    def process(number)
+      self.output = output.to_s + "Completed number #{number} on run #{run_data.id}.\n"
+    end
+
+    def output=(message)
+      self.class.cache = message
+    end
+
+    def output
+      self.class.cache
+    end
+  end
+end

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -751,6 +751,18 @@ module MaintenanceTasks
       TaskJob.perform_now(run)
     end
 
+    test ".perform_now can store task output into cache" do
+      run = Run.create!(task_name: "Maintenance::CacheOutputTask")
+
+      TaskJob.perform_now(run)
+
+      expected = <<~EOF
+        Completed number 1 on run #{run.id}.
+        Completed number 2 on run #{run.id}.
+      EOF
+      assert_equal(expected, run.output)
+    end
+
     test ".report_on reports the error" do
       run = Run.create!(task_name: "Maintenance::UpdatePostsTask")
 

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -757,8 +757,8 @@ module MaintenanceTasks
       TaskJob.perform_now(run)
 
       expected = <<~EOF
-        Completed number 1 on run #{run.id}.
-        Completed number 2 on run #{run.id}.
+        Completed number 1.
+        Completed number 2.
       EOF
       assert_equal(expected, run.output)
     end

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -725,6 +725,21 @@ module MaintenanceTasks
         (Run::ACTIVE_STATUSES + Run::COMPLETED_STATUSES).sort
     end
 
+    test "#output is delegated to task instance" do
+      test_task = Maintenance::TestTask.new
+      # redefine output method
+      test_task.class.define_method(:output) do
+        "Some task output"
+      end
+
+      run = Run.create!(
+        task_name: "Maintenance::TestTask",
+        status: :succeeded,
+      )
+
+      assert_equal(run.output, "Some task output")
+    end
+
     private
 
     def expected_notification(run)

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -625,6 +625,14 @@ module MaintenanceTasks
       assert_equal({ "foo" => "bar" }, run.task.metadata)
     end
 
+    test "#task sets a subset of the run fields on the Task" do
+      run = Run.new(task_name: "Maintenance::TestTask", id: 999, cursor: "998")
+      task = run.task
+
+      assert_equal(task.run_data.id, 999)
+      assert_equal(task.run_data.cursor, "998")
+    end
+
     test "#validate_task_arguments instantiates Task and assigns arguments if Task has parameters" do
       run = Run.new(
         task_name: "Maintenance::ParamsTask",

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -745,7 +745,7 @@ module MaintenanceTasks
         status: :succeeded,
       )
 
-      assert_equal(run.output, "Some task output")
+      assert_equal("Some task output", run.output)
     end
 
     private

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -131,5 +131,18 @@ module MaintenanceTasks
     ensure
       Maintenance::TestTask.status_reload_frequency = original_reload_frequency
     end
+
+    test "#output may contain task output" do
+      test_task = Maintenance::TestTask.new
+
+      assert_nil(test_task.output)
+
+      # redefine output method
+      test_task.class.define_method(:output) do
+        "Some task output"
+      end
+
+      assert_equal("Some task output", test_task.output)
+    end
   end
 end

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -7,6 +7,7 @@ module MaintenanceTasks
     test ".load_all returns list of tasks that inherit from the Task superclass" do
       expected = [
         "Maintenance::BatchImportPostsTask",
+        "Maintenance::CacheOutputTask",
         "Maintenance::CallbackTestTask",
         "Maintenance::CancelledEnqueueTask",
         "Maintenance::CustomEnumeratingTask",


### PR DESCRIPTION
> [!Note]
> This replaces #1251 

## Summary

Introduces the ability to collect and display task outputs by optionally adding and `output` method. This allows to save task logs or produce results to be displayed in the UI.

The storage of this output is the responsibility of the task class.

## Why This Change?

This expands the usage of maintenance tasks to allow generating outputs that can be used later, for example:

- better visibility of task progress execution
- inspection of data without needing to access console or database directly
- exporting data from one environment to another

## Implementation details

### Database Changes

No database/schema changes.

### Core Functionality

- Include a `run_data` field and method available for tasks, this field includes a subset of the `Run` instance data available through a Proc
- Include an `output` method in the `MaintenanceTasks::Task` class, intended to be overwritten
- Delegates `Run#output` to `Task#output` for easier use in views

### UI Changes

- Added new `_output.html.erb` partial to display task output
- Output is shown in a formatted box on the run details page
- Only displayed when output is not `nil`

### Usage example

This example task saves the output from each `process` call to a class instance variable.

```ruby
module Maintenance
  class CacheOutputTask < MaintenanceTasks::Task
    @cache = {}

    class << self
      attr_accessor :cache
    end

    def collection
      [1, 2]
    end

    def process(number)
      self.output = output.to_s + "Completed number #{number}.\n"
    end

    def output=(message)
      self.class.cache[run_data.id] = message
    end

    def output
      self.class.cache[run_data.id]
    end
  end
end
```

#### Screenshot

<img width="1295" height="784" alt="image" src="https://github.com/user-attachments/assets/eab1abbe-f881-41e8-b24a-ff9cc08fe75c" />

## Backward Compatibility

- Feature is optional
- No changes are required for existing tasks

