### PR TITLE
Sort tasks by most recent run first

### DIFF
--- a/app/models/maintenance_tasks/task_data_index.rb
+++ b/app/models/maintenance_tasks/task_data_index.rb
@@ -15,7 +15,9 @@ module MaintenanceTasks
       # Returns a list of sorted Task Data objects that represent the
       # available Tasks.
       #
-      # Tasks are sorted by category, and within a category, by Task name.
+      # Tasks are sorted by category, and within a category, by the most
+      # recent Run's creation time (most recent first). New tasks with no
+      # Run history fall back to alphabetical order by name.
       # Determining a Task's category requires their latest Run records.
       # Two queries are done to get the currently active and completed Run
       # records, and Task Data instances are initialized with these related run
@@ -41,10 +43,13 @@ module MaintenanceTasks
           tasks << TaskDataIndex.new(task_name, last_run)
         end
 
-        # We add an additional sorting key (status) to avoid possible
-        # inconsistencies across database adapters when a Task has
-        # multiple active Runs.
-        tasks.sort_by! { |task| [task.name, task.status] }
+        # Most-recent-first by Run creation time; new tasks (no Run) sort
+        # together by name. Status is a final tiebreaker to keep ordering
+        # stable across database adapters when a Task has multiple active
+        # Runs created at the same time.
+        tasks.sort_by! do |task|
+          [-(task.related_run&.created_at&.to_f || 0), task.name, task.status]
+        end
       end
     end
 

--- a/test/models/maintenance_tasks/task_data_index_test.rb
+++ b/test/models/maintenance_tasks/task_data_index_test.rb
@@ -4,32 +4,44 @@ require "test_helper"
 
 module MaintenanceTasks
   class TaskDataIndexTest < ActiveSupport::TestCase
-    test ".available_tasks returns a list of Tasks as TaskDataShow, ordered alphabetically by name" do
-      expected = [
-        "Maintenance::BatchImportPostsTask",
-        "Maintenance::CallbackTestTask",
-        "Maintenance::CancelledEnqueueTask",
-        "Maintenance::CompositePrimaryKeyModelTask",
-        "Maintenance::CustomEnumeratingTask",
-        "Maintenance::EnqueueErrorTask",
-        "Maintenance::ErrorTask",
-        "Maintenance::ImportPostsTask",
-        "Maintenance::ImportPostsWithEncodingTask",
-        "Maintenance::ImportPostsWithOptionsTask",
-        "Maintenance::Nested::NestedMore::NestedMoreTask",
-        "Maintenance::Nested::NestedTask",
-        "Maintenance::NoCollectionTask",
-        # duplicate due to fixtures containing two active runs of this task
-        "Maintenance::NoCollectionTask",
-        "Maintenance::ParamsTask",
-        "Maintenance::StaleTask",
-        "Maintenance::TestTask",
-        "Maintenance::UpdatePostsInBatchesTask",
-        "Maintenance::UpdatePostsModulePrependedTask",
-        "Maintenance::UpdatePostsTask",
-        "Maintenance::UpdatePostsThrottledTask",
-      ]
-      assert_equal expected, TaskDataIndex.available_tasks.map(&:name)
+    test ".available_tasks orders completed tasks by most recent run first" do
+      completed_tasks = TaskDataIndex.available_tasks.select { |task| task.category == :completed }
+
+      assert_equal(
+        ["Maintenance::StaleTask", "Maintenance::ImportPostsTask"],
+        completed_tasks.map(&:name),
+      )
+    end
+
+    test ".available_tasks orders active tasks by most recent run first, regardless of name order" do
+      # TestTask sorts alphabetically BEFORE UpdatePostsThrottledTask, but we
+      # give UpdatePostsThrottledTask the newer run so the test fails if the
+      # code falls back to alphabetical-by-name ordering.
+      Run.create!(task_name: "Maintenance::TestTask", status: :enqueued, created_at: 2.hours.ago)
+      Run.create!(task_name: "Maintenance::UpdatePostsThrottledTask", status: :enqueued, created_at: 1.minute.ago)
+
+      active_names = TaskDataIndex.available_tasks
+        .select { |task| task.category == :active }
+        .map(&:name)
+
+      assert_equal(
+        [
+          "Maintenance::UpdatePostsThrottledTask",
+          "Maintenance::TestTask",
+          "Maintenance::NoCollectionTask",
+          "Maintenance::NoCollectionTask",
+          "Maintenance::UpdatePostsTask",
+        ],
+        active_names,
+      )
+    end
+
+    test ".available_tasks orders new tasks alphabetically by name" do
+      new_task_names = TaskDataIndex.available_tasks
+        .select { |task| task.category == :new }
+        .map(&:name)
+
+      assert_equal new_task_names.sort, new_task_names
     end
 
     test ".available_tasks assigns related run by most recent created completed run" do

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -39,8 +39,8 @@ module MaintenanceTasks
         "Maintenance::UpdatePostsModulePrependedTask New",
         "Maintenance::UpdatePostsThrottledTask New",
         "Completed Tasks",
-        "Maintenance::ImportPostsTask Succeeded",
         "Maintenance::StaleTask Succeeded",
+        "Maintenance::ImportPostsTask Succeeded",
       ]
 
       assert_equal expected, page.all("h3").map(&:text)


### PR DESCRIPTION
## 💡 What it is

Sort the task list on `/maintenance_tasks` so the task with the most recently created Run appears at the top of its section, instead of sorting alphabetically by name.

- **Active** and **Completed** sections: most recently-created Run first.
- **New** section (no Run history): unchanged — alphabetical by name.

## ❓ Why

Recency is a more intuitive default for a list of things that have happened. Even when the task name is known, scanning an alphabetical list to find a recent Run is harder than scanning a chronological one — the visual position of any given task shifts as unrelated tasks are added or renamed, and there's no relationship between "alphabetically near" and "interesting right now". Chronological order matches how the list is actually used: most of the time the relevant row is something that ran recently.

## 🔧 How

Replace the sort key in `TaskDataIndex.available_tasks` from `[name, status]` to `[-related_run.created_at.to_f, name, status]`. New tasks (no related Run) collapse to the same recency value (`0`) and fall back to alphabetical via the secondary `name` key — preserving the previous ordering for that section.

The `status` tiebreaker is retained for stability when a task has multiple active Runs created at the same instant — that's the reason it was originally added in #667.

## 🧪 Testing

Unit tests in `task_data_index_test.rb` cover each section's new contract independently:

- Completed: asserts a known recency-vs-alphabetical inversion in the fixtures (`StaleTask` runs newer than `ImportPostsTask` despite sorting later alphabetically).
- Active: creates two extra Runs whose alphabetical order disagrees with their recency order, so the test fails if recency is ignored.
- New: asserts the section is alphabetical by name.
