### PR TITLE
Add support for instance-level throttles

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,28 @@ module Maintenance
 end
 ```
 
+If you want the throttle to change based on task attributes, you can define the
+`throttle_on` inside `#initialize`:
+
+```ruby
+# app/tasks/maintenance/update_posts_throttled_task.rb
+
+module Maintenance
+  class UpdatePostsThrottledTask < MaintenanceTasks::Task
+    attribute :throttle_backoff_seconds, :integer
+
+    def initialize(*)
+      super
+
+      throttle_on(backoff: throttle_backoff_seconds) do
+        DatabaseStatus.unhealthy?
+      end
+    end
+    # ...
+  end
+end
+```
+
 ### Custom Task Parameters
 
 Tasks may need additional information, supplied via parameters, to run.

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -17,7 +17,7 @@ module MaintenanceTasks
     # backoff. Note that Tasks inherit conditions from their superclasses.
     #
     # @api private
-    class_attribute :throttle_conditions, default: []
+    class_attribute :throttle_conditions, default: [], instance_reader: false
 
     # The number of active records to fetch in a single query when iterating
     # over an Active Record collection task.
@@ -330,6 +330,33 @@ module MaintenanceTasks
     # @return [Enumerator]
     def enumerator_builder(cursor:)
       nil
+    end
+
+    # Add a condition under which this Task instance will be throttled.
+    #
+    # @param backoff [ActiveSupport::Duration, #call] a custom backoff
+    #   can be specified. This is the time to wait before retrying the Task,
+    #   defaulting to 30 seconds. If provided as a Duration, the backoff is
+    #   wrapped in a proc. Alternatively,an object responding to call can be
+    #   used. It must return an ActiveSupport::Duration.
+    # @yieldreturn [Boolean] where the throttle condition is being met,
+    #   indicating that the Task should throttle.
+    def throttle_on(backoff: 30.seconds, &condition)
+      backoff_as_proc = backoff
+      backoff_as_proc = -> { backoff } unless backoff.respond_to?(:call)
+
+      @throttle_conditions ||= []
+      @throttle_conditions += [{ throttle_on: condition, backoff: backoff_as_proc }]
+    end
+
+    # The throttle conditions for a given Task instance. This is provided as
+    # an array of hashes, with each hash specifying two keys:
+    # throttle_condition and backoff. Note that Tasks inherit conditions from
+    # their superclasses.
+    #
+    # @api private
+    def throttle_conditions
+      self.class.throttle_conditions + (@throttle_conditions || [])
     end
   end
 end

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -113,6 +113,20 @@ module MaintenanceTasks
       Maintenance::TestTask.throttle_conditions = []
     end
 
+    test "#throttle_on registers throttle condition for Task" do
+      throttle_condition = -> { true }
+
+      task = Maintenance::TestTask.new
+      task.throttle_on(&throttle_condition)
+
+      task_throttle_conditions = task.throttle_conditions
+      assert_equal(1, task_throttle_conditions.size)
+
+      condition = task_throttle_conditions.first
+      assert_equal(throttle_condition, condition[:throttle_on])
+      assert_equal(30.seconds, condition[:backoff].call)
+    end
+
     test ".cursor_columns returns nil" do
       task = Task.new
       assert_nil task.cursor_columns


### PR DESCRIPTION
I've been trying to set up throttles for my maintenance tasks based on configurable values and it's pretty tricky to do in the current code. For instance, I want to be able to configure a database load threshold and tweak the backoff using an attribute. I'm also running the same maintenance task multiple times against different databases and I need different throttle parameters for each. Currently, throttles are set at the class level, so they can't vary per instance.

This PR adds support for per-instance throttles, using basically the same API as the current class-level throttles. Usage looks like:

```ruby
class MyMaintenanceTask < MaintenanceTasks::Task
  attribute :database, , inclusion: { in: DatabaseShards.all }
  attribute :throttle_db_load_limit, :integer, default: 16
  attribute :throttle_db_load_backoff, :integer, default: 3600

  def initialize(*)
    super

    throttle_on(backoff: throttle_db_load_backoff) do
      ApplicationRecord.connected_to(shard: database) do
        current_load >= throttle_db_load_limit
      end
    end
  end
end
```


The throttle conditions array is only accessed here via the instance, so I've just overridden this method:

https://github.com/Shopify/maintenance_tasks/blob/58e544a762cf3863839e4d7ee1d1ac54a3d37b00/app/jobs/concerns/maintenance_tasks/task_job_concern.rb#L98

Please let me know what you think. I'm happy to change things if you can think of a better way to achieve the outcomes I'm after.