### PR TITLE
Don't use symbol to denote absence of count method

### DIFF
--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -146,7 +146,7 @@ module MaintenanceTasks
 
     def on_start
       count = @task.count
-      count = @collection_enum.size if count == :no_count
+      count = @collection_enum.size if count == NO_COUNT_DEFINED
       @run.start(count)
     end
 

--- a/app/models/maintenance_tasks/null_collection_builder.rb
+++ b/app/models/maintenance_tasks/null_collection_builder.rb
@@ -22,7 +22,7 @@ module MaintenanceTasks
     #
     # @return [Integer, nil]
     def count(task)
-      :no_count
+      NO_COUNT_DEFINED
     end
 
     # Return that the Task does not process CSV content.

--- a/lib/maintenance_tasks.rb
+++ b/lib/maintenance_tasks.rb
@@ -145,6 +145,11 @@ module MaintenanceTasks
   #  @return [ActiveSupport::Duration, false] time interval after which a task is considered stale.
   mattr_accessor :task_staleness_threshold, default: 30.days
 
+  NO_COUNT_DEFINED = Object.new
+  NO_COUNT_DEFINED.define_singleton_method(:inspect) { "MaintenanceTasks::NO_COUNT_DEFINED" }
+  NO_COUNT_DEFINED.freeze
+  private_constant :NO_COUNT_DEFINED
+
   class << self
     DEPRECATION_MESSAGE = "MaintenanceTasks.error_handler is deprecated and will be removed in the 3.0 release. " \
       "Instead, reports will be sent to the Rails error reporter. Do not set a handler and subscribe " \

--- a/test/dummy/app/tasks/maintenance/test_task.rb
+++ b/test/dummy/app/tasks/maintenance/test_task.rb
@@ -6,6 +6,10 @@ module Maintenance
       [1, 2]
     end
 
+    def count
+      2
+    end
+
     def process(number)
       Rails.logger.debug("number: #{number}")
     end

--- a/test/models/maintenance_tasks/null_collection_builder_test.rb
+++ b/test/models/maintenance_tasks/null_collection_builder_test.rb
@@ -16,7 +16,7 @@ module MaintenanceTasks
     end
 
     test "count" do
-      assert_equal(:no_count, @builder.count(@task))
+      assert_equal(NO_COUNT_DEFINED, @builder.count(@task))
     end
 
     test "#has_csv_content?" do

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -75,12 +75,12 @@ module MaintenanceTasks
     end
 
     test ".count calls #count" do
-      assert_equal :no_count, Maintenance::TestTask.count
+      assert_equal 2, Maintenance::TestTask.count
     end
 
     test "#count is :no_count by default" do
       task = Task.new
-      assert_equal(:no_count, task.count)
+      assert_equal NO_COUNT_DEFINED, task.count
     end
 
     test "#collection raises NoMethodError" do


### PR DESCRIPTION
LLMs [apparently assume](https://github.com/Shopify/maintenance_tasks/pull/1463#issuecomment-4371222403) `:no_count` means the Task shouldn't try to calculate the total number of ticks, but it's actually the opposite, :no_count means no explicit count method has been defined, and the total number of ticks should be computed (possibly with an expensive query or processing).

This was always meant as an internal sentinel value, and it shouldn't be used by application code.

This switches to an sentinel value stored in a private constant, which thanks to nested modules is easily accessible, but not so from application code.