### PR TITLE
Add toggle to disable task list auto-refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,6 +856,11 @@ end
 
 You can run your new Task by accessing the Web UI and clicking on "Run".
 
+The task list page auto-refreshes in the background to reflect the latest run
+statuses. You can turn this off with the "Disable auto-refresh" toggle on the
+page, which adds a `?refresh=false` parameter to the URL. Use "Enable
+auto-refresh" to turn it back on.
+
 #### Running a Task from the command line
 
 Alternatively, you can run your Task in the command line:

--- a/README.md
+++ b/README.md
@@ -856,10 +856,10 @@ end
 
 You can run your new Task by accessing the Web UI and clicking on "Run".
 
-The task list page auto-refreshes in the background to reflect the latest run
-statuses. You can turn this off with the "Disable auto-refresh" toggle on the
-page, which adds a `?refresh=false` parameter to the URL. Use "Enable
-auto-refresh" to turn it back on.
+A Task's page auto-refreshes in the background while it has active runs, so the
+progress and run statuses stay up to date. You can turn this off with the
+"Disable auto-refresh" toggle on the Task page, which adds a `?refresh=false`
+parameter to the URL. Use "Enable auto-refresh" to turn it back on.
 
 #### Running a Task from the command line
 

--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -28,7 +28,7 @@ module MaintenanceTasks
     private
 
     def set_refresh
-      @refresh = true
+      @refresh = params[:refresh] != "false"
     end
   end
 end

--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -7,7 +7,7 @@ module MaintenanceTasks
   #
   # @api private
   class TasksController < ApplicationController
-    before_action :set_refresh, only: [:index]
+    before_action :set_refresh, only: [:index, :show]
 
     # Renders the maintenance_tasks/tasks page, displaying
     # available tasks to users, grouped by category.

--- a/app/views/maintenance_tasks/tasks/index.html.erb
+++ b/app/views/maintenance_tasks/tasks/index.html.erb
@@ -1,4 +1,11 @@
-<%= tag.div(data: { refresh: (defined?(@refresh) && @refresh) || "" }) do %>
+<div class="is-flex is-justify-content-flex-end mb-2">
+  <% if @refresh %>
+    <%= link_to "Disable auto-refresh", root_path(refresh: false), class: "button is-small" %>
+  <% else %>
+    <%= link_to "Enable auto-refresh", root_path, class: "button is-small" %>
+  <% end %>
+</div>
+<%= tag.div(data: { refresh: @refresh || "" }) do %>
   <% if @available_tasks.empty? %>
     <div class="content is-large">
       <h3 class="title is-3"> The MaintenanceTasks gem has been successfully installed! </h3>

--- a/app/views/maintenance_tasks/tasks/index.html.erb
+++ b/app/views/maintenance_tasks/tasks/index.html.erb
@@ -1,11 +1,4 @@
-<div class="is-flex is-justify-content-flex-end mb-2">
-  <% if @refresh %>
-    <%= link_to "Disable auto-refresh", root_path(refresh: false), class: "button is-small" %>
-  <% else %>
-    <%= link_to "Enable auto-refresh", root_path, class: "button is-small" %>
-  <% end %>
-</div>
-<%= tag.div(data: { refresh: @refresh || "" }) do %>
+<%= tag.div(data: { refresh: (defined?(@refresh) && @refresh) || "" }) do %>
   <% if @available_tasks.empty? %>
     <div class="content is-large">
       <h3 class="title is-3"> The MaintenanceTasks gem has been successfully installed! </h3>

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -42,7 +42,16 @@
 </details>
 <% end %>
 
-<%= tag.div(data: { refresh: @task.refresh? || "" }) do %>
+<% if @task.refresh? %>
+  <div class="is-flex is-justify-content-flex-end mb-2">
+    <% if @refresh %>
+      <%= link_to "Disable auto-refresh", task_path(@task, refresh: false), class: "button is-small" %>
+    <% else %>
+      <%= link_to "Enable auto-refresh", task_path(@task), class: "button is-small" %>
+    <% end %>
+  </div>
+<% end %>
+<%= tag.div(data: { refresh: (@task.refresh? && @refresh) || "" }) do %>
   <% if @task.active_runs.any? %>
     <hr>
 

--- a/test/integration/maintenance_tasks/tasks_controller_test.rb
+++ b/test/integration/maintenance_tasks/tasks_controller_test.rb
@@ -4,32 +4,44 @@ require "test_helper"
 
 module MaintenanceTasks
   class TasksControllerTest < ActionDispatch::IntegrationTest
-    test "task list auto-refreshes by default" do
-      get maintenance_tasks_path
+    # Maintenance::UpdatePostsTask has a paused (active) run, so its show page
+    # refreshes by default.
+    ACTIVE_TASK = "Maintenance::UpdatePostsTask"
+
+    test "task page auto-refreshes by default when there are active runs" do
+      get maintenance_tasks.task_path(ACTIVE_TASK)
 
       assert_response :success
       assert_select "[data-refresh=true]"
     end
 
-    test "task list does not auto-refresh when refresh=false is passed" do
-      get maintenance_tasks_path, params: { refresh: "false" }
+    test "task page does not auto-refresh when refresh=false is passed" do
+      get maintenance_tasks.task_path(ACTIVE_TASK), params: { refresh: "false" }
 
       assert_response :success
       assert_select "[data-refresh=true]", false
     end
 
-    test "task list shows a link to disable auto-refresh when refreshing" do
-      get maintenance_tasks_path
+    test "task page shows a link to disable auto-refresh when refreshing" do
+      get maintenance_tasks.task_path(ACTIVE_TASK)
 
       assert_response :success
       assert_select "a[href*='refresh=false']", text: "Disable auto-refresh"
     end
 
-    test "task list shows a link to enable auto-refresh when not refreshing" do
-      get maintenance_tasks_path, params: { refresh: "false" }
+    test "task page shows a link to enable auto-refresh when not refreshing" do
+      get maintenance_tasks.task_path(ACTIVE_TASK), params: { refresh: "false" }
 
       assert_response :success
-      assert_select "a[href='/maintenance_tasks/']", text: "Enable auto-refresh"
+      assert_select "a", text: "Enable auto-refresh"
+    end
+
+    test "task page shows no auto-refresh toggle when there are no active runs" do
+      get maintenance_tasks.task_path("Maintenance::ImportPostsTask")
+
+      assert_response :success
+      assert_select "a", text: "Disable auto-refresh", count: 0
+      assert_select "a", text: "Enable auto-refresh", count: 0
     end
   end
 end

--- a/test/integration/maintenance_tasks/tasks_controller_test.rb
+++ b/test/integration/maintenance_tasks/tasks_controller_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module MaintenanceTasks
+  class TasksControllerTest < ActionDispatch::IntegrationTest
+    test "task list auto-refreshes by default" do
+      get maintenance_tasks_path
+
+      assert_response :success
+      assert_select "[data-refresh=true]"
+    end
+
+    test "task list does not auto-refresh when refresh=false is passed" do
+      get maintenance_tasks_path, params: { refresh: "false" }
+
+      assert_response :success
+      assert_select "[data-refresh=true]", false
+    end
+
+    test "task list shows a link to disable auto-refresh when refreshing" do
+      get maintenance_tasks_path
+
+      assert_response :success
+      assert_select "a[href*='refresh=false']", text: "Disable auto-refresh"
+    end
+
+    test "task list shows a link to enable auto-refresh when not refreshing" do
+      get maintenance_tasks_path, params: { refresh: "false" }
+
+      assert_response :success
+      assert_select "a[href='/maintenance_tasks/']", text: "Enable auto-refresh"
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/Shopify/maintenance_tasks/issues/1490

## Problem

The Maintenance Tasks web UI auto-refreshes pages every 3 seconds to keep run statuses up to date. This behavior is driven by JavaScript in the application layout: when an element with `data-refresh` is present and truthy, the page periodically fetches the current URL and replaces the refreshed content in place.

While this is useful when monitoring active runs, it can be disruptive in other situations:

- **Debugging or inspecting the page** — the DOM is replaced every few seconds, making it hard to read logs, copy values, or use browser dev tools.
- **Stable UI for screenshots or demos** — auto-refresh causes the page to flicker and the cursor to change to a wait state.
- **Reduced background activity** — unnecessary polling when the operator does not need live updates.

Two pages are affected:

| Page | When it auto-refreshes | Prior behavior |
|------|------------------------|----------------|
| **Task list** (`TasksController#index`) | Always | `@refresh` was hard-coded to `true` |
| **Task show** (`TasksController#show`) | While the task has active runs (`@task.refresh?`) | No way to override `@task.refresh?` |

There was no user-facing way to turn auto-refresh off on either page.

## Proposed solution

Add a user-facing toggle on the **task show page** (when the task has active runs) to disable and re-enable auto-refresh. Respect a shared `?refresh=false` URL parameter in the controller so the preference applies consistently across both pages.

### Behavior

#### Task show page (primary UI)

The toggle is shown only when the task has active runs (`@task.refresh?`). When there are no active runs, the page does not auto-refresh and no toggle is displayed.

| State | URL | `data-refresh` attribute | UI control |
|-------|-----|--------------------------|------------|
| Default (auto-refresh on) | `/maintenance_tasks/tasks/:id` | `true` (when active runs exist) | "Disable auto-refresh" button |
| Auto-refresh off | `/maintenance_tasks/tasks/:id?refresh=false` | absent / empty | "Enable auto-refresh" button |

- Auto-refresh remains **on by default** when active runs are present.
- Disabling auto-refresh navigates to the same task with `?refresh=false`.
- Re-enabling auto-refresh navigates back to the task path without the query parameter.
- The toggle is a small button aligned to the top-right, above the runs section.

#### Task list page

The task list continues to auto-refresh by default and respects `?refresh=false` when present, but **does not include a toggle control**. Users who disable auto-refresh on a task show page can keep `refresh=false` in the URL when navigating back to the list, or append it manually.

| State | URL | `data-refresh` attribute | UI control |
|-------|-----|--------------------------|------------|
| Default (auto-refresh on) | `/maintenance_tasks/` | `true` | *(none)* |
| Auto-refresh off | `/maintenance_tasks/?refresh=false` | absent / empty | *(none)* |

### Implementation outline

1. **Controller** — Run `set_refresh` on both `index` and `show`, and read the `refresh` query parameter:

   ```ruby
   before_action :set_refresh, only: [:index, :show]

   def set_refresh
     @refresh = params[:refresh] != "false"
   end
   ```

2. **Task show view** — In `app/views/maintenance_tasks/tasks/show.html.erb`:
   - Render Disable/Enable toggle links when `@task.refresh?` is true.
   - Set `data-refresh` from `@task.refresh? && @refresh` so both active-run status and the user preference are respected.

3. **Task list view** — In `app/views/maintenance_tasks/tasks/index.html.erb`, continue setting `data-refresh` from `@refresh` (no toggle UI).

4. **Tests** — Integration tests in `test/integration/maintenance_tasks/tasks_controller_test.rb` covering:
   - Task show page auto-refreshes by default when there are active runs (`[data-refresh=true]` present).
   - `refresh=false` disables auto-refresh on the task show page (`[data-refresh=true]` absent).
   - Correct toggle link is shown in each state on the task show page.
   - No toggle links when the task has no active runs.

5. **Documentation** — Document the toggle and `?refresh=false` URL parameter in the README (under "Running a Task from the Web UI").

## Mocks

- <img width="1409" height="591" alt="Screenshot 2026-05-29 alle 21 45 41" src="https://github.com/user-attachments/assets/dcbd2a42-109f-4a45-b2fe-53800d29e260" />
- <img width="1392" height="630" alt="Screenshot 2026-05-29 alle 21 45 14" src="https://github.com/user-attachments/assets/5fb0863f-266b-4a50-b003-396272230dec" />


## Scope

- **In scope:** User toggle on the task show page when active runs exist; controller-level `?refresh=false` support on both index and show actions.
- **Out of scope:** Toggle UI on the task list page; persisting the preference beyond the current URL (e.g. cookies or local storage).

## Acceptance criteria

- [x] Task show page auto-refreshes by default when there are active runs (no change to current default behavior).
- [x] Users can disable auto-refresh via a visible control on the task show page (when active runs exist).
- [x] Disabling auto-refresh persists via the `?refresh=false` URL parameter.
- [x] Users can re-enable auto-refresh from the same page.
- [x] No toggle is shown when the task has no active runs.
- [x] Integration tests cover both refresh states, toggle links, and the no-active-runs case.
- [x] README documents the feature.
