### PR TITLE
Add tag macro for grouping tasks in the web UI

### DIFF
--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -39,6 +39,11 @@ module MaintenanceTasks
     # @api private
     class_attribute :status_reload_frequency, default: MaintenanceTasks.status_reload_frequency
 
+    # Tags applied to this Task, used to group and filter Tasks in the
+    # web UI. Subclasses inherit parent tags and may add their own via
+    # the `tag` class macro.
+    class_attribute :tags, default: [].freeze
+
     define_callbacks :start, :complete, :error, :cancel, :pause, :interrupt
 
     attr_accessor :metadata
@@ -164,6 +169,21 @@ module MaintenanceTasks
       # @param size [Integer] the number of records to fetch in a single query.
       def collection_batch_size(size)
         self.active_record_enumerator_batch_size = size
+      end
+
+      # Tag this Task with one or more labels. Tags are used by the web UI to
+      # group and filter Tasks on the index page. Tags are inherited from
+      # superclasses; calling tag on a subclass adds to (does not replace) the
+      # inherited set.
+      #
+      # @param names [Array<Symbol, String>] one or more tag names.
+      #
+      # @example
+      #   class Maintenance::CleanupOldPostsTask < MaintenanceTasks::Task
+      #     tag :data, :cleanup
+      #   end
+      def tag(*names)
+        self.tags = (tags + names.map(&:to_sym)).uniq.freeze
       end
 
       # Adds attribute names to sensitive arguments list.

--- a/app/models/maintenance_tasks/task_data_index.rb
+++ b/app/models/maintenance_tasks/task_data_index.rb
@@ -98,5 +98,15 @@ module MaintenanceTasks
         :completed
       end
     end
+
+    # Returns the tags declared on the Task class via the `tag` macro.
+    # Falls back to an empty array when the Task class has been deleted.
+    #
+    # @return [Array<Symbol>] the Task's tags.
+    def tags
+      @tags ||= Task.named(name).tags
+    rescue Task::NotFoundError
+      @tags = [].freeze
+    end
   end
 end

--- a/test/dummy/app/tasks/maintenance/batch_import_posts_task.rb
+++ b/test/dummy/app/tasks/maintenance/batch_import_posts_task.rb
@@ -2,6 +2,7 @@
 
 module Maintenance
   class BatchImportPostsTask < MaintenanceTasks::Task
+    tag :posts, :csv
     csv_collection(in_batches: 2)
 
     def process(post_rows)

--- a/test/dummy/app/tasks/maintenance/cancelled_enqueue_task.rb
+++ b/test/dummy/app/tasks/maintenance/cancelled_enqueue_task.rb
@@ -3,6 +3,8 @@
 module Maintenance
   # Any job enqueued for this task gets cancelled, see CustomTaskJob.
   class CancelledEnqueueTask < MaintenanceTasks::Task
+    tag :errors
+
     def collection
       []
     end

--- a/test/dummy/app/tasks/maintenance/enqueue_error_task.rb
+++ b/test/dummy/app/tasks/maintenance/enqueue_error_task.rb
@@ -3,6 +3,8 @@
 module Maintenance
   # Any job enqueued for this task errors, see CustomTaskJob.
   class EnqueueErrorTask < MaintenanceTasks::Task
+    tag :errors
+
     def collection
       []
     end

--- a/test/dummy/app/tasks/maintenance/error_task.rb
+++ b/test/dummy/app/tasks/maintenance/error_task.rb
@@ -2,6 +2,8 @@
 
 module Maintenance
   class ErrorTask < MaintenanceTasks::Task
+    tag :errors
+
     def collection
       [1, 2, 3, 4, 5]
     end

--- a/test/dummy/app/tasks/maintenance/import_posts_task.rb
+++ b/test/dummy/app/tasks/maintenance/import_posts_task.rb
@@ -2,6 +2,7 @@
 
 module Maintenance
   class ImportPostsTask < MaintenanceTasks::Task
+    tag :posts, :csv
     csv_collection
 
     def process(row)

--- a/test/dummy/app/tasks/maintenance/import_posts_with_encoding_task.rb
+++ b/test/dummy/app/tasks/maintenance/import_posts_with_encoding_task.rb
@@ -2,6 +2,7 @@
 
 module Maintenance
   class ImportPostsWithEncodingTask < MaintenanceTasks::Task
+    tag :posts, :csv
     csv_collection(encoding: Encoding::ASCII)
 
     def process(row)

--- a/test/dummy/app/tasks/maintenance/import_posts_with_options_task.rb
+++ b/test/dummy/app/tasks/maintenance/import_posts_with_options_task.rb
@@ -2,6 +2,7 @@
 
 module Maintenance
   class ImportPostsWithOptionsTask < MaintenanceTasks::Task
+    tag :posts, :csv
     csv_collection(skip_lines: /^#/, converters: ->(field) { field.to_s.upcase })
 
     def process(row)

--- a/test/dummy/app/tasks/maintenance/params_task.rb
+++ b/test/dummy/app/tasks/maintenance/params_task.rb
@@ -10,6 +10,8 @@ module Maintenance
   end
 
   class ParamsTask < MaintenanceTasks::Task
+    tag :params, :examples
+
     attribute :post_ids, :string
 
     validates :post_ids,

--- a/test/dummy/app/tasks/maintenance/stale_task.rb
+++ b/test/dummy/app/tasks/maintenance/stale_task.rb
@@ -2,6 +2,8 @@
 
 module Maintenance
   class StaleTask < MaintenanceTasks::Task
+    tag :examples
+
     def collection
       [1, 2]
     end

--- a/test/dummy/app/tasks/maintenance/update_posts_in_batches_task.rb
+++ b/test/dummy/app/tasks/maintenance/update_posts_in_batches_task.rb
@@ -2,6 +2,8 @@
 
 module Maintenance
   class UpdatePostsInBatchesTask < MaintenanceTasks::Task
+    tag :posts, :updates
+
     def collection
       Post.in_batches(of: 5)
     end

--- a/test/dummy/app/tasks/maintenance/update_posts_module_prepended_task.rb
+++ b/test/dummy/app/tasks/maintenance/update_posts_module_prepended_task.rb
@@ -4,6 +4,7 @@ require "test_module"
 
 module Maintenance
   class UpdatePostsModulePrependedTask < MaintenanceTasks::Task
+    tag :posts, :updates
     prepend TestModule
 
     class << self

--- a/test/dummy/app/tasks/maintenance/update_posts_task.rb
+++ b/test/dummy/app/tasks/maintenance/update_posts_task.rb
@@ -2,6 +2,8 @@
 
 module Maintenance
   class UpdatePostsTask < MaintenanceTasks::Task
+    tag :posts, :updates
+
     class << self
       attr_accessor :fast_task
     end

--- a/test/dummy/app/tasks/maintenance/update_posts_throttled_task.rb
+++ b/test/dummy/app/tasks/maintenance/update_posts_throttled_task.rb
@@ -2,6 +2,8 @@
 
 module Maintenance
   class UpdatePostsThrottledTask < MaintenanceTasks::Task
+    tag :posts, :updates, :throttled
+
     class << self
       attr_accessor :throttle, :throttle_proc
     end

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -133,5 +133,55 @@ module MaintenanceTasks
     ensure
       Maintenance::TestTask.status_reload_frequency = original_reload_frequency
     end
+
+    test ".tags defaults to an empty frozen array" do
+      assert_equal [], Maintenance::TestTask.tags
+      assert Maintenance::TestTask.tags.frozen?
+    end
+
+    test ".tag adds the given symbols to .tags" do
+      assert_equal [:posts, :updates], Maintenance::UpdatePostsTask.tags
+    end
+
+    test ".tag accepts strings and coerces them to symbols" do
+      sandbox_tags(Maintenance::TestTask) do
+        Maintenance::TestTask.tag("data", "cleanup")
+        assert_equal [:data, :cleanup], Maintenance::TestTask.tags
+      end
+    end
+
+    test ".tag is additive across multiple calls and dedupes" do
+      sandbox_tags(Maintenance::TestTask) do
+        Maintenance::TestTask.tag(:data)
+        Maintenance::TestTask.tag(:data, :cleanup)
+        assert_equal [:data, :cleanup], Maintenance::TestTask.tags
+      end
+    end
+
+    test ".tag in a subclass inherits parent tags without mutating the parent" do
+      # Use two existing tagged tasks: ImportPostsTask (:posts, :csv)
+      # subclasses are tested implicitly elsewhere; here we directly verify
+      # that the inheritance semantic works via class_attribute.
+      assert_equal [:posts, :csv], Maintenance::ImportPostsTask.tags
+      assert_equal [:posts, :updates], Maintenance::UpdatePostsTask.tags
+      # And that calls to one do not leak into the other.
+      sandbox_tags(Maintenance::TestTask) do
+        Maintenance::TestTask.tag(:isolated)
+        assert_equal [:isolated], Maintenance::TestTask.tags
+        assert_equal [:posts, :csv], Maintenance::ImportPostsTask.tags
+      end
+    end
+
+    private
+
+    # Snapshots and restores a Task class's tags around a block so each test
+    # is hermetic. Avoids spawning anonymous subclasses (which would leak into
+    # ActiveSupport::DescendantsTracker and pollute .load_all).
+    def sandbox_tags(task_class)
+      original = task_class.tags
+      yield
+    ensure
+      task_class.tags = original
+    end
   end
 end


### PR DESCRIPTION
## Summary

Introduces a `tag` class macro on `MaintenanceTasks::Task` that records one or more symbol labels on a Task class. Tags are inherited from the superclass and additive across `tag` calls — calling `tag :foo, :bar` on a subclass extends (does not replace) the parent's tags.

```ruby
class Maintenance::CleanupOldPostsTask < MaintenanceTasks::Task
  tag :data, :cleanup
  # ...
end
```

`TaskDataIndex#tags` exposes the value to the index view, returning an empty frozen array when the underlying class has been deleted so the deleted-task render path stays safe.

This PR is **data-layer only**. The tag-filter chips on the Tasks index are part of the follow-up UI PR (so this one can be reviewed and shipped in isolation).

## Stack

This is **PR 1 of 4** in a stack that progressively lands a refreshed Tasks UI:

1. **(this PR)** Tagging API
2. UI overhaul (search, tag filter chips, dark theme, navbar refresh indicator)
3. Auto-refresh: morph DOM in place instead of replacing subtrees
4. Run-card spacing & style refinement

The follow-up PRs are open as drafts; their diffs will shrink as the earlier ones land.

## Test plan

- [x] `bundle exec rake test` passes (296 runs, 939 assertions, 0 failures)
- [x] `bundle exec rubocop` clean on touched files
- [x] New `task_test.rb` coverage: default empty-and-frozen tags, additive `tag`, string coercion, dedup, sub/superclass isolation