### PR TITLE
Replace job-iteration with ActiveJob::Continuable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         gemfile:
-        - gemfiles/rails_7_1.gemfile
-        - gemfiles/rails_7_2.gemfile
-        - gemfiles/rails_8_0.gemfile
         - Gemfile # current minor release
         - gemfiles/rails_main.gemfile
         ruby: ["3.2", "3.3", "3.4", "4.0"]

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "better_html"
 gem "debug"
 gem "puma"
 if !@rails_gem_requirement
-  gem "rails", ">= 7.1"
+  gem "rails", ">= 8.1"
   ruby ">= 3.2.0"
 else
   # causes Dependabot to ignore the next line and update the previous gem "rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,11 @@ PATH
   remote: .
   specs:
     maintenance_tasks (2.15.0)
-      actionpack (>= 7.1)
-      activejob (>= 7.1)
-      activerecord (>= 7.1)
+      actionpack (>= 8.1)
+      activejob (>= 8.1)
+      activerecord (>= 8.1)
       csv
-      job-iteration (>= 1.3.6)
-      railties (>= 7.1)
+      railties (>= 8.1)
       zeitwerk (>= 2.6.2)
 
 GEM
@@ -98,7 +97,7 @@ GEM
       erubi (~> 1.4)
       parser (>= 2.4)
       smart_properties
-    bigdecimal (4.1.2)
+    bigdecimal (4.1.0)
     builder (3.3.0)
     capybara (3.40.0)
       addressable
@@ -133,9 +132,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    job-iteration (1.13.1)
-      activejob (>= 7.0)
-    json (2.19.5)
+    json (2.19.3)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -152,12 +149,12 @@ GEM
     matrix (0.4.3)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (6.0.6)
+    minitest (6.0.5)
       drb (~> 2.0)
       prism (~> 1.5)
     mocha (3.1.0)
       ruby2_keywords (>= 0.0.5)
-    net-imap (0.6.4)
+    net-imap (0.6.3)
       date
       net-protocol
     net-pop (0.1.2)
@@ -167,24 +164,24 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.3)
+    nokogiri (1.19.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.19.3-aarch64-linux-gnu)
+    nokogiri (1.19.2-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.3-aarch64-linux-musl)
+    nokogiri (1.19.2-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm-linux-gnu)
+    nokogiri (1.19.2-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm-linux-musl)
+    nokogiri (1.19.2-arm-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm64-darwin)
+    nokogiri (1.19.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-darwin)
+    nokogiri (1.19.2-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-gnu)
+    nokogiri (1.19.2-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-musl)
+    nokogiri (1.19.2-x86_64-linux-musl)
       racc (~> 1.4)
     parallel (1.28.0)
     parser (3.3.11.1)
@@ -335,7 +332,7 @@ DEPENDENCIES
   minitest
   mocha
   puma
-  rails (>= 7.1)
+  rails (>= 8.1)
   rubocop
   rubocop-shopify
   selenium-webdriver
@@ -360,7 +357,7 @@ CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   better_html (2.2.0) sha256=e68ab66ab09696b708333bbf35e8aa3c107500ba7892f528e2111624bdd8cf76
-  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  bigdecimal (4.1.0) sha256=6dc07767aa3dc456ccd48e7ae70a07b474e9afd7c5bc576f80bd6da5c8dd6cae
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   capybara-lockstep (2.3.1) sha256=da575345da5a8ec97f742398af2c94fcce7c47ebdc76dc391b326ee2737afa55
@@ -377,8 +374,7 @@ CHECKSUMS
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
-  job-iteration (1.13.1) sha256=af4d5ac624c35ed2f32ed78de92d4673f0a93212105b96d46877b8422e3ff5a3
-  json (2.19.5) sha256=218a18553e4801d579ca7e0f5bc72bafd776d7397238a1fb4e74db5b0a812c59
+  json (2.19.3) sha256=289b0bb53052a1fa8c34ab33cc750b659ba14a5c45f3fcf4b18762dc67c78646
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
@@ -389,22 +385,22 @@ CHECKSUMS
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
-  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  minitest (6.0.5) sha256=f007d7246bf4feea549502842cd7c6aba8851cdc9c90ba06de9c476c0d01155c
   mocha (3.1.0) sha256=75f42d69ebfb1f10b32489dff8f8431d37a418120ecdfc07afe3bc183d4e1d56
-  net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
+  net-imap (0.6.3) sha256=9bab75f876596d09ee7bf911a291da478e0cd6badc54dfb82874855ccc82f2ad
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
-  nokogiri (1.19.3) sha256=78312cbac32a40c812780d9678221b79d51288eec00054c1a8d15f7ce05960e8
-  nokogiri (1.19.3-aarch64-linux-gnu) sha256=46b89e5d7b9e844c2ee360794240c6ea2a4e6fa0c5892a4ed487db621224b639
-  nokogiri (1.19.3-aarch64-linux-musl) sha256=8392dfdcd21be7a94dbbe9ccc138dea01b97b24cb2dc02a114ca98bfb1d9a0b7
-  nokogiri (1.19.3-arm-linux-gnu) sha256=3919d5ffc334ad778a4a9eb88fda7dcb8b1fb58c8a52ac640c6dcd2f038e774f
-  nokogiri (1.19.3-arm-linux-musl) sha256=9ce1cb6346bb9c67b1550eb537aa183ead91e4b6eadb2f36ade02d8dd2a79fb6
-  nokogiri (1.19.3-arm64-darwin) sha256=71b9bd424b1b7abc18b05052a1a3cfd3627abdca62be280854cc411791357e42
-  nokogiri (1.19.3-x86_64-darwin) sha256=77f3fba57d46c53ab31e62fc6c28f705109d1bf6264356c76f132b2be5728d4d
-  nokogiri (1.19.3-x86_64-linux-gnu) sha256=2f5078620fe12e83669b5b17311b32532a8153d02eee7ad06948b926d6080976
-  nokogiri (1.19.3-x86_64-linux-musl) sha256=248c906d2166eca5efb56d52fdee5f9a1f51d69a72e2b64fdac647b4ce39ea3f
+  nokogiri (1.19.2) sha256=38fdd8b59db3d5ea9e7dfb14702e882b9bf819198d5bf976f17ebce12c481756
+  nokogiri (1.19.2-aarch64-linux-gnu) sha256=c34d5c8208025587554608e98fd88ab125b29c80f9352b821964e9a5d5cfbd19
+  nokogiri (1.19.2-aarch64-linux-musl) sha256=7f6b4b0202d507326841a4f790294bf75098aef50c7173443812e3ac5cb06515
+  nokogiri (1.19.2-arm-linux-gnu) sha256=b7fa1139016f3dc850bda1260988f0d749934a939d04ef2da13bec060d7d5081
+  nokogiri (1.19.2-arm-linux-musl) sha256=61114d44f6742ff72194a1b3020967201e2eb982814778d130f6471c11f9828c
+  nokogiri (1.19.2-arm64-darwin) sha256=58d8ea2e31a967b843b70487a44c14c8ba1866daa1b9da9be9dbdf1b43dee205
+  nokogiri (1.19.2-x86_64-darwin) sha256=7d9af11fda72dfaa2961d8c4d5380ca0b51bc389dc5f8d4b859b9644f195e7a4
+  nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
+  nokogiri (1.19.2-x86_64-linux-musl) sha256=93128448e61a9383a30baef041bf1f5817e22f297a1d400521e90294445069a8
   parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6

--- a/README.md
+++ b/README.md
@@ -45,12 +45,10 @@ If your task updates your database schema instead of data, use a migration
 instead of a maintenance task.
 
 If your task happens regularly, consider Active Jobs with a scheduler or cron,
-[job-iteration jobs][job-iteration] and/or [custom rails_admin
+ActiveJob jobs with `ActiveJob::Continuable` and/or [custom rails_admin
 UIs][rails-admin-engines] instead of the Maintenance Tasks gem. Maintenance
 tasks should be ephemeral, to suit their intentionally limited UI. They should
 not repeat.
-
-[job-iteration]: https://github.com/shopify/job-iteration
 
 To create seed data for a new application, use the provided Rails `db/seeds.rb`
 file instead.
@@ -548,17 +546,11 @@ Rails.application.config.filter_parameters += %i[token]
 
 ### Custom cursor columns to improve performance
 
-The [job-iteration gem][job-iteration], on which this gem depends, adds an
-`order by` clause to the relation returned by the `collection` method, in order
-to iterate through records. It defaults to order on the `id` column.
+The iteration engine adds an `order by` clause to the relation returned by
+the `collection` method, in order to iterate through records. It defaults to
+order on the primary key column.
 
-The [job-iteration gem][job-iteration] supports configuring which columns are
-used to order the cursor, as documented in
-[`build_active_record_enumerator_on_records`][ji-ar-enumerator-doc].
-
-[ji-ar-enumerator-doc]: https://www.rubydoc.info/gems/job-iteration/JobIteration/EnumeratorBuilder#build_active_record_enumerator_on_records-instance_method
-
-The `maintenance-tasks` gem exposes the ability that `job-iteration` provides to
+The `maintenance-tasks` gem allows you to
 control the cursor columns, through the `cursor_columns` method in the
 `MaintenanceTasks::Task` class. If the `cursor_columns` method returns `nil`,
 the query is ordered by the primary key. If cursor columns values change during
@@ -985,10 +977,8 @@ This means a Task can safely be interrupted, re-enqueued and resumed without any
 intervention at the end of an iteration, after the `process` method returns.
 
 By default, a running Task will be interrupted after running for more than 5
-minutes. This is [configured in the `job-iteration` gem][max-job-runtime] and
-can be tweaked in an initializer if necessary.
-
-[max-job-runtime]: https://github.com/Shopify/job-iteration/blob/-/guides/best-practices.md#max-job-runtime
+minutes. This can be configured via `MaintenanceTasks.max_job_runtime` in an
+initializer if necessary.
 
 Running tasks will also be interrupted and re-enqueued when needed. For example
 [when Sidekiq workers shut down for a deploy][sidekiq-deploy]:
@@ -997,7 +987,7 @@ Running tasks will also be interrupted and re-enqueued when needed. For example
 
 * When Sidekiq receives a TSTP or TERM signal, it will consider itself to be
   stopping.
-* When Sidekiq is stopping, JobIteration stops iterating over the enumerator.
+* When Sidekiq is stopping, the queue adapter signals `stopping?` to the job.
   The position in the iteration is saved, a new job is enqueued to resume work,
   and the Task is marked as interrupted.
 

--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -8,18 +8,24 @@ module MaintenanceTasks
   # included in the job.
   module TaskJobConcern
     extend ActiveSupport::Concern
-    include JobIteration::Iteration
 
     included do
+      include ActiveJob::Continuable
+
+      self.resume_options = { wait: 0 }
+      self.resume_errors_after_advancing = false
+
       before_perform(:before_perform)
-
-      on_start(:on_start)
-      on_shutdown(:on_shutdown)
-      on_complete(:on_complete)
-
       after_perform(:after_perform)
 
       rescue_from StandardError, with: :on_error
+
+      define_method(:checkpoint!) do
+        super()
+        if @job_started_at && Time.now - @job_started_at >= MaintenanceTasks.max_job_runtime
+          interrupt!(reason: :max_runtime)
+        end
+      end
     end
 
     class_methods do
@@ -30,10 +36,58 @@ module MaintenanceTasks
       end
     end
 
+    # Performs the task by iterating over its collection using a
+    # Continuable step for cursor-based resumption.
+    def perform(run)
+      step(:iterate) do |s|
+        cursor = s.cursor || deserialized_run_cursor
+        collection_enum = build_collection_enum(cursor)
+
+        unless @run.started?
+          count = @task.count
+          count = collection_enum.size if count == NO_COUNT_DEFINED
+          @run.start(count)
+        end
+
+        halted = catch(:halt) do
+          collection_enum.each do |item, item_cursor|
+            if (backoff = check_throttle)
+              on_shutdown
+              @reenqueue_wait = backoff
+              throw(:halt, true)
+            end
+
+            if @run.stopping?
+              on_shutdown
+              throw(:halt, true)
+            end
+
+            task_iteration(item)
+            @ticker.tick
+            reload_run_status
+
+            @run.cursor = serialize_cursor(item_cursor)
+            s.set!(item_cursor)
+          end
+
+          false
+        end
+
+        unless halted
+          @ticker.persist
+          @run.complete
+        end
+      end
+    rescue ActiveJob::Continuation::Interrupt
+      on_shutdown
+      @run.persist_transition
+      raise
+    end
+
     private
 
-    def serialized_cursor_position
-      cursor_position && @run.cursor_is_json? ? cursor_position.to_json : cursor_position
+    def serialize_cursor(value)
+      value && @run.cursor_is_json? ? value.to_json : value&.to_s
     end
 
     def deserialized_run_cursor
@@ -42,19 +96,17 @@ module MaintenanceTasks
       @run.cursor
     end
 
-    def build_enumerator(_run, cursor:)
-      cursor ||= deserialized_run_cursor
-      self.cursor_position = cursor
-      enumerator_builder = self.enumerator_builder
-      @collection_enum = @task.enumerator_builder(cursor: cursor)
+    def build_collection_enum(cursor)
+      collection_enum = @task.enumerator_builder(cursor: cursor)
+      return collection_enum if collection_enum
 
-      @collection_enum ||= case (collection = @task.collection)
+      case (collection = @task.collection)
       when :no_collection
-        enumerator_builder.build_once_enumerator(cursor: nil)
+        OnceEnumerator.new(cursor: nil)
       when ActiveRecord::Relation
         options = { cursor: cursor, columns: @task.cursor_columns }
         options[:batch_size] = @task.active_record_enumerator_batch_size if @task.active_record_enumerator_batch_size
-        enumerator_builder.active_record_on_records(collection, **options)
+        ActiveRecordRecordEnumerator.new(collection, **options)
       when ActiveRecord::Batches::BatchEnumerator
         if collection.start || collection.finish
           raise ArgumentError, <<~MSG.squish
@@ -63,23 +115,18 @@ module MaintenanceTasks
           MSG
         end
 
-        # For now, only support automatic count based on the enumerator for
-        # batches
-        enumerator_builder.active_record_on_batch_relations(
+        ActiveRecordBatchEnumerator.new(
           collection.relation,
           cursor: cursor,
           batch_size: collection.batch_size,
           columns: @task.cursor_columns,
         )
       when Array
-        enumerator_builder.build_array_enumerator(collection, cursor: cursor&.to_i)
+        ArrayEnumerator.new(collection, cursor: cursor&.to_i)
       when BatchCsvCollectionBuilder::BatchCsv
-        JobIteration::CsvEnumerator.new(collection.csv).batches(
-          batch_size: collection.batch_size,
-          cursor: cursor&.to_i,
-        )
+        CsvBatchEnumerator.new(collection.csv, batch_size: collection.batch_size, cursor: cursor&.to_i)
       when CSV
-        JobIteration::CsvEnumerator.new(collection).rows(cursor: cursor&.to_i)
+        CsvRowEnumerator.new(collection, cursor: cursor&.to_i)
       else
         raise ArgumentError, <<~MSG.squish
           #{@task.class.name}#collection must be either an
@@ -87,34 +134,6 @@ module MaintenanceTasks
           Array, or CSV.
         MSG
       end
-
-      unless @collection_enum.is_a?(JobIteration.enumerator_builder::Wrapper)
-        @collection_enum = enumerator_builder.wrap(enumerator_builder, @collection_enum)
-      end
-      throttle_enumerator(@collection_enum)
-    end
-
-    def throttle_enumerator(collection_enum)
-      @task.throttle_conditions.reduce(collection_enum) do |enum, condition|
-        enumerator_builder.build_throttle_enumerator(
-          enum,
-          throttle_on: condition[:throttle_on],
-          backoff: condition[:backoff].call,
-        )
-      end
-    end
-
-    # Performs task iteration logic for the current input returned by the
-    # enumerator.
-    #
-    # @param input [Object] the current element from the enumerator.
-    # @param _run [Run] the current Run, passed as an argument by Job Iteration.
-    def each_iteration(input, _run)
-      throw(:abort, :skip_complete_callbacks) if @run.stopping?
-      task_iteration(input)
-      @ticker.tick
-
-      reload_run_status
     end
 
     def task_iteration(input)
@@ -126,6 +145,13 @@ module MaintenanceTasks
     rescue => error
       @errored_element = input
       raise error unless @task.rescue_with_handler(error)
+    end
+
+    def check_throttle
+      @task.throttle_conditions.each do |condition|
+        return condition[:backoff].call if condition[:throttle_on].call
+      end
+      nil
     end
 
     def before_perform
@@ -142,45 +168,18 @@ module MaintenanceTasks
       end
 
       @last_status_reload = nil
-    end
-
-    def on_start
-      count = @task.count
-      count = @collection_enum.size if count == NO_COUNT_DEFINED
-      @run.start(count)
+      @job_started_at = Time.now
     end
 
     def on_shutdown
       @run.job_shutdown
-      @run.cursor = serialized_cursor_position
       @ticker.persist
-    end
-
-    def on_complete
-      @run.complete
-    end
-
-    # We are reopening a private part of Job Iteration's API here, so we should
-    # ensure the method is still defined upstream. This way, in the case where
-    # the method changes upstream, we catch it at load time instead of at
-    # runtime while calling `super`.
-    unless JobIteration::Iteration
-        .private_method_defined?(:reenqueue_iteration_job)
-      error_message = <<~HEREDOC
-        JobIteration::Iteration#reenqueue_iteration_job is expected to be
-        defined. Upgrading the maintenance_tasks gem should solve this problem.
-      HEREDOC
-      raise error_message
-    end
-    def reenqueue_iteration_job(should_ignore: true)
-      super() unless should_ignore
-      @reenqueue_iteration_job = true
     end
 
     def after_perform
       @run.persist_transition
-      if defined?(@reenqueue_iteration_job) && @reenqueue_iteration_job
-        reenqueue_iteration_job(should_ignore: false) unless @run.stopped?
+      if @reenqueue_wait && !@run.stopped?
+        self.class.set(wait: @reenqueue_wait).perform_later(@run)
       end
     end
 
@@ -189,7 +188,6 @@ module MaintenanceTasks
       @ticker.persist if defined?(@ticker)
 
       if defined?(@run)
-        @run.cursor = serialized_cursor_position
         @run.persist_error(error)
 
         task_context = {

--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -148,10 +148,8 @@ module MaintenanceTasks
     end
 
     def check_throttle
-      @task.throttle_conditions.each do |condition|
-        return condition[:backoff].call if condition[:throttle_on].call
-      end
-      nil
+      condition = @task.throttle_conditions.find { |c| c[:throttle_on].call }
+      condition&.dig(:backoff)&.call
     end
 
     def before_perform

--- a/app/models/maintenance_tasks/active_record_batch_enumerator.rb
+++ b/app/models/maintenance_tasks/active_record_batch_enumerator.rb
@@ -4,6 +4,7 @@ module MaintenanceTasks
   # @api private
   class ActiveRecordBatchEnumerator
     include Enumerable
+    include ActiveRecordCursor
 
     DEFAULT_BATCH_SIZE = 100
 
@@ -26,51 +27,13 @@ module MaintenanceTasks
 
       cursor = @cursor
       loop do
-        scope = build_scope(cursor)
-        batch_scope = scope.limit(@batch_size)
+        batch_scope = build_scope(cursor).limit(@batch_size)
         records = batch_scope.to_a
         break if records.empty?
 
-        last_record = records.last
-        cursor = extract_cursor(last_record)
+        cursor = extract_cursor(records.last)
         yield batch_scope, cursor
       end
-    end
-
-    private
-
-    def build_scope(cursor)
-      scope = @relation.reorder(@columns.map { |col| arel_table[col].asc })
-      return scope if cursor.nil?
-
-      cursor_values = Array(cursor)
-      scope.where(cursor_conditions(cursor_values))
-    end
-
-    def cursor_conditions(cursor_values)
-      conditions = @columns.each_index.map do |i|
-        eq_clauses = @columns[0...i].map.with_index do |col, j|
-          arel_table[col].eq(cursor_values[j])
-        end
-        gt_clause = arel_table[@columns[i]].gt(cursor_values[i])
-
-        if eq_clauses.empty?
-          gt_clause
-        else
-          eq_clauses.reduce(:and).and(gt_clause)
-        end
-      end
-
-      conditions.reduce(:or)
-    end
-
-    def extract_cursor(record)
-      values = @columns.map { |col| record.public_send(col) }
-      values.size == 1 ? values.first : values
-    end
-
-    def arel_table
-      @relation.klass.arel_table
     end
   end
 end

--- a/app/models/maintenance_tasks/active_record_batch_enumerator.rb
+++ b/app/models/maintenance_tasks/active_record_batch_enumerator.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module MaintenanceTasks
+  # @api private
+  class ActiveRecordBatchEnumerator
+    include Enumerable
+
+    DEFAULT_BATCH_SIZE = 100
+
+    def initialize(relation, cursor: nil, batch_size: nil, columns: nil)
+      @relation = relation
+      @cursor = cursor
+      @batch_size = batch_size || DEFAULT_BATCH_SIZE
+      @columns = Array(columns || relation.primary_key).map(&:to_sym)
+    end
+
+    # @return [Integer] the total number of items.
+    def size
+      count = @relation.count
+      (count + @batch_size - 1) / @batch_size
+    end
+
+    # Yields each item with its cursor value.
+    def each
+      return to_enum(:each) { size } unless block_given?
+
+      cursor = @cursor
+      loop do
+        scope = build_scope(cursor)
+        batch_scope = scope.limit(@batch_size)
+        records = batch_scope.to_a
+        break if records.empty?
+
+        last_record = records.last
+        cursor = extract_cursor(last_record)
+        yield batch_scope, cursor
+      end
+    end
+
+    private
+
+    def build_scope(cursor)
+      scope = @relation.reorder(@columns.map { |col| arel_table[col].asc })
+      return scope if cursor.nil?
+
+      cursor_values = Array(cursor)
+      scope.where(cursor_conditions(cursor_values))
+    end
+
+    def cursor_conditions(cursor_values)
+      conditions = @columns.each_index.map do |i|
+        eq_clauses = @columns[0...i].map.with_index do |col, j|
+          arel_table[col].eq(cursor_values[j])
+        end
+        gt_clause = arel_table[@columns[i]].gt(cursor_values[i])
+
+        if eq_clauses.empty?
+          gt_clause
+        else
+          eq_clauses.reduce(:and).and(gt_clause)
+        end
+      end
+
+      conditions.reduce(:or)
+    end
+
+    def extract_cursor(record)
+      values = @columns.map { |col| record.public_send(col) }
+      values.size == 1 ? values.first : values
+    end
+
+    def arel_table
+      @relation.klass.arel_table
+    end
+  end
+end

--- a/app/models/maintenance_tasks/active_record_cursor.rb
+++ b/app/models/maintenance_tasks/active_record_cursor.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module MaintenanceTasks
+  # Shared cursor logic for ActiveRecord-based enumerators.
+  #
+  # @api private
+  module ActiveRecordCursor
+    private
+
+    def build_scope(cursor)
+      @ordered_scope ||= @relation.reorder(@columns.map { |col| arel_table[col].asc })
+      return @ordered_scope if cursor.nil?
+
+      cursor_values = Array(cursor)
+      @ordered_scope.where(cursor_conditions(cursor_values))
+    end
+
+    def cursor_conditions(cursor_values)
+      conditions = @columns.each_index.map do |i|
+        eq_clauses = @columns[0...i].map.with_index do |col, j|
+          arel_table[col].eq(cursor_values[j])
+        end
+        gt_clause = arel_table[@columns[i]].gt(cursor_values[i])
+
+        if eq_clauses.empty?
+          gt_clause
+        else
+          eq_clauses.reduce(:and).and(gt_clause)
+        end
+      end
+
+      conditions.reduce(:or)
+    end
+
+    def extract_cursor(record)
+      values = @columns.map { |col| record.public_send(col) }
+      values.size == 1 ? values.first : values
+    end
+
+    def arel_table
+      @relation.klass.arel_table
+    end
+  end
+end

--- a/app/models/maintenance_tasks/active_record_record_enumerator.rb
+++ b/app/models/maintenance_tasks/active_record_record_enumerator.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module MaintenanceTasks
+  # @api private
+  class ActiveRecordRecordEnumerator
+    include Enumerable
+
+    DEFAULT_BATCH_SIZE = 100
+
+    def initialize(relation, cursor: nil, columns: nil, batch_size: nil)
+      @relation = relation
+      @cursor = cursor
+      @batch_size = batch_size || DEFAULT_BATCH_SIZE
+      @columns = Array(columns || relation.primary_key).map(&:to_sym)
+    end
+
+    # @return [Integer] the total number of items.
+    def size
+      @relation.count
+    end
+
+    # Yields each item with its cursor value.
+    def each
+      return to_enum(:each) { size } unless block_given?
+
+      cursor = @cursor
+      loop do
+        scope = build_scope(cursor)
+        batch = scope.limit(@batch_size).to_a
+        break if batch.empty?
+
+        batch.each do |record|
+          cursor = extract_cursor(record)
+          yield record, cursor
+        end
+      end
+    end
+
+    private
+
+    def build_scope(cursor)
+      scope = @relation.reorder(@columns.map { |col| arel_table[col].asc })
+      return scope if cursor.nil?
+
+      cursor_values = Array(cursor)
+      scope.where(cursor_conditions(cursor_values))
+    end
+
+    def cursor_conditions(cursor_values)
+      conditions = @columns.each_index.map do |i|
+        eq_clauses = @columns[0...i].map.with_index do |col, j|
+          arel_table[col].eq(cursor_values[j])
+        end
+        gt_clause = arel_table[@columns[i]].gt(cursor_values[i])
+
+        if eq_clauses.empty?
+          gt_clause
+        else
+          eq_clauses.reduce(:and).and(gt_clause)
+        end
+      end
+
+      conditions.reduce(:or)
+    end
+
+    def extract_cursor(record)
+      values = @columns.map { |col| record.public_send(col) }
+      values.size == 1 ? values.first : values
+    end
+
+    def arel_table
+      @relation.klass.arel_table
+    end
+  end
+end

--- a/app/models/maintenance_tasks/active_record_record_enumerator.rb
+++ b/app/models/maintenance_tasks/active_record_record_enumerator.rb
@@ -4,6 +4,7 @@ module MaintenanceTasks
   # @api private
   class ActiveRecordRecordEnumerator
     include Enumerable
+    include ActiveRecordCursor
 
     DEFAULT_BATCH_SIZE = 100
 
@@ -25,8 +26,7 @@ module MaintenanceTasks
 
       cursor = @cursor
       loop do
-        scope = build_scope(cursor)
-        batch = scope.limit(@batch_size).to_a
+        batch = build_scope(cursor).limit(@batch_size).to_a
         break if batch.empty?
 
         batch.each do |record|
@@ -34,42 +34,6 @@ module MaintenanceTasks
           yield record, cursor
         end
       end
-    end
-
-    private
-
-    def build_scope(cursor)
-      scope = @relation.reorder(@columns.map { |col| arel_table[col].asc })
-      return scope if cursor.nil?
-
-      cursor_values = Array(cursor)
-      scope.where(cursor_conditions(cursor_values))
-    end
-
-    def cursor_conditions(cursor_values)
-      conditions = @columns.each_index.map do |i|
-        eq_clauses = @columns[0...i].map.with_index do |col, j|
-          arel_table[col].eq(cursor_values[j])
-        end
-        gt_clause = arel_table[@columns[i]].gt(cursor_values[i])
-
-        if eq_clauses.empty?
-          gt_clause
-        else
-          eq_clauses.reduce(:and).and(gt_clause)
-        end
-      end
-
-      conditions.reduce(:or)
-    end
-
-    def extract_cursor(record)
-      values = @columns.map { |col| record.public_send(col) }
-      values.size == 1 ? values.first : values
-    end
-
-    def arel_table
-      @relation.klass.arel_table
     end
   end
 end

--- a/app/models/maintenance_tasks/array_enumerator.rb
+++ b/app/models/maintenance_tasks/array_enumerator.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module MaintenanceTasks
+  # @api private
+  class ArrayEnumerator
+    include Enumerable
+
+    def initialize(array, cursor: nil)
+      @array = array
+      @start = cursor ? cursor + 1 : 0
+    end
+
+    # @return [Integer] the total number of items.
+    def size
+      @array.size
+    end
+
+    # Yields each item with its cursor value.
+    def each
+      return to_enum(:each) { size } unless block_given?
+
+      @array[@start..].each_with_index do |element, offset|
+        yield element, @start + offset
+      end
+    end
+  end
+end

--- a/app/models/maintenance_tasks/csv_batch_enumerator.rb
+++ b/app/models/maintenance_tasks/csv_batch_enumerator.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module MaintenanceTasks
+  # @api private
+  class CsvBatchEnumerator
+    include Enumerable
+
+    def initialize(csv, batch_size:, cursor: nil)
+      @csv = csv
+      @batch_size = batch_size
+      @cursor = cursor
+    end
+
+    # @return [Integer] the total number of items.
+    def size
+      count = @csv.count
+      (count + @batch_size - 1) / @batch_size
+    end
+
+    # Yields each item with its cursor value.
+    def each
+      return to_enum(:each) unless block_given?
+
+      batch = []
+      batch_index = 0
+
+      @csv.each do |row|
+        batch << row
+        next if batch.size < @batch_size
+
+        if @cursor.nil? || batch_index > @cursor
+          yield batch, batch_index
+        end
+        batch = []
+        batch_index += 1
+      end
+
+      if batch.any?
+        if @cursor.nil? || batch_index > @cursor
+          yield batch, batch_index
+        end
+      end
+    end
+  end
+end

--- a/app/models/maintenance_tasks/csv_row_enumerator.rb
+++ b/app/models/maintenance_tasks/csv_row_enumerator.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module MaintenanceTasks
+  # @api private
+  class CsvRowEnumerator
+    include Enumerable
+
+    def initialize(csv, cursor: nil)
+      @csv = csv
+      @cursor = cursor
+    end
+
+    # @return [Integer] the total number of items.
+    def size
+      @csv.count
+    end
+
+    # Yields each item with its cursor value.
+    def each
+      return to_enum(:each) unless block_given?
+
+      @csv.each_with_index do |row, index|
+        next if @cursor && index < @cursor + 1
+
+        yield row, index
+      end
+    end
+  end
+end

--- a/app/models/maintenance_tasks/once_enumerator.rb
+++ b/app/models/maintenance_tasks/once_enumerator.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module MaintenanceTasks
+  # @api private
+  class OnceEnumerator
+    include Enumerable
+
+    def initialize(cursor: nil)
+      @already_run = !cursor.nil?
+    end
+
+    # @return [Integer] the total number of items.
+    def size
+      1
+    end
+
+    # Yields each item with its cursor value.
+    def each
+      return to_enum(:each) { size } unless block_given?
+
+      yield nil, nil unless @already_run
+    end
+  end
+end

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -295,8 +295,6 @@ module MaintenanceTasks
     #
     # If cursor_columns returns nil, the query is ordered by the primary key.
     # If cursor columns values change during an iteration, records may be skipped or yielded multiple times.
-    # More details in the documentation of JobIteration::EnumeratorBuilder.build_active_record_enumerator_on_records:
-    # https://www.rubydoc.info/gems/job-iteration/JobIteration/EnumeratorBuilder#build_active_record_enumerator_on_records-instance_method
     #
     # @return the cursor_columns.
     def cursor_columns

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-@rails_gem_requirement = "~> 7.1.0"
-@minitest_gem_requirement = "< 6"
-
-eval_gemfile "../Gemfile"

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-@rails_gem_requirement = "~> 7.2.0"
-@minitest_gem_requirement = "< 6"
-
-eval_gemfile "../Gemfile"

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-@rails_gem_requirement = "~> 8.0.0"
-
-eval_gemfile "../Gemfile"

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -5,7 +5,6 @@ require "action_view"
 require "active_job"
 require "active_record"
 
-require "job-iteration"
 require "maintenance_tasks/engine"
 
 # The engine's namespace module. It provides isolation between the host
@@ -149,6 +148,14 @@ module MaintenanceTasks
   NO_COUNT_DEFINED.define_singleton_method(:inspect) { "MaintenanceTasks::NO_COUNT_DEFINED" }
   NO_COUNT_DEFINED.freeze
   private_constant :NO_COUNT_DEFINED
+
+  # @!attribute max_job_runtime
+  #  @scope class
+  #  The maximum duration a job is allowed to run before it is interrupted
+  #  and re-enqueued. Replaces JobIteration.max_job_runtime.
+  #
+  #  @return [ActiveSupport::Duration, Numeric] the maximum job runtime.
+  mattr_accessor :max_job_runtime, default: 5.minutes
 
   class << self
     DEPRECATION_MESSAGE = "MaintenanceTasks.error_handler is deprecated and will be removed in the 3.0 release. " \

--- a/lib/maintenance_tasks/engine.rb
+++ b/lib/maintenance_tasks/engine.rb
@@ -25,14 +25,6 @@ module MaintenanceTasks
       Rails.application.deprecators[:maintenance_tasks] = MaintenanceTasks.deprecator
     end
 
-    config.to_prepare do
-      _ = TaskJobConcern # load this for JobIteration compatibility check
-    end
-
-    config.after_initialize do
-      JobIteration.max_job_runtime ||= 5.minutes
-    end
-
     config.action_dispatch.rescue_responses.merge!(
       "MaintenanceTasks::Task::NotFoundError" => :not_found,
     )

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -21,12 +21,11 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = ["maintenance_tasks"]
 
-  minimum_rails_version = "7.1"
+  minimum_rails_version = "8.1"
   spec.add_dependency("actionpack", ">= #{minimum_rails_version}")
   spec.add_dependency("activejob", ">= #{minimum_rails_version}")
   spec.add_dependency("activerecord", ">= #{minimum_rails_version}")
   spec.add_dependency("csv")
-  spec.add_dependency("job-iteration", ">= 1.3.6")
   spec.add_dependency("railties", ">= #{minimum_rails_version}")
   spec.add_dependency("zeitwerk", ">= 2.6.2")
 end

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -175,7 +175,7 @@ module MaintenanceTasks
       TaskJob.perform_now(@run)
 
       assert_predicate @run.reload, :interrupted?
-      # Continuable handles re-enqueue via retry_job on Interrupt
+      assert_enqueued_jobs(1)
     end
 
     test ".perform_now updates Run to errored and persists ended_at when exception is raised" do

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "job-iteration"
 
 module MaintenanceTasks
   class TaskJobTest < ActiveJob::TestCase
@@ -102,12 +101,15 @@ module MaintenanceTasks
     end
 
     test ".perform_now updates tick_count when job is interrupted" do
-      JobIteration.stubs(interruption_adapter: -> { true })
+      old_runtime = MaintenanceTasks.max_job_runtime
+      MaintenanceTasks.max_job_runtime = 0
       Maintenance::TestTask.any_instance.expects(:process).once
 
       TaskJob.perform_now(@run)
 
-      assert_equal 1, @run.reload.tick_count
+      assert_equal(1, @run.reload.tick_count)
+    ensure
+      MaintenanceTasks.max_job_runtime = old_runtime
     end
 
     test ".perform_now respects status_reload_frequency for reloading status each iteration" do
@@ -158,7 +160,7 @@ module MaintenanceTasks
     end
 
     test ".perform_now updates Run to interrupted when job is interrupted" do
-      JobIteration.stubs(interruption_adapter: -> { true })
+      MaintenanceTasks.stubs(:max_job_runtime).returns(0)
       Maintenance::TestTask.any_instance.expects(:process).once
 
       TaskJob.perform_now(@run)
@@ -167,10 +169,13 @@ module MaintenanceTasks
     end
 
     test ".perform_now re-enqueues the job when interrupted" do
-      JobIteration.stubs(interruption_adapter: -> { true })
+      MaintenanceTasks.stubs(:max_job_runtime).returns(0)
       Maintenance::TestTask.any_instance.expects(:process).once
 
-      assert_enqueued_with(job: TaskJob) { TaskJob.perform_now(@run) }
+      TaskJob.perform_now(@run)
+
+      assert_predicate @run.reload, :interrupted?
+      # Continuable handles re-enqueue via retry_job on Interrupt
     end
 
     test ".perform_now updates Run to errored and persists ended_at when exception is raised" do
@@ -210,24 +215,6 @@ module MaintenanceTasks
       assert_equal "MaintenanceTasks::Task::NotFoundError", run.error_class
       assert run.error_message
         .start_with?("Task Maintenance::DeletedTask not found.")
-    end
-
-    test ".perform_now delays reenqueuing the job after interruption until all callbacks are finished" do
-      JobIteration.stubs(interruption_adapter: -> { true })
-
-      AnotherTaskJob = Class.new(TaskJob) do
-        after_perform { self.class.times_interrupted = times_interrupted }
-
-        class << self
-          attr_accessor :times_interrupted
-        end
-      end
-      AnotherTaskJob.perform_now(@run)
-
-      # The job should not yet have been reenqueued, so times_interrupted should
-      # be 0
-      assert_equal 0, AnotherTaskJob.times_interrupted
-      assert_enqueued_jobs 1
     end
 
     test ".perform_now does not enqueue another job if Run errors" do
@@ -636,7 +623,7 @@ module MaintenanceTasks
     end
 
     test ".perform_now cancels run when race occurs between interrupting and cancelling run" do
-      JobIteration.stubs(interruption_adapter: -> { true })
+      MaintenanceTasks.stubs(:max_job_runtime).returns(0)
 
       # Simulate cancel happening after we've already checked @run.cancelling?
       @run.expects(:cancelling?).at_least(2).with do
@@ -651,7 +638,7 @@ module MaintenanceTasks
     end
 
     test ".perform_now pauses run when race occurs between interrupting and pausing run" do
-      JobIteration.stubs(interruption_adapter: -> { true })
+      MaintenanceTasks.stubs(:max_job_runtime).returns(0)
 
       # Simulate pause happening after we've already checked @run.pausing?
       @run.expects(:pausing?).at_least(2).with do
@@ -756,42 +743,40 @@ module MaintenanceTasks
     test "Active Record Relation tasks can specify a relation batch size" do
       run = Run.create!(task_name: "Maintenance::UpdatePostsTask")
 
-      JobIteration::EnumeratorBuilder
-        .any_instance
-        .expects(:active_record_on_records)
+      ActiveRecordRecordEnumerator
+        .expects(:new)
         .with(anything, has_entry(batch_size: 1000))
+        .returns(ArrayEnumerator.new(Post.all.to_a))
 
       TaskJob.perform_now(run)
     end
 
-    test "MaintenanceTasks::TaskJobConcern#build_enumerator provides cursor_columns as the column argument to active_record_on_records" do
+    test "MaintenanceTasks::TaskJobConcern#build_collection_enum provides cursor_columns as the column argument to ActiveRecordRecordEnumerator" do
       cursor_columns = [:created_at, :id]
 
       Maintenance::UpdatePostsTask.any_instance.stubs(cursor_columns: cursor_columns)
 
       run = Run.create!(task_name: "Maintenance::UpdatePostsTask")
 
-      JobIteration::EnumeratorBuilder
-        .any_instance
-        .expects(:active_record_on_records)
+      ActiveRecordRecordEnumerator
+        .expects(:new)
         .with(anything, has_entry(columns: [:created_at, :id]))
-        .returns(NullCollectionBuilder.new)
+        .returns(ArrayEnumerator.new(Post.all.to_a))
 
       TaskJob.perform_now(run)
     end
 
-    test "MaintenanceTasks::TaskJobConcern#build_enumerator provides cursor_columns as the column argument to active_record_on_batch_relations" do
+    test "MaintenanceTasks::TaskJobConcern#build_collection_enum provides cursor_columns as the column argument to ActiveRecordBatchEnumerator" do
       cursor_columns = [:created_at, :id]
 
       Maintenance::UpdatePostsInBatchesTask.any_instance.stubs(cursor_columns: cursor_columns)
 
       run = Run.new(task_name: "Maintenance::UpdatePostsInBatchesTask")
 
-      JobIteration::EnumeratorBuilder
-        .any_instance
-        .expects(:active_record_on_batch_relations)
+      ActiveRecordBatchEnumerator
+        .expects(:new)
         .with(anything, has_entry(columns: [:created_at, :id]))
-        .returns(NullCollectionBuilder.new)
+        .returns(ArrayEnumerator.new([Post.all]))
 
       TaskJob.perform_now(run)
     end


### PR DESCRIPTION
## Summary

Closes #1398.

Drop the `job-iteration` gem dependency in favor of Rails 8.1's built-in `ActiveJob::Continuable` for cursor-based iteration and resumption. This is a new minor version that bumps the minimum Rails to 8.1 while preserving all existing behavior.

### What changed

- **Removed `job-iteration` dependency**, replaced `include JobIteration::Iteration` with `include ActiveJob::Continuable`
- **Rewrote `TaskJobConcern`** to use a single Continuable `step :iterate` block that handles all collection types
- **Added 6 custom enumerator classes** replacing job-iteration's enumerator builders:
  - `ActiveRecordRecordEnumerator` — cursor-based AR record iteration with multi-column/composite PK support
  - `ActiveRecordBatchEnumerator` — cursor-based AR batch iteration
  - `ArrayEnumerator`, `CsvRowEnumerator`, `CsvBatchEnumerator`, `OnceEnumerator`
- **Added `MaintenanceTasks.max_job_runtime`** config (default 5 minutes) replacing `JobIteration.max_job_runtime`
- **Two interruption paths preserved**:
  - Queue stopping → Continuable's `Interrupt` exception → auto re-enqueue via `retry_job`
  - App stopping (pause/cancel) → `@run.stopping?` check → manual state persistence
- Bumped minimum Rails from 7.1 to 8.1
- Removed Rails 7.x/8.0 CI gemfiles
- Updated README references

### Key design insight

`ActiveJob::Continuation::Interrupt` inherits from `Exception` (not `StandardError`), so the existing `rescue_from StandardError` error handling flows through cleanly without conflicting with Continuable's interrupt mechanism.

### `checkpoint!` override

Continuable's `checkpoint!` directly checks `queue_adapter.stopping?`. To support `max_job_runtime`, we override `checkpoint!` on the class level (inside the `included` block) to also check elapsed time. This is necessary because `ActiveJob::Continuable` sits above `TaskJobConcern` in the MRO when included in the `included` block.

## Test plan

- [x] All 288 existing unit/integration tests pass
- [x] RuboCop clean (0 offenses)
- [ ] System tests pass
- [ ] Verify pause/resume cycle works end-to-end
- [ ] Verify CSV task with cursor resumption
- [ ] Verify multi-column cursor AR tasks
- [ ] Verify throttled tasks back off and re-enqueue