### PR TITLE
Drop support for no-longer-supported Rails 7.1 and clean up ✨

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         gemfile:
-        - gemfiles/rails_7_1.gemfile
         - gemfiles/rails_7_2.gemfile
         - gemfiles/rails_8_0.gemfile
         - Gemfile # current minor release

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "better_html"
 gem "debug"
 gem "puma"
 if !@rails_gem_requirement
-  gem "rails", ">= 7.1"
+  gem "rails", ">= 7.2"
   ruby ">= 3.2.0"
 else
   # causes Dependabot to ignore the next line and update the previous gem "rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,12 @@ PATH
   remote: .
   specs:
     maintenance_tasks (2.16.0)
-      actionpack (>= 7.1)
-      activejob (>= 7.1)
-      activerecord (>= 7.1)
+      actionpack (>= 7.2)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
       csv
       job-iteration (>= 1.3.6)
-      railties (>= 7.1)
+      railties (>= 7.2)
       zeitwerk (>= 2.6.2)
 
 GEM
@@ -335,7 +335,7 @@ DEPENDENCIES
   minitest
   mocha
   puma
-  rails (>= 7.1)
+  rails (>= 7.2)
   rubocop
   rubocop-shopify
   selenium-webdriver

--- a/db/migrate/20251128180556_add_cursor_is_json_flag_to_runs.rb
+++ b/db/migrate/20251128180556_add_cursor_is_json_flag_to_runs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddCursorIsJsonFlagToRuns < ActiveRecord::Migration[7.1]
+class AddCursorIsJsonFlagToRuns < ActiveRecord::Migration[7.2]
   def change
     add_column(:maintenance_tasks_runs, :cursor_is_json, :boolean, default: false, null: false)
   end

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-@rails_gem_requirement = "~> 7.1.0"
-@minitest_gem_requirement = "< 6"
-
-eval_gemfile "../Gemfile"

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = ["maintenance_tasks"]
 
-  minimum_rails_version = "7.1"
+  minimum_rails_version = "7.2"
   spec.add_dependency("actionpack", ">= #{minimum_rails_version}")
   spec.add_dependency("activejob", ">= #{minimum_rails_version}")
   spec.add_dependency("activerecord", ">= #{minimum_rails_version}")

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_01_19_151430) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_19_151430) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false


### PR DESCRIPTION
Inspired / based on https://github.com/Shopify/maintenance_tasks/pull/1248

Proposing we drop support for Rails 7.1 (not 7.2, _yet_) as it's no longer supported as of over 3 months ago. Doing so additionally allows us to clean up quite a few `if >= 7.1` type conditionals. ([Rails EOL info source](https://endoflife.date/rails))

<img width="1536" height="930" alt="Screenshot From 2026-05-14 21-34-05" src="https://github.com/user-attachments/assets/ab026b58-9695-4786-b82d-ff14bbe9314c" />

Regarding the likely `rails_7_1_gemfile` CI failure we can follow the guidance here: https://github.com/Shopify/maintenance_tasks/pull/1248#issuecomment-3127483925.