### PR TITLE
Serialize Active Record errored elements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    maintenance_tasks (2.16.0)
+    maintenance_tasks (2.17.0)
       actionpack (>= 7.2)
       activejob (>= 7.2)
       activerecord (>= 7.2)
@@ -354,7 +354,7 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
+  bundler (4.0.11) sha256=5bcec0fb78302e48d02ee46f10ee6e6942be647ba5b44a6d1ddfda9a240ce785
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   capybara-lockstep (2.3.1) sha256=da575345da5a8ec97f742398af2c94fcce7c47ebdc76dc391b326ee2737afa55
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
@@ -385,7 +385,7 @@ CHECKSUMS
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
-  maintenance_tasks (2.16.0)
+  maintenance_tasks (2.17.0)
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef

--- a/README.md
+++ b/README.md
@@ -1047,6 +1047,8 @@ Reports to the error reporter will contain the following data:
    * `run_id`: The id of the errored Task run
    * `tick_count`: The tick count at the time of the error
    * `errored_element`: The element, if any, that was being processed when the
+     Task errored. Active Record elements are reported as a hash with
+     `class_name` and `id` keys.
 * `source`: This will be `maintenance-tasks`
 * `handled`: the value of `MaintenanceTasks.report_errors_as_handled` (default `true`, see below)
 

--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -42,6 +42,15 @@ module MaintenanceTasks
       @run.cursor
     end
 
+    def serialized_errored_element(errored_element)
+      return errored_element unless errored_element.is_a?(ActiveRecord::Base)
+
+      {
+        class_name: errored_element.class.name,
+        id: errored_element.id,
+      }
+    end
+
     def build_enumerator(_run, cursor:)
       cursor ||= deserialized_run_cursor
       self.cursor_position = cursor
@@ -206,10 +215,15 @@ module MaintenanceTasks
         errored_element = task_context.delete(:errored_element)
         MaintenanceTasks.error_handler.call(error, task_context.except(:run_id, :tick_count), errored_element)
       else
+        report_context = task_context.dup
+        if report_context.key?(:errored_element)
+          report_context[:errored_element] = serialized_errored_element(report_context[:errored_element])
+        end
+
         Rails.error.report(
           error,
           handled: MaintenanceTasks.report_errors_as_handled,
-          context: task_context,
+          context: report_context,
           source: "maintenance-tasks",
         )
       end

--- a/maintenance_tasks.gemspec
+++ b/maintenance_tasks.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "maintenance_tasks"
-  spec.version = "2.16.0"
+  spec.version = "2.17.0"
   spec.author = "Shopify Engineering"
   spec.email = "gems@shopify.com"
   spec.homepage = "https://github.com/Shopify/maintenance_tasks"

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -517,9 +517,30 @@ module MaintenanceTasks
       assert_equal("Maintenance::ErrorTask", report.dig(:context, :task_name))
       assert_equal(run.id, report.dig(:context, :run_id))
       assert_equal(0, report.dig(:context, :tick_count))
+      assert_equal(3, report.dig(:context, :errored_element))
       refute_predicate(report, :handled)
     ensure
       MaintenanceTasks.report_errors_as_handled = @old_handled
+    end
+
+    test ".perform_now reports Active Record errored elements as serializable context" do
+      post = Post.create!(title: "Hello World!", content: "Something")
+      run = Run.create!(task_name: "Maintenance::UpdatePostsTask")
+
+      Maintenance::UpdatePostsTask.any_instance.expects(:collection).returns(Post.where(id: post.id))
+      Maintenance::UpdatePostsTask.any_instance.expects(:process).with do |input|
+        assert_equal(post.id, input.id)
+        true
+      end.raises(ArgumentError)
+
+      report = assert_error_reported(ArgumentError) do
+        TaskJob.perform_now(run)
+      end
+
+      assert_equal(
+        { class_name: "Post", id: post.id },
+        report.dig(:context, :errored_element),
+      )
     end
 
     test ".perform_now handles case where run is not set and reports error" do


### PR DESCRIPTION
Rails now deep-dups error report context for each subscriber, so passing an Active Record instance as `errored_element` can clear its primary key before subscribers serialize it.

This PR serialize the Active Record `errored_element` values before calling `Rails.error.report`, while preserving non-Active Record values and the legacy handler path.

Rails change: https://github.com/rails/rails/commit/d9e293ee196c42349f0f2ea4596b5af692057f31

I'm opting not to branch based on the AR version (ie. deprecate calling the error reporter with the full AR object and branch on the new codepath), but we can go that route if preferred.