### PR TITLE
Use capybara-lockstep

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "better_html"
-gem "capybara"
 gem "debug"
-gem "mocha"
 gem "puma"
 if !@rails_gem_requirement
   gem "rails", ">= 7.1"
@@ -19,7 +17,6 @@ else
 end
 gem "rubocop"
 gem "rubocop-shopify"
-gem "selenium-webdriver"
 gem "sprockets-rails"
 if @sqlite3_requirement
   # causes Dependabot to ignore the next line and update the next gem "sqlite3"
@@ -29,3 +26,10 @@ else
   gem "sqlite3"
 end
 gem "yard"
+
+group :test do
+  gem "capybara"
+  gem "capybara-lockstep"
+  gem "mocha"
+  gem "selenium-webdriver"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,11 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    capybara-lockstep (2.2.3)
+      activesupport (>= 4.2)
+      capybara (>= 3.0)
+      ruby2_keywords
+      selenium-webdriver (>= 4.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -316,6 +321,7 @@ PLATFORMS
 DEPENDENCIES
   better_html
   capybara
+  capybara-lockstep
   debug
   maintenance_tasks!
   mocha

--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -13,9 +13,15 @@ module MaintenanceTasks
         # <style> tag in app/views/layouts/maintenance_tasks/application.html.erb
         "'sha256-WHHDQLdkleXnAN5zs0GDXC5ls41CHUaVsJtVpaNx+EM='",
       )
+      capybara_lockstep_scripts = [
+        "'sha256-1AoN3ZtJC5OvqkMgrYvhZjp4kI8QjJjO7TAyKYiDw+U='",
+        "'sha256-QVSzZi6ZsX/cu4h+hIs1iVivG1BxUmJggiEsGDIXBG0='", # with debug on
+      ] if defined?(Capybara::Lockstep)
       policy.script_src_elem(
         # <script> tag in app/views/layouts/maintenance_tasks/application.html.erb
         "'sha256-NiHKryHWudRC2IteTqmY9v1VkaDUA/5jhgXkMTkgo2w='",
+        # <script> tag for capybara-lockstep
+        *capybara_lockstep_scripts,
       )
 
       policy.require_trusted_types_for # disable because we use new DOMParser().parseFromString

--- a/app/views/layouts/maintenance_tasks/application.html.erb
+++ b/app/views/layouts/maintenance_tasks/application.html.erb
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <%= capybara_lockstep if defined?(Capybara::Lockstep) %>
 
     <title>
       <% if content_for?(:page_title) %>


### PR DESCRIPTION
This should help prevent the flakiness we're seeing in system tests, at least around navigation events, because [it doesn't support `setTimeout`](https://github.com/makandra/capybara-lockstep/blob/v2.2.3/README.md#limitations).