### PR TITLE
Auto-refresh: morph the DOM in place instead of replacing subtrees

### DIFF
--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -19,7 +19,7 @@ module MaintenanceTasks
       ] if defined?(Capybara::Lockstep)
       policy.script_src_elem(
         # <script> tag in app/views/layouts/maintenance_tasks/application.html.erb
-        "'sha256-EgJg72VJBHkkzLEDQu1lwiwXRk+MTKJ2i9w3W3CWlBc='",
+        "'sha256-ZkcBB93dJLHCMozzRI0qwnn9xOL1apTbXgbZ1u33rvI='",
         # <script> tag for capybara-lockstep
         *capybara_lockstep_scripts,
       )

--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -11,7 +11,7 @@ module MaintenanceTasks
       policy.style_src_elem(
         BULMA_CDN,
         # <style> tag in app/views/layouts/maintenance_tasks/application.html.erb
-        "'sha256-b9tTK1UaF0U8792/A1vIUkeZwjPgECIOeKJdhYED06A='",
+        "'sha256-2+QYdn+KxogttA55Mat4WTVkM02itlZXLQ5aolcv3qk='",
       )
       capybara_lockstep_scripts = [
         "'sha256-1AoN3ZtJC5OvqkMgrYvhZjp4kI8QjJjO7TAyKYiDw+U='",
@@ -19,7 +19,7 @@ module MaintenanceTasks
       ] if defined?(Capybara::Lockstep)
       policy.script_src_elem(
         # <script> tag in app/views/layouts/maintenance_tasks/application.html.erb
-        "'sha256-NiHKryHWudRC2IteTqmY9v1VkaDUA/5jhgXkMTkgo2w='",
+        "'sha256-EgJg72VJBHkkzLEDQu1lwiwXRk+MTKJ2i9w3W3CWlBc='",
         # <script> tag for capybara-lockstep
         *capybara_lockstep_scripts,
       )

--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -10,9 +10,11 @@ module MaintenanceTasks
     before_action :set_refresh, only: [:index]
 
     # Renders the maintenance_tasks/tasks page, displaying
-    # available tasks to users, grouped by category.
+    # the list of available tasks, their tags, and their most
+    # recent run status.
     def index
-      @available_tasks = TaskDataIndex.available_tasks.group_by(&:category)
+      @tasks = TaskDataIndex.available_tasks
+      @tag_filters = @tasks.flat_map(&:tags).uniq.sort
     end
 
     # Renders the page responsible for providing Task actions to users.

--- a/app/helpers/maintenance_tasks/application_helper.rb
+++ b/app/helpers/maintenance_tasks/application_helper.rb
@@ -6,15 +6,14 @@ module MaintenanceTasks
   # @api private
   module ApplicationHelper
     # Renders a time element with the given datetime, worded as relative to the
-    # current time.
-    #
-    # The ISO 8601 version of the datetime is shown on hover
-    # via a title attribute.
+    # current time. The absolute UTC time is exposed via aria-label so that
+    # assistive technologies (and touch users without hover) can read it,
+    # not just desktop users hovering for the title tooltip.
     #
     # @param datetime [ActiveSupport::TimeWithZone] the time to be presented.
     # @return [String] the HTML to render with the relative datetime in words.
     def time_ago(datetime)
-      time_tag(datetime, title: datetime.utc, class: "is-clickable") do
+      time_tag(datetime, aria: { label: "#{datetime.utc.strftime("%B %-d, %Y at %H:%M")} UTC" }) do
         time_ago_in_words(datetime) + " ago"
       end
     end

--- a/app/helpers/maintenance_tasks/tasks_helper.rb
+++ b/app/helpers/maintenance_tasks/tasks_helper.rb
@@ -20,6 +20,21 @@ module MaintenanceTasks
       "errored" => ["is-danger"],
     }
 
+    # Unicode glyph paired with each status word so the indicator carries shape
+    # plus color, not color alone (helps colorblind users distinguish statuses).
+    STATUS_ICONS = {
+      "new" => "✦",
+      "enqueued" => "⌛",
+      "running" => "▶",
+      "interrupted" => "‖",
+      "pausing" => "⌛",
+      "paused" => "‖",
+      "succeeded" => "✓",
+      "cancelling" => "⌛",
+      "cancelled" => "✕",
+      "errored" => "⚠",
+    }
+
     # Formats a run backtrace.
     #
     # @param backtrace [Array<String>] the backtrace associated with an
@@ -43,13 +58,15 @@ module MaintenanceTasks
       return unless run.started?
 
       progress = Progress.new(run)
+      text_id = "progress_text_#{run.id}"
 
       progress_bar = tag.progress(
         value: progress.value,
         max: progress.max,
         class: ["progress", "mt-4"] + STATUS_COLOURS.fetch(run.status),
+        aria: { labelledby: text_id },
       )
-      progress_text = tag.p(tag.i(progress.text))
+      progress_text = tag.p(tag.i(progress.text), id: text_id)
       tag.div(progress_bar + progress_text, class: "block")
     end
 
@@ -60,10 +77,12 @@ module MaintenanceTasks
     # @return [String] the span element containing the status, with the
     #   appropriate tag class attached.
     def status_tag(status)
-      tag.span(
-        status.capitalize,
-        class: ["tag", "has-text-weight-medium", "px-2", "mx-4"] + STATUS_COLOURS.fetch(status),
-      )
+      tag.span(class: ["tag", "has-text-weight-medium", "px-2", "ml-2"] + STATUS_COLOURS.fetch(status)) do
+        safe_join([
+          tag.span(STATUS_ICONS.fetch(status), aria: { hidden: true }, class: "mr-1"),
+          status.capitalize,
+        ])
+      end
     end
 
     # Reports the approximate elapsed time a Run has been processed so far based

--- a/app/models/maintenance_tasks/task.rb
+++ b/app/models/maintenance_tasks/task.rb
@@ -39,6 +39,11 @@ module MaintenanceTasks
     # @api private
     class_attribute :status_reload_frequency, default: MaintenanceTasks.status_reload_frequency
 
+    # Tags applied to this Task, used to group and filter Tasks in the
+    # web UI. Subclasses inherit parent tags and may add their own via
+    # the `tag` class macro.
+    class_attribute :tags, default: [].freeze
+
     define_callbacks :start, :complete, :error, :cancel, :pause, :interrupt
 
     attr_accessor :metadata
@@ -164,6 +169,21 @@ module MaintenanceTasks
       # @param size [Integer] the number of records to fetch in a single query.
       def collection_batch_size(size)
         self.active_record_enumerator_batch_size = size
+      end
+
+      # Tag this Task with one or more labels. Tags are used by the web UI to
+      # group and filter Tasks on the index page. Tags are inherited from
+      # superclasses; calling tag on a subclass adds to (does not replace) the
+      # inherited set.
+      #
+      # @param names [Array<Symbol, String>] one or more tag names.
+      #
+      # @example
+      #   class Maintenance::CleanupOldPostsTask < MaintenanceTasks::Task
+      #     tag :data, :cleanup
+      #   end
+      def tag(*names)
+        self.tags = (tags + names.map(&:to_sym)).uniq.freeze
       end
 
       # Adds attribute names to sensitive arguments list.

--- a/app/models/maintenance_tasks/task_data_index.rb
+++ b/app/models/maintenance_tasks/task_data_index.rb
@@ -98,5 +98,15 @@ module MaintenanceTasks
         :completed
       end
     end
+
+    # Returns the tags declared on the Task class via the `tag` macro.
+    # Falls back to an empty array when the Task class has been deleted.
+    #
+    # @return [Array<Symbol>] the Task's tags.
+    def tags
+      @tags ||= Task.named(name).tags
+    rescue Task::NotFoundError
+      @tags = [].freeze
+    end
   end
 end

--- a/app/views/layouts/maintenance_tasks/_navbar.html.erb
+++ b/app/views/layouts/maintenance_tasks/_navbar.html.erb
@@ -1,5 +1,24 @@
 <nav class="navbar" role="navigation" aria-label="Main navigation">
   <div class="navbar-brand">
-    <%= link_to 'Maintenance Tasks', root_path, class: 'navbar-item is-size-4 has-text-weight-semibold has-text-danger' %>
+    <%= link_to 'Maintenance Tasks', root_path, class: 'navbar-item is-size-5 has-text-weight-medium brand-link' %>
+  </div>
+  <div class="navbar-end">
+    <span class="navbar-item">
+      <span class="navbar-refresh-indicator"
+            id="refresh-indicator"
+            role="status"
+            aria-live="polite"
+            aria-label="Auto-refresh idle"
+            hidden></span>
+    </span>
+    <span class="navbar-item">
+      <button type="button"
+              id="theme-toggle"
+              class="theme-toggle"
+              aria-label="Toggle color theme"
+              title="Toggle color theme">
+        <span class="theme-toggle-icon" aria-hidden="true"></span>
+      </button>
+    </span>
   </div>
 </nav>

--- a/app/views/layouts/maintenance_tasks/application.html.erb
+++ b/app/views/layouts/maintenance_tasks/application.html.erb
@@ -15,12 +15,15 @@
 
     <%= csrf_meta_tags %>
 
-    <%=
-      stylesheet_link_tag(URI.join(controller.class::BULMA_CDN, "npm/bulma@1.0.4/css/bulma.min.css"),
-        media: :all,
-        integrity: "sha256-Z/om3xyp6V2PKtx8BPobFfo9JCV0cOvBDMaLmquRS+4=",
-        crossorigin: "anonymous") unless request.xhr?
-    %>
+    <% unless request.xhr? %>
+      <link rel="preconnect" href="<%= controller.class::BULMA_CDN %>" crossorigin>
+      <%=
+        stylesheet_link_tag(URI.join(controller.class::BULMA_CDN, "npm/bulma@1.0.4/css/bulma.min.css"),
+          media: :all,
+          integrity: "sha256-Z/om3xyp6V2PKtx8BPobFfo9JCV0cOvBDMaLmquRS+4=",
+          crossorigin: "anonymous")
+      %>
+    <% end %>
 
     <style>
       :root {
@@ -31,11 +34,10 @@
         --ruby-number: #005cc5;
         --ruby-keyword: #d73a49;
         --ruby-string: #032f62;
-        --required-color: #ff6685;
       }
 
       @media (prefers-color-scheme: dark) {
-        :root {
+        :root:not([data-theme="light"]) {
           --ruby-comment: #8b949e;
           --ruby-const: #ffa657;
           --ruby-embexpr: #c9d1d9;
@@ -43,9 +45,21 @@
           --ruby-number: #79c0ff;
           --ruby-keyword: #ff7b72;
           --ruby-string: #a5d6ff;
-          --required-color: #ff6685;
         }
       }
+      :root[data-theme="dark"] {
+        --ruby-comment: #8b949e;
+        --ruby-const: #ffa657;
+        --ruby-embexpr: #c9d1d9;
+        --ruby-ident: #d2a8ff;
+        --ruby-number: #79c0ff;
+        --ruby-keyword: #ff7b72;
+        --ruby-string: #a5d6ff;
+      }
+
+      .brand-link,
+      .brand-link:hover,
+      .brand-link:focus { color: var(--bulma-danger-on-scheme); }
 
       .ruby-comment { color: var(--ruby-comment); }
       .ruby-const { color: var(--ruby-const); }
@@ -56,23 +70,42 @@
       .ruby-label, .ruby-tstring-beg, .ruby-tstring-content, .ruby-tstring-end { color: var(--ruby-string); }
 
       .select, select { width: 100%; }
-      summary { cursor: pointer; }
       input[type="datetime-local"], input[type="date"], input[type="time"] {
         width: fit-content;
       }
-	  details > summary {
+
+      details > summary {
         list-style: none;
+        cursor: pointer;
       }
-      summary::-webkit-details-marker {
-        display: none
-      }
+      summary::-webkit-details-marker { display: none; }
       summary::before {
-        content: '► ';
-        position:absolute;
-        font-size: 16px
+        content: "▶";
+        display: inline-block;
+        margin-right: 0.5em;
+        font-size: 0.75em;
+        vertical-align: 0.1em;
+        transition: transform 150ms ease-out;
       }
-      details[open] summary:before {
-        content: "▼ ";
+      details[open] > summary::before {
+        transform: rotate(90deg);
+      }
+      @media (prefers-reduced-motion: reduce) {
+        summary::before { transition: none; }
+      }
+
+      details.box pre {
+        overflow-x: auto;
+      }
+
+      /* Per Vercel guidelines: eliminate 300ms double-tap delay on touch UIs. */
+      a, button, input[type="submit"], summary, .task-row, .tag-filter, .theme-toggle {
+        touch-action: manipulation;
+      }
+
+      /* Per Vercel guidelines: prevent widows/orphans on headings. */
+      .title, h1, h2, h3 {
+        text-wrap: balance;
       }
 
       .box {
@@ -80,48 +113,531 @@
                     0 2px 4px -1px #0000001a;
       }
 
-      @media (prefers-color-scheme: dark) {
-        .box {
-          background-color: var(--bulma-background);
-        }
-      }
-
       .label.is-required:after {
         content: " (required)";
-        color: var(--required-color);
+        color: var(--bulma-danger-on-scheme);
         font-size: 12px;
+      }
+
+      .skip-link {
+        position: absolute;
+        left: -9999px;
+        top: 0.5rem;
+        z-index: 100;
+        padding: 0.5rem 1rem;
+        background: var(--bulma-link, #485fc7);
+        color: #fff;
+        border-radius: 4px;
+        text-decoration: none;
+      }
+      .skip-link:focus {
+        left: 0.5rem;
+        outline: 2px solid currentColor;
+        outline-offset: 2px;
+      }
+      main:focus { outline: none; }
+
+      .run { position: relative; }
+      .run-permalink {
+        position: absolute;
+        top: 0.6rem;
+        right: 0.75rem;
+        z-index: 2;
+        display: inline-block;
+        padding: 0.35rem 0.6rem;
+        min-width: 2.75rem;
+        min-height: 2.75rem;
+        text-align: right;
+        line-height: 2rem;
+      }
+
+      .grid > .cell { min-width: 0; }
+
+      @media (max-width: 32rem) {
+        .grid[class*="is-col-min-"] { grid-template-columns: 1fr; }
+      }
+
+      .task-title { gap: 0.5rem; flex-wrap: wrap; }
+      .task-title > a {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow-wrap: anywhere;
+        word-break: break-word;
+      }
+      .task-title .tag { flex: 0 0 auto; }
+
+      .pagination-link {
+        display: inline-block;
+        padding: 0.625rem 1rem;
+        min-height: 2.75rem;
+        line-height: 1.6;
+        margin-top: 0.5rem;
+      }
+
+      /* Bulma's .section defaults to 3rem padding — too airy for an embedded
+         admin UI. Tighten the top so the page H1 sits closer to the navbar. */
+      main.section { padding-top: 1.75rem; padding-bottom: 3rem; }
+      main.section > .container > .title.is-3 { margin-bottom: 1.25rem; }
+
+      /* Style the native file input so the "Choose file" button matches Bulma
+         buttons. The selector-button pseudo is the only cross-browser way to
+         style file inputs without restructuring the markup. */
+      .csv-file-input {
+        font: inherit;
+        color: var(--bulma-text);
+        max-width: 100%;
+      }
+      .csv-file-input::file-selector-button {
+        background: var(--bulma-link);
+        color: var(--bulma-link-invert, #fff);
+        border: 0;
+        border-radius: 6px;
+        padding: 0.5rem 1rem;
+        font: inherit;
+        font-weight: 500;
+        cursor: pointer;
+        margin-right: 0.75rem;
+        transition: background-color 150ms ease-out;
+      }
+      .csv-file-input::file-selector-button:hover {
+        background: var(--bulma-link-active, var(--bulma-link));
+        filter: brightness(0.93);
+      }
+      .csv-file-input:focus-visible::file-selector-button {
+        outline: 2px solid var(--bulma-link);
+        outline-offset: 2px;
+      }
+
+      .task-toolbar {
+        display: flex;
+        flex-direction: column;
+        gap: 0.85rem;
+        margin-bottom: 1.25rem;
+      }
+      .task-toolbar .control { max-width: 28rem; }
+      .task-toolbar .control .icon { pointer-events: none; }
+
+      .task-section-divider td {
+        padding: 1.75rem 0 0.5rem;
+        border: 0;
+        border-top: 1px solid var(--bulma-border, #d6d8db);
+        padding-top: 1.75rem;
+      }
+      .task-section-divider td > span {
+        display: inline-block;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--task-muted-text);
+        padding-top: 1.25rem;
+      }
+      /* Don't double-border with the row above. */
+      .task-table tbody.task-section-divider + tbody tr:first-child > td {
+        padding-top: 0.5rem;
+      }
+
+      /* Scheme-aware muted text. Bulma's .has-text-grey is a fixed value that
+         fails contrast on dark backgrounds; use this token for any secondary
+         text inside .task-row-status to keep AA contrast in both schemes. */
+      :root { --task-muted-text: rgb(74, 85, 104); }
+      @media (prefers-color-scheme: dark) {
+        :root:not([data-theme="light"]) { --task-muted-text: rgb(199, 205, 214); }
+      }
+      :root[data-theme="dark"] { --task-muted-text: rgb(199, 205, 214); }
+      /* Bulma's .has-text-* helpers ship with !important; match it. */
+      .task-row-status .has-text-grey { color: var(--task-muted-text) !important; }
+      .task-row-status .has-text-grey-light {
+        color: var(--task-muted-text) !important;
+        opacity: 0.7;
+      }
+
+      .tag-filters {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+      }
+      .tag-filter {
+        cursor: pointer;
+        border: 1px solid transparent;
+        background: var(--bulma-background);
+        color: var(--bulma-text);
+        font-family: inherit;
+      }
+      .tag-filter:hover {
+        border-color: var(--bulma-link);
+      }
+      .tag-filter[aria-pressed="true"] {
+        background: var(--bulma-link);
+        color: var(--bulma-link-invert, #fff);
+      }
+      .tag-filter:focus-visible {
+        outline: 2px solid var(--bulma-link);
+        outline-offset: 2px;
+      }
+
+      .task-table { table-layout: auto; }
+      .task-table th {
+        font-weight: 600;
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--task-muted-text);
+        padding-bottom: 0.65rem;
+        border-bottom: 1px solid var(--bulma-border, #d6d8db);
+      }
+      .task-table th.task-col-last-run { text-align: right; }
+      .task-table td.task-row-status { text-align: right; white-space: nowrap; }
+      .task-table .tag.is-light {
+        background-color: var(--bulma-background);
+        color: var(--bulma-text);
+      }
+      .task-table .task-row { position: relative; transition: background-color 120ms ease-out; }
+      .task-table .task-row td { vertical-align: middle; }
+      .task-table .task-row .task-row-name a::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        z-index: 0;
+      }
+      .task-table .task-row > td { position: relative; z-index: 1; }
+      .task-table .task-row .task-row-name { z-index: 0; }
+      .task-table tbody:not(.task-section-divider) > .task-row:hover {
+        background-color: var(--bulma-background);
+      }
+      .task-table tbody:not(.task-section-divider) > .task-row:hover .task-row-name a {
+        text-decoration: underline;
+      }
+
+      /* Row pulse when a task's status changes during a polling refresh.
+         Subtle yellow wash that decays — helps the eye catch live updates. */
+      @keyframes task-row-status-pulse {
+        0%   { background-color: var(--bulma-warning-90, rgba(255, 224, 138, 0.45)); }
+        100% { background-color: transparent; }
+      }
+      .task-row.task-row-just-changed {
+        animation: task-row-status-pulse 1800ms ease-out;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .task-row.task-row-just-changed { animation: none; }
+      }
+
+      /* Smooth opacity for rows hidden by search/chip filtering, so the list
+         feels filtered rather than chopped. The [hidden] attribute removes
+         layout; opacity transition only fires during the show direction. */
+      .task-row { transition: background-color 120ms ease-out, opacity 150ms ease-out; }
+      .task-row[hidden] { display: none; }
+      @media (prefers-reduced-motion: reduce) {
+        .task-row { transition: none; }
+      }
+
+      /* Theme toggle: half-turn spin when clicked. The icon character itself
+         changes via [data-theme] selectors — combined with the rotation, the
+         icon flip feels intentional rather than a sudden swap. */
+      .theme-toggle-icon {
+        display: inline-block;
+        transition: transform 220ms cubic-bezier(0.25, 1, 0.5, 1);
+      }
+      .theme-toggle.is-spinning .theme-toggle-icon {
+        transform: rotate(180deg);
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .theme-toggle-icon { transition: none; }
+      }
+
+      @media (max-width: 40rem) {
+        .task-table thead { display: none; }
+        .task-table tr { display: block; padding: 0.6rem 0; border-top: 1px solid var(--bulma-border, #ededed); }
+        .task-table td { display: block; padding: 0.1rem 0; border: 0; overflow-wrap: anywhere; }
+        .task-table .task-row-name a { word-break: break-word; }
+      }
+
+      .theme-toggle {
+        border: 0;
+        background: transparent;
+        cursor: pointer;
+        padding: 0.4rem 0.6rem;
+        border-radius: 999px;
+        font: inherit;
+        line-height: 1;
+        color: var(--bulma-text);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .theme-toggle:hover { background: var(--bulma-background); }
+      .theme-toggle:focus-visible {
+        outline: 2px solid var(--bulma-link);
+        outline-offset: 2px;
+      }
+      .theme-toggle-icon::before {
+        content: "☾";
+        font-size: 1.05rem;
+        display: inline-block;
+        line-height: 1;
+      }
+      /* Resolved scheme determines which icon shows. Icon represents the
+         destination state (sun = "switch to light", moon = "switch to dark"). */
+      @media (prefers-color-scheme: dark) {
+        :root:not([data-theme="light"]) .theme-toggle-icon::before { content: "☀"; }
+      }
+      :root[data-theme="dark"] .theme-toggle-icon::before { content: "☀"; }
+      :root[data-theme="light"] .theme-toggle-icon::before { content: "☾"; }
+
+      .navbar-refresh-indicator {
+        display: inline-block;
+        width: 1rem;
+        height: 1rem;
+        border: 2px solid var(--bulma-border, #ededed);
+        border-top-color: var(--bulma-link);
+        border-radius: 50%;
+        animation: navbar-refresh-spin 0.8s linear infinite;
+      }
+      .navbar-refresh-indicator[hidden] { display: none; }
+      @keyframes navbar-refresh-spin {
+        to { transform: rotate(360deg); }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .navbar-refresh-indicator { animation: none; }
       }
     </style>
 
     <script>
-      function refresh() {
-        const target = document.querySelector("[data-refresh]")
-        if (!target || !target.dataset.refresh) return
-        window.setTimeout(() => {
-          document.body.style.cursor = "wait"
-          fetch(document.location, { headers: { "X-Requested-With": "XMLHttpRequest" } }).then(
-            async response => {
-              const text = await response.text()
-              const newDocument = new DOMParser().parseFromString(text, "text/html")
-              const newTarget = newDocument.querySelector("[data-refresh]")
-              if (newTarget) {
-                target.replaceWith(newTarget)
-              }
-              document.body.style.cursor = ""
-              refresh()
-            },
-            error => location.reload()
+      // Apply saved theme synchronously, before <body> paints, to prevent a
+      // flash of the wrong scheme. Pure feature detection — silent on failure.
+      try {
+        var savedTheme = localStorage.getItem("maintenance-tasks-theme")
+        if (savedTheme === "dark" || savedTheme === "light") {
+          document.documentElement.setAttribute("data-theme", savedTheme)
+        }
+      } catch (e) { /* localStorage may be disabled */ }
+
+      (function () {
+        const POLL_INTERVAL = 3000
+        const MAX_FAILURES = 5
+        let failures = 0
+        let timer = null
+
+        function toggleTheme() {
+          const html = document.documentElement
+          const current = html.getAttribute("data-theme")
+          const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches
+          let next
+          if (!current) {
+            next = prefersDark ? "light" : "dark"
+          } else {
+            next = current === "dark" ? "light" : "dark"
+          }
+          html.setAttribute("data-theme", next)
+          try { localStorage.setItem("maintenance-tasks-theme", next) } catch (e) {}
+
+          // Trigger the icon spin: add the class, remove it after the transition.
+          const btn = document.getElementById("theme-toggle")
+          if (btn) {
+            btn.classList.add("is-spinning")
+            setTimeout(() => btn.classList.remove("is-spinning"), 250)
+          }
+        }
+
+        function clearFilters() {
+          const search = document.getElementById("task-search")
+          let changed = false
+          if (search && search.value) {
+            search.value = ""
+            changed = true
+          }
+          document.querySelectorAll('.tag-filter[aria-pressed="true"]').forEach((c) => {
+            c.setAttribute("aria-pressed", "false")
+            changed = true
+          })
+          if (changed) applyFilter()
+          return changed
+        }
+
+        function isTypingTarget(el) {
+          if (!el) return false
+          if (el.isContentEditable) return true
+          const tag = el.tagName
+          if (tag === "TEXTAREA" || tag === "SELECT") return true
+          if (tag === "INPUT") {
+            const type = (el.type || "").toLowerCase()
+            return type !== "checkbox" && type !== "radio" && type !== "button" && type !== "submit"
+          }
+          return false
+        }
+
+        document.addEventListener("keydown", (e) => {
+          if (e.metaKey || e.ctrlKey || e.altKey) return
+          const search = document.getElementById("task-search")
+          const typing = isTypingTarget(document.activeElement)
+
+          // "/" focuses search — common dev convention (GitHub, Linear, …).
+          if (e.key === "/" && !typing && search) {
+            e.preventDefault()
+            search.focus()
+            search.select()
+            return
+          }
+          // Esc clears search/chips, or blurs the search input.
+          if (e.key === "Escape") {
+            if (document.activeElement === search && search.value === "") {
+              search.blur()
+              return
+            }
+            const cleared = clearFilters()
+            if (cleared && search) search.focus()
+            return
+          }
+          // "t" toggles theme (only when not typing).
+          if (e.key === "t" && !typing) {
+            e.preventDefault()
+            toggleTheme()
+          }
+        })
+
+        function setIndicator(visible) {
+          const el = document.getElementById("refresh-indicator")
+          if (!el) return
+          el.hidden = !visible
+          el.setAttribute("aria-label", visible ? "Refreshing" : "Auto-refresh idle")
+        }
+
+        function applyFilter() {
+          const searchInput = document.getElementById("task-search")
+          const search = (searchInput ? searchInput.value : "").trim().toLowerCase()
+          const activeTags = new Set(
+            Array.from(document.querySelectorAll('.tag-filter[aria-pressed="true"]'))
+              .map((b) => b.dataset.tag)
           )
-        }, 3000)
-      }
-      document.addEventListener('DOMContentLoaded', refresh)
+          const rows = document.querySelectorAll("tr.task-row")
+          let visible = 0
+          rows.forEach((row) => {
+            const name = (row.dataset.taskName || "").toLowerCase()
+            const rowTags = (row.dataset.tags || "").split(" ").filter(Boolean)
+            const matchesSearch = !search || name.includes(search)
+            const matchesTags = activeTags.size === 0 || rowTags.some((t) => activeTags.has(t))
+            const show = matchesSearch && matchesTags
+            row.hidden = !show
+            if (show) visible += 1
+          })
+          const empty = document.querySelector(".task-empty-results")
+          if (empty) empty.hidden = visible !== 0 || rows.length === 0
+        }
+
+        document.addEventListener("input", (e) => {
+          if (e.target && e.target.id === "task-search") applyFilter()
+        })
+        document.addEventListener("click", (e) => {
+          if (!e.target.closest) return
+          const chip = e.target.closest(".tag-filter")
+          if (chip) {
+            const pressed = chip.getAttribute("aria-pressed") === "true"
+            chip.setAttribute("aria-pressed", pressed ? "false" : "true")
+            applyFilter()
+            return
+          }
+          if (e.target.closest("#theme-toggle")) {
+            toggleTheme()
+          }
+        })
+
+        function refreshOnce() {
+          const targets = Array.from(document.querySelectorAll("[data-refresh]"))
+          if (targets.length === 0 || !targets.some((t) => t.dataset.refresh)) return
+
+          const detailsState = new Map()
+          targets.forEach((t) => {
+            t.querySelectorAll("details[id]").forEach((d) => detailsState.set(d.id, d.open))
+          })
+          // Snapshot task-row statuses so we can pulse rows whose status changed.
+          const previousStatuses = new Map()
+          targets.forEach((t) => {
+            t.querySelectorAll("tr.task-row[data-task-name]").forEach((r) => {
+              previousStatuses.set(r.dataset.taskName, r.dataset.status)
+            })
+          })
+          const active = document.activeElement
+          const focusedId = active && active.id && targets.some((t) => t.contains(active))
+            ? active.id
+            : null
+          const scrollY = window.scrollY
+
+          setIndicator(true)
+
+          fetch(document.location, { headers: { "X-Requested-With": "XMLHttpRequest" } })
+            .then(async (response) => {
+              if (!response.ok) throw new Error("HTTP " + response.status)
+              const text = await response.text()
+              const newDoc = new DOMParser().parseFromString(text, "text/html")
+              const newTargets = Array.from(newDoc.querySelectorAll("[data-refresh]"))
+
+              targets.forEach((target, i) => {
+                const newTarget = newTargets[i]
+                if (!newTarget) return
+                newTarget.querySelectorAll("details[id]").forEach((d) => {
+                  if (detailsState.has(d.id)) d.open = detailsState.get(d.id)
+                })
+                // Mark rows whose status transitioned so the pulse animation fires.
+                newTarget.querySelectorAll("tr.task-row[data-task-name]").forEach((r) => {
+                  const prev = previousStatuses.get(r.dataset.taskName)
+                  if (prev !== undefined && prev !== r.dataset.status) {
+                    r.classList.add("task-row-just-changed")
+                    setTimeout(() => r.classList.remove("task-row-just-changed"), 1900)
+                  }
+                })
+                target.replaceWith(newTarget)
+              })
+
+              if (focusedId) {
+                const el = document.getElementById(focusedId)
+                if (el && typeof el.focus === "function") el.focus()
+              }
+              window.scrollTo(0, scrollY)
+
+              setIndicator(false)
+              applyFilter()
+
+              failures = 0
+              scheduleNext()
+            })
+            .catch(() => {
+              setIndicator(false)
+              failures += 1
+              if (failures >= MAX_FAILURES) {
+                location.reload()
+                return
+              }
+              scheduleNext(POLL_INTERVAL * Math.pow(2, failures - 1))
+            })
+        }
+
+        function scheduleNext(delay) {
+          clearTimeout(timer)
+          if (document.hidden) return
+          timer = setTimeout(refreshOnce, delay == null ? POLL_INTERVAL : delay)
+        }
+
+        document.addEventListener("visibilitychange", () => {
+          if (document.hidden) {
+            clearTimeout(timer)
+          } else {
+            scheduleNext(0)
+          }
+        })
+
+        document.addEventListener("DOMContentLoaded", () => {
+          applyFilter()
+          scheduleNext()
+        })
+      })()
     </script>
   </head>
 
   <body>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
     <%= render 'layouts/maintenance_tasks/navbar' %>
 
-    <section class="section">
+    <main id="main-content" tabindex="-1" class="section">
       <div class="container">
         <% if notice %>
           <div class="notification is-success"><%= notice %></div>
@@ -131,6 +647,7 @@
 
         <%= yield %>
       </div>
-    </section>
+    </main>
+
   </body>
 </html>

--- a/app/views/layouts/maintenance_tasks/application.html.erb
+++ b/app/views/layouts/maintenance_tasks/application.html.erb
@@ -541,14 +541,77 @@
           }
         })
 
+        // In-place DOM morph: leave unchanged subtrees alone so polls don't
+        // wipe `<details>` state, focus, scroll, or text selection. Children
+        // are matched by id when possible, otherwise by position — fine here
+        // because the server orders runs and task rows deterministically.
+        // Form input value/checked properties aren't preserved; no inputs
+        // currently live inside [data-refresh] so it's not a concern.
+        function syncAttributes(oldEl, newEl) {
+          const oldAttrs = oldEl.attributes
+          for (let i = oldAttrs.length - 1; i >= 0; i--) {
+            const name = oldAttrs[i].name
+            // `<details open>` is user-controlled — server always renders it open.
+            if (oldEl.nodeName === "DETAILS" && name === "open") continue
+            if (!newEl.hasAttribute(name)) oldEl.removeAttribute(name)
+          }
+          const newAttrs = newEl.attributes
+          for (let i = 0; i < newAttrs.length; i++) {
+            const { name, value } = newAttrs[i]
+            if (oldEl.nodeName === "DETAILS" && name === "open") continue
+            if (oldEl.getAttribute(name) !== value) oldEl.setAttribute(name, value)
+          }
+        }
+
+        function morph(oldNode, newNode) {
+          if (oldNode.isEqualNode(newNode)) return
+          if (oldNode.nodeType !== newNode.nodeType || oldNode.nodeName !== newNode.nodeName) {
+            oldNode.replaceWith(newNode.cloneNode(true))
+            return
+          }
+          if (oldNode.nodeType !== Node.ELEMENT_NODE) {
+            if (oldNode.nodeValue !== newNode.nodeValue) oldNode.nodeValue = newNode.nodeValue
+            return
+          }
+          syncAttributes(oldNode, newNode)
+
+          const oldById = new Map()
+          for (let c = oldNode.firstChild; c; c = c.nextSibling) {
+            if (c.nodeType === Node.ELEMENT_NODE && c.id) oldById.set(c.id, c)
+          }
+
+          const newChildren = Array.from(newNode.childNodes)
+          for (let i = 0; i < newChildren.length; i++) {
+            const newChild = newChildren[i]
+            const slot = oldNode.childNodes[i] || null
+            const keyed = newChild.nodeType === Node.ELEMENT_NODE && newChild.id
+              ? oldById.get(newChild.id)
+              : null
+
+            if (keyed) {
+              oldById.delete(newChild.id)
+              if (keyed !== slot) oldNode.insertBefore(keyed, slot)
+              morph(keyed, newChild)
+            } else if (
+              slot &&
+              slot.nodeType === newChild.nodeType &&
+              slot.nodeName === newChild.nodeName &&
+              !(slot.nodeType === Node.ELEMENT_NODE && slot.id)
+            ) {
+              morph(slot, newChild)
+            } else {
+              oldNode.insertBefore(newChild.cloneNode(true), slot)
+            }
+          }
+          while (oldNode.childNodes.length > newChildren.length) {
+            oldNode.removeChild(oldNode.lastChild)
+          }
+        }
+
         function refreshOnce() {
           const targets = Array.from(document.querySelectorAll("[data-refresh]"))
           if (targets.length === 0 || !targets.some((t) => t.dataset.refresh)) return
 
-          const detailsState = new Map()
-          targets.forEach((t) => {
-            t.querySelectorAll("details[id]").forEach((d) => detailsState.set(d.id, d.open))
-          })
           // Snapshot task-row statuses so we can pulse rows whose status changed.
           const previousStatuses = new Map()
           targets.forEach((t) => {
@@ -556,11 +619,6 @@
               previousStatuses.set(r.dataset.taskName, r.dataset.status)
             })
           })
-          const active = document.activeElement
-          const focusedId = active && active.id && targets.some((t) => t.contains(active))
-            ? active.id
-            : null
-          const scrollY = window.scrollY
 
           setIndicator(true)
 
@@ -573,26 +631,17 @@
 
               targets.forEach((target, i) => {
                 const newTarget = newTargets[i]
-                if (!newTarget) return
-                newTarget.querySelectorAll("details[id]").forEach((d) => {
-                  if (detailsState.has(d.id)) d.open = detailsState.get(d.id)
-                })
-                // Mark rows whose status transitioned so the pulse animation fires.
-                newTarget.querySelectorAll("tr.task-row[data-task-name]").forEach((r) => {
-                  const prev = previousStatuses.get(r.dataset.taskName)
-                  if (prev !== undefined && prev !== r.dataset.status) {
-                    r.classList.add("task-row-just-changed")
-                    setTimeout(() => r.classList.remove("task-row-just-changed"), 1900)
-                  }
-                })
-                target.replaceWith(newTarget)
+                if (newTarget) morph(target, newTarget)
               })
 
-              if (focusedId) {
-                const el = document.getElementById(focusedId)
-                if (el && typeof el.focus === "function") el.focus()
-              }
-              window.scrollTo(0, scrollY)
+              // Pulse rows whose status changed during this poll.
+              document.querySelectorAll("tr.task-row[data-task-name]").forEach((r) => {
+                const prev = previousStatuses.get(r.dataset.taskName)
+                if (prev !== undefined && prev !== r.dataset.status) {
+                  r.classList.add("task-row-just-changed")
+                  setTimeout(() => r.classList.remove("task-row-just-changed"), 1900)
+                }
+              })
 
               setIndicator(false)
               applyFilter()

--- a/app/views/maintenance_tasks/runs/_arguments.html.erb
+++ b/app/views/maintenance_tasks/runs/_arguments.html.erb
@@ -1,4 +1,4 @@
 <% if arguments.present? %>
-  <h6 class="title is-6 has-text-weight-medium">Arguments:</h6>
+  <h4 class="title is-6 has-text-weight-medium">Arguments:</h4>
   <%= render "maintenance_tasks/runs/serializable", serializable: arguments %>
 <% end %>

--- a/app/views/maintenance_tasks/runs/_csv.html.erb
+++ b/app/views/maintenance_tasks/runs/_csv.html.erb
@@ -1,5 +1,7 @@
 <% if run.csv_file.present? %>
   <div class="block">
-    <%= link_to("Download CSV", csv_file_download_path(run)) %>
+    <%= link_to(csv_file_download_path(run), class: "button is-small is-light", download: "") do %>
+      <span aria-hidden="true" class="mr-1">⬇</span>Download CSV
+    <% end %>
   </div>
 <% end %>

--- a/app/views/maintenance_tasks/runs/_metadata.html.erb
+++ b/app/views/maintenance_tasks/runs/_metadata.html.erb
@@ -1,4 +1,4 @@
 <% if metadata.present? %>
-  <h6 class="title is-6">Metadata:</h6>
+  <h4 class="title is-6">Metadata:</h4>
   <%= render "maintenance_tasks/runs/serializable", serializable: metadata %>
 <% end %>

--- a/app/views/maintenance_tasks/runs/_run.html.erb
+++ b/app/views/maintenance_tasks/runs/_run.html.erb
@@ -1,51 +1,49 @@
-<details class="box" open id="run_<%= run.id %>">
-  <summary class="is-flex is-justify-content-space-between is-align-items-center">
-    <div class="is-flex is-align-items-center">
-      <h5 class="title is-5 has-text-weight-medium pl-5 pr-5 mb-0">
-        <%= time_tag run.created_at, title: run.created_at.utc %>
-      </h5>
+<div class="run">
+  <%= link_to "##{run.id}", "#run_#{run.id}", class: "run-permalink", title: "Run ID" %>
+  <details class="box" open id="run_<%= run.id %>">
+    <summary class="is-flex is-align-items-center">
+      <h3 class="title is-5 has-text-weight-medium pr-5 mb-0">
+        <%= time_tag run.created_at, aria: { label: "#{run.created_at.utc.strftime("%B %-d, %Y at %H:%M")} UTC" } %>
+      </h3>
       <%= status_tag run.status %>
+    </summary>
+
+    <%= progress run %>
+
+    <div class="content">
+      <%= render "maintenance_tasks/runs/info/#{run.status}", run: run %>
     </div>
-    <div>
-      <a href="#run_<%= run.id %>" class="is-pulled-right" title="Run ID">#<%= run.id %></a>
+
+    <div class="content" id="custom-content-<%= run.id %>">
+      <%= render "maintenance_tasks/runs/info/custom", run: run %>
     </div>
-  </summary>
 
-  <%= progress run %>
+    <%= render "maintenance_tasks/runs/csv", run: run %>
+    <%= tag.hr if run.csv_file.present? && run.arguments.present? %>
+    <%= render "maintenance_tasks/runs/arguments", arguments: run.masked_arguments %>
+    <%= tag.hr if run.csv_file.present? || run.arguments.present? && run.metadata.present? %>
+    <%= render "maintenance_tasks/runs/metadata", metadata: run.metadata %>
 
-  <div class="content">
-    <%= render "maintenance_tasks/runs/info/#{run.status}", run: run %>
-  </div>
-
-  <div class="content" id="custom-content">
-    <%= render "maintenance_tasks/runs/info/custom", run: run %>
-  </div>
-
-  <%= render "maintenance_tasks/runs/csv", run: run %>
-  <%= tag.hr if run.csv_file.present? && run.arguments.present? %>
-  <%= render "maintenance_tasks/runs/arguments", arguments: run.masked_arguments %>
-  <%= tag.hr if run.csv_file.present? || run.arguments.present? && run.metadata.present? %>
-  <%= render "maintenance_tasks/runs/metadata", metadata: run.metadata %>
-
-  <div class="buttons">
-    <% if run.paused? %>
-      <%= button_to 'Resume', resume_task_run_path(@task, run), class: 'button is-primary', disabled: @task.deleted? %>
-      <%= button_to 'Cancel', cancel_task_run_path(@task, run), class: 'button is-danger' %>
-    <% elsif run.errored? %>
-      <%= button_to 'Resume', resume_task_run_path(@task, run), class: 'button is-primary', disabled: @task.deleted? %>
-    <% elsif run.cancelling? %>
-      <% if run.stuck? %>
-        <%= button_to 'Cancel', cancel_task_run_path(@task, run), class: 'button is-danger', disabled: @task.deleted? %>
+    <div class="buttons">
+      <% if run.paused? %>
+        <%= button_to 'Resume', resume_task_run_path(@task, run), class: 'button is-primary', disabled: @task.deleted? %>
+        <%= button_to 'Cancel', cancel_task_run_path(@task, run), class: 'button is-danger' %>
+      <% elsif run.errored? %>
+        <%= button_to 'Resume', resume_task_run_path(@task, run), class: 'button is-primary', disabled: @task.deleted? %>
+      <% elsif run.cancelling? %>
+        <% if run.stuck? %>
+          <%= button_to 'Cancel', cancel_task_run_path(@task, run), class: 'button is-danger', disabled: @task.deleted? %>
+        <% end %>
+      <% elsif run.pausing? %>
+        <%= button_to 'Pausing', pause_task_run_path(@task, run), class: 'button is-warning', disabled: true %>
+        <%= button_to 'Cancel', cancel_task_run_path(@task, run), class: 'button is-danger' %>
+        <% if run.stuck? %>
+          <%= button_to 'Force pause', pause_task_run_path(@task, run), class: 'button is-danger', disabled: @task.deleted? %>
+        <% end %>
+      <% elsif run.active? %>
+        <%= button_to 'Pause', pause_task_run_path(@task, run), class: 'button is-warning', disabled: @task.deleted? %>
+        <%= button_to 'Cancel', cancel_task_run_path(@task, run), class: 'button is-danger' %>
       <% end %>
-    <% elsif run.pausing? %>
-      <%= button_to 'Pausing', pause_task_run_path(@task, run), class: 'button is-warning', disabled: true %>
-      <%= button_to 'Cancel', cancel_task_run_path(@task, run), class: 'button is-danger' %>
-      <% if run.stuck? %>
-        <%= button_to 'Force pause', pause_task_run_path(@task, run), class: 'button is-danger', disabled: @task.deleted? %>
-      <% end %>
-    <% elsif run.active? %>
-      <%= button_to 'Pause', pause_task_run_path(@task, run), class: 'button is-warning', disabled: @task.deleted? %>
-      <%= button_to 'Cancel', cancel_task_run_path(@task, run), class: 'button is-danger' %>
-    <% end %>
-  </div>
-</details>
+    </div>
+  </details>
+</div>

--- a/app/views/maintenance_tasks/tasks/_task.html.erb
+++ b/app/views/maintenance_tasks/tasks/_task.html.erb
@@ -1,40 +1,35 @@
-<div class="cell box">
-  <h3 class="title is-5 has-text-weight-medium is-flex is-align-items-center">
-    <%= link_to task, task_path(task) %>
-    <%= status_tag(task.status) %>
-  </h3>
-
-  <% if (run = task.related_run) %>
-    <% if task.stale? %>
-      <div class="content is-size-7 is-flex is-align-items-center has-text-warning">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon is-small">
-          <path stroke-linecap="round" stroke-linejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
-        </svg>
-
-        <p class="ml-1">
-          This task last ran <%= MaintenanceTasks.task_staleness_threshold.inspect %> ago. Consider removing it as it may be stale.
-        </p>
-      </div>
+<tr class="task-row"
+    data-task-name="<%= task.name %>"
+    data-tags="<%= task.tags.join(" ") %>"
+    data-status="<%= task.status %>">
+  <td class="task-row-name">
+    <%= link_to task, task_path(task), class: "has-text-weight-medium" %>
+  </td>
+  <td class="task-row-tags">
+    <% if task.tags.any? %>
+      <% task.tags.each do |tag_name| %>
+        <span class="tag is-light is-small mr-1"><%= tag_name %></span>
+      <% end %>
+    <% else %>
+      <span class="has-text-grey-light">—</span>
     <% end %>
-
-    <h5 class="title is-5 has-text-weight-medium">
-      <%= time_tag run.created_at, title: run.created_at.utc %>
-    </h5>
-
-    <%= progress run %>
-
-    <div class="content">
-      <%= render "maintenance_tasks/runs/info/#{run.status}", run: run %>
-    </div>
-
-    <div class="content" id="custom-content">
-      <%= render "maintenance_tasks/runs/info/custom", run: run %>
-    </div>
-
-    <%= render "maintenance_tasks/runs/csv", run: run %>
-    <%= tag.hr if run.csv_file.present? && run.arguments.present? %>
-    <%= render "maintenance_tasks/runs/arguments", arguments: run.masked_arguments %>
-    <%= tag.hr if run.csv_file.present? || run.arguments.present? && run.metadata.present? %>
-    <%= render "maintenance_tasks/runs/metadata", metadata: run.metadata %>
-  <% end %>
-</div>
+  </td>
+  <td class="task-row-status">
+    <% if (run = task.related_run) %>
+      <%= status_tag(task.status) %>
+      <span class="has-text-grey is-size-7 ml-2">
+        <%= time_ago(run.created_at) %>
+      </span>
+      <% if task.stale? %>
+        <span class="has-text-warning is-size-7 ml-2"
+              aria-label="This task last ran <%= MaintenanceTasks.task_staleness_threshold.inspect %> ago; consider removing it.">
+          <span aria-hidden="true">⚠</span> stale
+        </span>
+      <% end %>
+    <% else %>
+      <% unless local_assigns[:hide_never_run_label] %>
+        <span class="has-text-grey-light is-size-7">Never run</span>
+      <% end %>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/maintenance_tasks/tasks/index.html.erb
+++ b/app/views/maintenance_tasks/tasks/index.html.erb
@@ -1,26 +1,75 @@
-<%= tag.div(data: { refresh: (defined?(@refresh) && @refresh) || "" }) do %>
-  <% if @available_tasks.empty? %>
-    <div class="content is-large">
-      <h3 class="title is-3"> The MaintenanceTasks gem has been successfully installed! </h3>
-      <p>
-        Any new Tasks will show up here. To start writing your first Task,
-        run <code>bin/rails generate maintenance_tasks:task my_task</code>.
-      </p>
+<h1 class="title is-3 has-text-weight-bold">Tasks</h1>
+
+<% if @tasks.empty? %>
+  <div class="content">
+    <p class="is-size-5">No maintenance tasks have been defined yet.</p>
+    <p>
+      Generate your first task with:
+    </p>
+    <pre><code>bin/rails generate maintenance_tasks:task my_task</code></pre>
+  </div>
+<% else %>
+  <div class="task-toolbar mb-4">
+    <div class="control has-icons-left">
+      <input type="search"
+             id="task-search"
+             class="input"
+             placeholder="Search tasks…"
+             aria-label="Search tasks by name"
+             autocomplete="off"
+             autocapitalize="off"
+             spellcheck="false">
+      <span class="icon is-left" aria-hidden="true">⌕</span>
     </div>
-  <% else %>
-    <% if active_tasks = @available_tasks[:active] %>
-      <h3 class="title is-4 has-text-weight-bold">Active Tasks</h3>
-      <%= render partial: 'task', collection: active_tasks %>
-    <% end %>
-    <% if new_tasks = @available_tasks[:new] %>
-      <h3 class="title is-4 has-text-weight-bold">New Tasks</h3>
-      <div class="grid is-col-min-20">
-        <%= render partial: 'task', collection: new_tasks %>
+
+    <% if @tag_filters.any? %>
+      <div class="tag-filters" role="group" aria-label="Filter tasks by tag">
+        <% @tag_filters.each do |tag_name| %>
+          <button type="button"
+                  class="tag-filter tag is-medium"
+                  data-tag="<%= tag_name %>"
+                  aria-pressed="false">
+            <%= tag_name %>
+          </button>
+        <% end %>
       </div>
     <% end %>
-    <% if completed_tasks = @available_tasks[:completed] %>
-      <h3 class="title is-4 has-text-weight-bold">Completed Tasks</h3>
-      <%= render partial: 'task', collection: completed_tasks %>
-    <% end %>
+  </div>
+
+  <p class="task-empty-results has-text-grey is-italic mb-4" hidden role="status">
+    No tasks match the current filters.
+  </p>
+
+  <% with_runs, never_run = @tasks.partition(&:related_run) %>
+
+  <%= tag.div(data: { refresh: (defined?(@refresh) && @refresh) || "" }) do %>
+    <div class="table-container">
+      <table class="task-table table is-fullwidth is-hoverable">
+        <thead>
+          <tr>
+            <th scope="col">Task</th>
+            <th scope="col">Tags</th>
+            <th scope="col" class="task-col-last-run">Last run</th>
+          </tr>
+        </thead>
+        <% if with_runs.any? %>
+          <tbody>
+            <%= render partial: "task", collection: with_runs %>
+          </tbody>
+        <% end %>
+        <% if never_run.any? %>
+          <% if with_runs.any? %>
+            <tbody class="task-section-divider" aria-hidden="true">
+              <tr>
+                <td colspan="3"><span>Never run</span></td>
+              </tr>
+            </tbody>
+          <% end %>
+          <tbody>
+            <%= render partial: "task", collection: never_run, locals: { hide_never_run_label: with_runs.any? } %>
+          </tbody>
+        <% end %>
+      </table>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -4,12 +4,31 @@
   <%= @task %>
 </h1>
 
-<div class="container">
+<% if @task.deleted? %>
+  <div class="notification is-warning is-light" role="status">
+    This task no longer exists in the codebase. <strong>Run, Pause, Resume, and Cancel actions are disabled</strong> until it is restored.
+  </div>
+<% end %>
+
+<%= tag.div(data: { refresh: @task.refresh? || "" }) do %>
+  <% if @task.active_runs.any? %>
+    <section class="task-active-runs mb-6">
+      <h2 class="title is-4">Active Runs</h2>
+      <%= render partial: "maintenance_tasks/runs/run", collection: @task.active_runs %>
+    </section>
+  <% end %>
+<% end %>
+
+<h2 class="title is-4 mt-5">Run this task</h2>
+
+<div class="container mb-6">
   <%= form_with url: task_runs_path(@task), method: :post do |form| %>
     <% if @task.csv_task? %>
-      <div class="container mb-4">
-        <%= form.label :csv_file, class: "label" %>
-        <%= form.file_field :csv_file, accept: "text/csv" %>
+      <div class="field mb-4">
+        <%= form.label :csv_file, "CSV file", class: "label" %>
+        <div class="control">
+          <%= form.file_field :csv_file, accept: "text/csv", class: "csv-file-input" %>
+        </div>
       </div>
     <% end %>
     <% parameter_names = @task.parameter_names %>
@@ -27,37 +46,28 @@
     <% end %>
     <%= render "maintenance_tasks/tasks/custom", form: form %>
     <div class="block">
-      <%= form.submit 'Run', class: "button is-success is-rounded mb-4 has-text-white-ter", disabled: @task.deleted? %>
+      <%= form.submit "Run", class: "button is-success", disabled: @task.deleted? %>
     </div>
   <% end %>
 </div>
 
-<% if (code = @task.code) %>
+<%= tag.div(data: { refresh: @task.refresh? || "" }) do %>
+  <% if @task.runs_page.records.present? %>
+    <section class="task-previous-runs mt-6">
+      <h2 class="title is-4">Previous Runs</h2>
 
-<details class="box">
-  <summary class="is-size-5 is-flex is-align-items-center">
-    <h5 class="pl-5">Source code</h5>
-  </summary>
-  <pre><code><%= highlight_code(code) %></code></pre>
-</details>
+      <%= render partial: "maintenance_tasks/runs/run", collection: @task.runs_page.records %>
+
+      <%= link_to "Next page", task_path(@task, cursor: @task.runs_page.next_cursor), class: "pagination-link" unless @task.runs_page.last? %>
+    </section>
+  <% end %>
 <% end %>
 
-<%= tag.div(data: { refresh: @task.refresh? || "" }) do %>
-  <% if @task.active_runs.any? %>
-    <hr>
-
-    <h4 class="title is-4">Active Runs</h4>
-
-    <%= render partial: "maintenance_tasks/runs/run", collection: @task.active_runs %>
-  <% end %>
-
-  <% if @task.runs_page.records.present? %>
-    <hr>
-
-    <h4 class="title is-5 has-text-weight-bold">Previous Runs</h4>
-
-    <%= render partial: "maintenance_tasks/runs/run", collection: @task.runs_page.records %>
-
-    <%= link_to "Next page", task_path(@task, cursor: @task.runs_page.next_cursor) unless @task.runs_page.last? %>
-  <% end %>
+<% if (code = @task.code) %>
+  <details class="box mt-6">
+    <summary class="is-size-5 is-flex is-align-items-center">
+      <h2 class="title is-5 mb-0">Source code</h2>
+    </summary>
+    <pre><code><%= highlight_code(code) %></code></pre>
+  </details>
 <% end %>

--- a/test/dummy/app/tasks/maintenance/batch_import_posts_task.rb
+++ b/test/dummy/app/tasks/maintenance/batch_import_posts_task.rb
@@ -2,6 +2,7 @@
 
 module Maintenance
   class BatchImportPostsTask < MaintenanceTasks::Task
+    tag :posts, :csv
     csv_collection(in_batches: 2)
 
     def process(post_rows)

--- a/test/dummy/app/tasks/maintenance/cancelled_enqueue_task.rb
+++ b/test/dummy/app/tasks/maintenance/cancelled_enqueue_task.rb
@@ -3,6 +3,8 @@
 module Maintenance
   # Any job enqueued for this task gets cancelled, see CustomTaskJob.
   class CancelledEnqueueTask < MaintenanceTasks::Task
+    tag :errors
+
     def collection
       []
     end

--- a/test/dummy/app/tasks/maintenance/enqueue_error_task.rb
+++ b/test/dummy/app/tasks/maintenance/enqueue_error_task.rb
@@ -3,6 +3,8 @@
 module Maintenance
   # Any job enqueued for this task errors, see CustomTaskJob.
   class EnqueueErrorTask < MaintenanceTasks::Task
+    tag :errors
+
     def collection
       []
     end

--- a/test/dummy/app/tasks/maintenance/error_task.rb
+++ b/test/dummy/app/tasks/maintenance/error_task.rb
@@ -2,6 +2,8 @@
 
 module Maintenance
   class ErrorTask < MaintenanceTasks::Task
+    tag :errors
+
     def collection
       [1, 2, 3, 4, 5]
     end

--- a/test/dummy/app/tasks/maintenance/import_posts_task.rb
+++ b/test/dummy/app/tasks/maintenance/import_posts_task.rb
@@ -2,6 +2,7 @@
 
 module Maintenance
   class ImportPostsTask < MaintenanceTasks::Task
+    tag :posts, :csv
     csv_collection
 
     def process(row)

--- a/test/dummy/app/tasks/maintenance/import_posts_with_encoding_task.rb
+++ b/test/dummy/app/tasks/maintenance/import_posts_with_encoding_task.rb
@@ -2,6 +2,7 @@
 
 module Maintenance
   class ImportPostsWithEncodingTask < MaintenanceTasks::Task
+    tag :posts, :csv
     csv_collection(encoding: Encoding::ASCII)
 
     def process(row)

--- a/test/dummy/app/tasks/maintenance/import_posts_with_options_task.rb
+++ b/test/dummy/app/tasks/maintenance/import_posts_with_options_task.rb
@@ -2,6 +2,7 @@
 
 module Maintenance
   class ImportPostsWithOptionsTask < MaintenanceTasks::Task
+    tag :posts, :csv
     csv_collection(skip_lines: /^#/, converters: ->(field) { field.to_s.upcase })
 
     def process(row)

--- a/test/dummy/app/tasks/maintenance/params_task.rb
+++ b/test/dummy/app/tasks/maintenance/params_task.rb
@@ -10,6 +10,8 @@ module Maintenance
   end
 
   class ParamsTask < MaintenanceTasks::Task
+    tag :params, :examples
+
     attribute :post_ids, :string
 
     validates :post_ids,

--- a/test/dummy/app/tasks/maintenance/stale_task.rb
+++ b/test/dummy/app/tasks/maintenance/stale_task.rb
@@ -2,6 +2,8 @@
 
 module Maintenance
   class StaleTask < MaintenanceTasks::Task
+    tag :examples
+
     def collection
       [1, 2]
     end

--- a/test/dummy/app/tasks/maintenance/update_posts_in_batches_task.rb
+++ b/test/dummy/app/tasks/maintenance/update_posts_in_batches_task.rb
@@ -2,6 +2,8 @@
 
 module Maintenance
   class UpdatePostsInBatchesTask < MaintenanceTasks::Task
+    tag :posts, :updates
+
     def collection
       Post.in_batches(of: 5)
     end

--- a/test/dummy/app/tasks/maintenance/update_posts_module_prepended_task.rb
+++ b/test/dummy/app/tasks/maintenance/update_posts_module_prepended_task.rb
@@ -4,6 +4,7 @@ require "test_module"
 
 module Maintenance
   class UpdatePostsModulePrependedTask < MaintenanceTasks::Task
+    tag :posts, :updates
     prepend TestModule
 
     class << self

--- a/test/dummy/app/tasks/maintenance/update_posts_task.rb
+++ b/test/dummy/app/tasks/maintenance/update_posts_task.rb
@@ -2,6 +2,8 @@
 
 module Maintenance
   class UpdatePostsTask < MaintenanceTasks::Task
+    tag :posts, :updates
+
     class << self
       attr_accessor :fast_task
     end

--- a/test/dummy/app/tasks/maintenance/update_posts_throttled_task.rb
+++ b/test/dummy/app/tasks/maintenance/update_posts_throttled_task.rb
@@ -2,6 +2,8 @@
 
 module Maintenance
   class UpdatePostsThrottledTask < MaintenanceTasks::Task
+    tag :posts, :updates, :throttled
+
     class << self
       attr_accessor :throttle, :throttle_proc
     end

--- a/test/helpers/maintenance_tasks/application_helper_test.rb
+++ b/test/helpers/maintenance_tasks/application_helper_test.rb
@@ -4,12 +4,12 @@ require "test_helper"
 
 module MaintenanceTasks
   class ApplicationHelperTest < ActionView::TestCase
-    test "#time_ago returns a time element with the given datetime worded as relative to now and ISO 8601 UTC time in title attribute" do
+    test "#time_ago returns a time element with relative wording and an accessible UTC label" do
       travel_to Time.zone.local(2020, 1, 9, 9, 41, 44)
       time = Time.zone.local(2020, 1, 1, 1, 0, 0)
 
       expected = '<time datetime="2020-01-01T01:00:00Z" ' \
-        'title="2020-01-01 01:00:00 UTC" class="is-clickable">8 days ago</time>'
+        'aria-label="January 1, 2020 at 01:00 UTC">8 days ago</time>'
       assert_equal expected, time_ago(time)
     end
   end

--- a/test/helpers/maintenance_tasks/tasks_helper_test.rb
+++ b/test/helpers/maintenance_tasks/tasks_helper_test.rb
@@ -28,8 +28,9 @@ module MaintenanceTasks
       )
 
       expected = '<div class="block"><progress value="42" max="84" ' \
-        'class="progress mt-4 is-primary is-light"></progress>' \
-        "<p><i>Almost there!</i></p></div>"
+        'class="progress mt-4 is-primary is-light" ' \
+        'aria-labelledby="progress_text_"></progress>' \
+        '<p id="progress_text_"><i>Almost there!</i></p></div>'
       assert_equal expected, progress(@run)
     end
 
@@ -44,13 +45,15 @@ module MaintenanceTasks
       )
 
       expected = '<div class="block"><progress max="84" ' \
-        'class="progress mt-4 is-primary is-light"></progress>' \
-        "<p><i>Almost there!</i></p></div>"
+        'class="progress mt-4 is-primary is-light" ' \
+        'aria-labelledby="progress_text_"></progress>' \
+        '<p id="progress_text_"><i>Almost there!</i></p></div>'
       assert_equal expected, progress(@run)
     end
 
     test "#status_tag renders a span with the appropriate tag based on status" do
-      expected = '<span class="tag has-text-weight-medium px-2 mx-4 is-warning is-light">Pausing</span>'
+      expected = '<span class="tag has-text-weight-medium px-2 ml-2 is-warning is-light">' \
+        '<span aria-hidden="true" class="mr-1">⌛</span>Pausing</span>'
       assert_equal expected, status_tag("pausing")
     end
 

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -182,7 +182,7 @@ module MaintenanceTasks
 
       assert_equal "ArgumentError", run.error_class
       assert_equal "Something went wrong", run.error_message
-      expected_backtrace = %r{app/tasks/maintenance/error_task\.rb:10:in ('Maintenance::ErrorTask#|`)process'}
+      expected_backtrace = %r{app/tasks/maintenance/error_task\.rb:12:in ('Maintenance::ErrorTask#|`)process'}
       assert_match expected_backtrace, run.backtrace.first
       assert_equal Time.now, run.ended_at
       assert_equal "1", run.cursor

--- a/test/models/maintenance_tasks/task_test.rb
+++ b/test/models/maintenance_tasks/task_test.rb
@@ -133,5 +133,55 @@ module MaintenanceTasks
     ensure
       Maintenance::TestTask.status_reload_frequency = original_reload_frequency
     end
+
+    test ".tags defaults to an empty frozen array" do
+      assert_equal [], Maintenance::TestTask.tags
+      assert Maintenance::TestTask.tags.frozen?
+    end
+
+    test ".tag adds the given symbols to .tags" do
+      assert_equal [:posts, :updates], Maintenance::UpdatePostsTask.tags
+    end
+
+    test ".tag accepts strings and coerces them to symbols" do
+      sandbox_tags(Maintenance::TestTask) do
+        Maintenance::TestTask.tag("data", "cleanup")
+        assert_equal [:data, :cleanup], Maintenance::TestTask.tags
+      end
+    end
+
+    test ".tag is additive across multiple calls and dedupes" do
+      sandbox_tags(Maintenance::TestTask) do
+        Maintenance::TestTask.tag(:data)
+        Maintenance::TestTask.tag(:data, :cleanup)
+        assert_equal [:data, :cleanup], Maintenance::TestTask.tags
+      end
+    end
+
+    test ".tag in a subclass inherits parent tags without mutating the parent" do
+      # Use two existing tagged tasks: ImportPostsTask (:posts, :csv)
+      # subclasses are tested implicitly elsewhere; here we directly verify
+      # that the inheritance semantic works via class_attribute.
+      assert_equal [:posts, :csv], Maintenance::ImportPostsTask.tags
+      assert_equal [:posts, :updates], Maintenance::UpdatePostsTask.tags
+      # And that calls to one do not leak into the other.
+      sandbox_tags(Maintenance::TestTask) do
+        Maintenance::TestTask.tag(:isolated)
+        assert_equal [:isolated], Maintenance::TestTask.tags
+        assert_equal [:posts, :csv], Maintenance::ImportPostsTask.tags
+      end
+    end
+
+    private
+
+    # Snapshots and restores a Task class's tags around a block so each test
+    # is hermetic. Avoids spawning anonymous subclasses (which would leak into
+    # ActiveSupport::DescendantsTracker and pollute .load_all).
+    def sandbox_tags(task_class)
+      original = task_class.tags
+      yield
+    ensure
+      task_class.tags = original
+    end
   end
 end


### PR DESCRIPTION
## Summary

Before, every 3-second poll on a page with `[data-refresh]` wholesale replaced the matching subtree, then patched things back up: re-applying `<details open>` state, re-focusing the active element, restoring `window.scrollY`, and adding a pulse class to rows whose status had transitioned. With nothing changed server-side, this still produced a complete subtree replacement every tick.

This PR adds a small `morph(oldNode, newNode)` walker (~70 lines inline JS):

- **Fast-path on `isEqualNode`** — identical subtrees produce zero DOM mutations. Verified with `MutationObserver`: a no-op poll records **0** mutation records (was: one large `childList` replacement covering the whole subtree).
- **Per-element attribute sync.** `<details open>` is explicitly skipped — server always renders open, but a user-closed detail must stay closed.
- **Children matched by id when present** (run cards have `id=\"run_N\"`), otherwise by position. Server ordering is deterministic so position matching is stable.

Because morph preserves node identity, the explicit snapshot/restore of `<details>` state, focus, and scrollY is no longer needed — it's gone. The row-pulse on status transitions stays and keys off the live (preserved) row.

### Constraint

Form input `value`/`checked` properties are not synced — no inputs currently live inside `[data-refresh]`. This is called out in an inline comment so the next person to add an input to a polled region sees it.

CSP hash for the inline `<script>` updated accordingly.

## Stack

**PR 3 of 4.** Depends on #1486.

Until #1485 and #1486 merge, this PR's diff includes their commits. Once they merge, this diff shrinks to just the morph rewrite + CSP hash bump.

## Test plan

- [x] `bundle exec rake test` passes (296 runs, 939 assertions, 0 failures)
- [x] `bundle exec rubocop` clean
- [x] In-browser via `MutationObserver`:
  - **No-op poll** (no server-side change) → 0 DOM mutations across 2 polling cycles
  - **Divergent state** (mutate row's `data-status` client-side) → next morph reverts only that attribute, **2** attribute mutations, row node identity preserved
  - Stale client-only attribute removed by morph (e.g. a marker `data-*`)
  - `<details>` that user has closed stays closed across polls