### PR TITLE
(Not) handled exceptions

### DIFF
--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -194,7 +194,12 @@ module MaintenanceTasks
         errored_element = task_context.delete(:errored_element)
         MaintenanceTasks.error_handler.call(error, task_context.except(:run_id, :tick_count), errored_element)
       else
-        Rails.error.report(error, context: task_context, source: "maintenance-tasks")
+        Rails.error.report(
+          error,
+          handled: MaintenanceTasks.report_errors_as_handled,
+          context: task_context,
+          source: "maintenance-tasks",
+        )
       end
     end
 

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -235,7 +235,7 @@ module MaintenanceTasks
       #
       # @param exceptions list of exceptions to rescue and report
       # @param report_options [Hash] optionally, supply additional options for `Rails.error.report`.
-      #   By default: <code>{ source: "maintenance-tasks" }</code>.
+      #   By default: <code>{ handled: true, source: "maintenance-tasks" }</code>.
       def report_on(*exceptions, **report_options)
         rescue_from(*exceptions) do |exception|
           Rails.error.report(exception, source: "maintenance-tasks", **report_options)

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -93,6 +93,22 @@ module MaintenanceTasks
   #  @return [ActiveSupport::Duration, Numeric] the time interval between status reloads.
   mattr_accessor :status_reload_frequency, default: 1.second
 
+  # @!attribute report_errors_as_handled
+  #  @scope class
+  #  How unexpected errors are reported to Rails.error.report.
+  #
+  #  When an error occurs that isn't explicitly handled (e.g., via `report_on`),
+  #  it gets reported to Rails.error.report. This setting determines whether
+  #  these errors are marked as "handled" or "unhandled".
+  #
+  #  The current default of `true` is for backwards compatibility, but it prevents
+  #  error subscribers from distinguishing between expected and unexpected errors.
+  #  Setting this to `false` provides more accurate error reporting and will become the default in v3.0.
+  #
+  #  @see https://api.rubyonrails.org/classes/ActiveSupport/ErrorReporter.html#method-i-report
+  #  @return [Boolean] whether to report unexpected errors as handled (true) or unhandled (false).
+  mattr_accessor :report_errors_as_handled, default: true
+
   class << self
     DEPRECATION_MESSAGE = "MaintenanceTasks.error_handler is deprecated and will be removed in the 3.0 release. " \
       "Instead, reports will be sent to the Rails error reporter. Do not set a handler and subscribe " \


### PR DESCRIPTION
This PR:
- ...fixes an inconsistency in the `source` that is reported for rescued exceptions (ie via report_on)
- ...ensures exceptions are by default considered not handled. Whereas 'report_on exceptions' are considered handled.

This makes it possible to distinguish between rescued exceptions and other exceptions in an error-subscriber:
```ruby
class MaintenanceTasksErrorSubscriber
  def report(error, handled:, severity:, context:, source: nil)
    return unless source == "maintenance-tasks"

    ExceptionService.capture(ex) unless handled
    ...e.g. logging based on severity
  end
end
```