### PR TITLE
Handle Task::NotFoundError with a 404 page instead of raising an error

### DIFF
--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -31,5 +31,9 @@ module MaintenanceTasks
     end
 
     protect_from_forgery with: :exception
+
+    rescue_from Task::NotFoundError do |error|
+      render("maintenance_tasks/not_found", status: :not_found)
+    end
   end
 end

--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -31,5 +31,9 @@ module MaintenanceTasks
     end
 
     protect_from_forgery with: :exception
+
+    rescue_from Task::NotFoundError do
+      render("maintenance_tasks/not_found", status: :not_found)
+    end
   end
 end

--- a/app/views/maintenance_tasks/not_found.html.erb
+++ b/app/views/maintenance_tasks/not_found.html.erb
@@ -1,0 +1,9 @@
+<% content_for :page_title, "Not Found" %>
+
+<div class="container has-text-centered">
+  <h1 class="title is-3 has-text-weight-bold">Task Not Found</h1>
+  <p class="subtitle is-5">The task you are looking for does not exist or has been deleted.</p>
+  <p>
+    <%= link_to "Back to Tasks", tasks_path, class: "button is-primary is-rounded" %>
+  </p>
+</div>

--- a/lib/maintenance_tasks/engine.rb
+++ b/lib/maintenance_tasks/engine.rb
@@ -32,9 +32,5 @@ module MaintenanceTasks
     config.after_initialize do
       JobIteration.max_job_runtime ||= 5.minutes
     end
-
-    config.action_dispatch.rescue_responses.merge!(
-      "MaintenanceTasks::Task::NotFoundError" => :not_found,
-    )
   end
 end

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -259,6 +259,15 @@ module MaintenanceTasks
       assert_button "Run", disabled: true
     end
 
+    test "show a not found Task" do
+      visit maintenance_tasks_path + "/tasks/Maintenance::DoesNotExist"
+
+      assert_title "Not Found"
+      assert_text "Task Not Found"
+      assert_text "The task you are looking for does not exist or has been deleted."
+      assert_link "Back to Tasks"
+    end
+
     test "visit main page through iframe" do
       visit root_path
 

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -263,6 +263,7 @@ module MaintenanceTasks
       visit maintenance_tasks_path + "/tasks/Maintenance::DoesNotExist"
 
       assert_title "Not Found"
+      assert_includes page.driver.browser.logs.get(:browser).sole.message, "404"
       assert_text "Task Not Found"
       assert_text "The task you are looking for does not exist or has been deleted."
       assert_link "Back to Tasks"

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -348,6 +348,16 @@ module MaintenanceTasks
       assert_button "Run", disabled: true
     end
 
+    test "show a not found Task" do
+      visit maintenance_tasks_path + "/tasks/Maintenance::DoesNotExist"
+
+      assert_title "Not Found"
+      assert_includes page.driver.browser.logs.get(:browser).sole.message, "404"
+      assert_text "Task Not Found"
+      assert_text "The task you are looking for does not exist or has been deleted."
+      assert_link "Back to Tasks"
+    end
+
     test "visit main page through iframe" do
       visit root_path
 


### PR DESCRIPTION
<img width="647" height="258" alt="deleted task" src="https://github.com/user-attachments/assets/d96f8535-0dfa-4ca7-83d8-6f4e75c7217b" />

- Add `rescue_from Task::NotFoundError` in `ApplicationController` to render a friendly 404 page when users access a task that no longer exists
- Create a dedicated not found view (`not_found.html.erb`) styled with Bulma to match the existing UI, with a link back to the tasks list
- Remove the `rescue_responses` mapping from `Engine` since the error is now handled directly by the controller

## Motivation

Maintenance tasks are short-lived by nature — they are created for one-time data migrations or cleanup operations and are expected to be deleted once they are no longer needed. However, users may still have bookmarked URLs or links in Slack/docs pointing to deleted tasks.

Previously, accessing a deleted task with no associated runs raised `MaintenanceTasks::Task::NotFoundError`, which:

1. Displayed an unfriendly error page to users
2. Was reported to error monitoring systems (e.g., Sentry) as an unhandled exception, creating noise

By using `rescue_from` in the controller, the exception is caught before it propagates to error monitoring middleware, and users see a clean 404 page with navigation back to the task list.
