### PR TITLE
Add a count preview to maintenance task UI

### DIFF
--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -20,6 +20,8 @@ module MaintenanceTasks
       policy.script_src_elem(
         # <script> tag in app/views/layouts/maintenance_tasks/application.html.erb
         "'sha256-NiHKryHWudRC2IteTqmY9v1VkaDUA/5jhgXkMTkgo2w='",
+        # <script> tag in app/views/maintenance_tasks/tasks/show.html.erb
+        "'sha256-oCsB8YG3WI4aqJRWK/T7XfMAd3GEq+jhwDCOkSokj68='",
         # <script> tag for capybara-lockstep
         *capybara_lockstep_scripts,
       )

--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -25,6 +25,17 @@ module MaintenanceTasks
       )
     end
 
+    # Returns the estimated count of items for a Task as JSON.
+    def count
+      task_data = TaskDataShow.new(
+        params.fetch(:id),
+        arguments: params.except(:id, :controller, :action).permit!,
+      )
+      render(json: { count: task_data.count })
+    rescue StandardError
+      render(json: { count: nil })
+    end
+
     private
 
     def set_refresh

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -26,6 +26,11 @@
       </div>
     <% end %>
     <%= render "maintenance_tasks/tasks/custom", form: form %>
+    <% unless @task.deleted? || @task.csv_task? || @task.no_collection? %>
+      <div id="task-count" data-url="<%= count_task_path(@task) %>" class="block">
+        <p class="has-text-grey">Estimating expected items count...</p>
+      </div>
+    <% end %>
     <div class="block">
       <%= form.submit 'Run', class: "button is-success is-rounded mb-4 has-text-white-ter", disabled: @task.deleted? %>
     </div>
@@ -60,4 +65,68 @@
 
     <%= link_to "Next page", task_path(@task, cursor: @task.runs_page.next_cursor) unless @task.runs_page.last? %>
   <% end %>
+<% end %>
+
+<% unless @task.deleted? || @task.csv_task? || @task.no_collection? %>
+<script>
+(function() {
+  var countEl = document.getElementById('task-count');
+  if (!countEl) return;
+
+  var form = document.querySelector('form');
+  if (!form) return;
+
+  var url = countEl.dataset.url;
+  var abortCtrl;
+
+  function serializeParams() {
+    var params = new URLSearchParams();
+    new FormData(form).forEach(function(value, key) {
+      var m = key.match(/^task\[(.+)\]$/);
+      if (m) params.set(m[1], value);
+    });
+    return params.toString();
+  }
+
+  var lastParams = serializeParams();
+
+  function fetchCount() {
+    if (abortCtrl) abortCtrl.abort();
+    abortCtrl = new AbortController();
+
+    var p = countEl.querySelector('p');
+    p.textContent = 'Estimating expected items count...';
+    countEl.classList.remove('is-hidden');
+
+    var serialized = serializeParams();
+    lastParams = serialized;
+
+    fetch(url + '?' + serialized, { signal: abortCtrl.signal })
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        if (data.count != null) {
+          p.textContent = '';
+          var strong = document.createElement('strong');
+          strong.textContent = data.count.toLocaleString();
+          p.appendChild(strong);
+          p.appendChild(document.createTextNode(
+            ' ' + (data.count === 1 ? 'item' : 'items') + ' expected to be processed'
+          ));
+          countEl.classList.remove('is-hidden');
+        } else {
+          countEl.classList.add('is-hidden');
+        }
+      })
+      .catch(function() {});
+  }
+
+  function fetchCountIfChanged() {
+    if (serializeParams() !== lastParams) fetchCount();
+  }
+
+  fetchCount();
+  form.addEventListener('focusout', fetchCountIfChanged);
+  form.addEventListener('change', fetchCount);
+})();
+</script>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,9 @@
 
 MaintenanceTasks::Engine.routes.draw do
   resources :tasks, only: [:index, :show], format: false do
+    member do
+      get :count
+    end
     resources :runs, only: [:create], format: false do
       member do
         post "pause"

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -258,6 +258,32 @@ module MaintenanceTasks
       assert_button "Run", disabled: true
     end
 
+    test "show a Task with count indicator" do
+      visit maintenance_tasks.task_path("Maintenance::UpdatePostsThrottledTask")
+      assert_text "items expected to be processed"
+    end
+
+    test "count updates dynamically when params change" do
+      visit maintenance_tasks.task_path("Maintenance::ParamsTask")
+      assert_selector "#task-count:not(.is-hidden)"
+
+      fill_in "task[post_ids]", with: Post.first.id.to_s
+      find_field("task[post_ids]").send_keys(:tab)
+      within("#task-count") do
+        assert_text "1 item expected to be processed"
+      end
+    end
+
+    test "show a Task without count indicator" do
+      visit maintenance_tasks.task_path("Maintenance::ImportPostsTask")
+      assert_no_text "expected to be processed"
+    end
+
+    test "show a no-collection Task without count indicator" do
+      visit maintenance_tasks.task_path("Maintenance::NoCollectionTask")
+      assert_no_selector "#task-count"
+    end
+
     test "visit main page through iframe" do
       visit root_path
 


### PR DESCRIPTION
## Add a count preview to maintenance task UI

### Summary

- Displays an estimated count of items to be processed before running a task, giving operators visibility into the scope of a task run
- Fetches the count asynchronously via a new JSON endpoint so the main page load is not blocked
- Automatically re-fetches the count when task parameters change, keeping the estimate in sync with the current input

### Motivation

When running a maintenance task, operators had no way to gauge how many items would be processed beforehand. This made it difficult to assess the impact of a run or verify that parameters were configured correctly. A count preview solves this by showing a live estimate directly on the task show page.

### What changed

**New `count` endpoint** (`GET /tasks/:id/count`)
- Added a `count` action to `TasksController` that returns `{ count: <integer|null> }` as JSON.
- Errors are gracefully rescued, returning `{ count: null }` so the UI can hide the indicator instead of showing a broken state.
- Route added as a member action on the `tasks` resource.

**`TaskDataShow#count` method**
- Computes the estimated item count by first trying the task's `#count` method, then falling back to `collection.count`.
- Returns `nil` for CSV tasks (collection depends on uploaded file content), deleted tasks, and when the query times out.
- Wrapped in a 15-second `Timeout` to prevent long-running count queries from blocking the endpoint.

**`TaskDataShow#no_collection?` method**
- New predicate to detect tasks that have no collection (e.g. one-off tasks). These tasks skip the count preview since the indicator is not meaningful.

**Frontend (show.html.erb)**
- Renders a `#task-count` div that starts with "Estimating expected items count..." placeholder text.
- Inline `<script>` fetches the count on page load and displays it as "**N** items expected to be processed".
- Listens on `focusout` and `change` events on the task form to re-fetch when parameters are modified.
- Hidden for deleted tasks, CSV tasks, and no-collection tasks.
- CSP updated with a new script hash for the inline script.

### How it looks

- **Task with collection**: Shows "**42** items expected to be processed" below the parameters form.
- **Task with parameters**: Count updates dynamically as parameters change (e.g. entering post IDs narrows the count).
- **CSV / no-collection / deleted tasks**: Count indicator is not shown.
- **Timeout or error**: Count indicator is silently hidden.

<img width="1422" height="729" alt="Screenshot 2026-02-12 at 2 56 16 PM" src="https://github.com/user-attachments/assets/8cbf5e5f-04e7-4f40-9614-9ade17f2ec6a" />

