### PR TITLE
Fix RecordInvalid when a concurrent run reaches a terminal status

### DIFF
--- a/app/models/concerns/maintenance_tasks/run_concern.rb
+++ b/app/models/concerns/maintenance_tasks/run_concern.rb
@@ -110,6 +110,14 @@ module MaintenanceTasks
 
           success = succeeded?
           reload_status
+          # A concurrent execution of the same Run may have already moved it to
+          # a terminal status (succeeded, errored, or cancelled). Forcing a
+          # further transition would raise a RunStatusValidator error (e.g.
+          # "Cannot transition run from status errored to interrupted"), so
+          # accept the persisted terminal status and let the finalizing worker
+          # own the lifecycle callbacks.
+          return if completed?
+
           if success
             self.status = :succeeded
           else

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -155,6 +155,30 @@ module MaintenanceTasks
       assert_predicate run.reload, :succeeded?
     end
 
+    test "#persist_transition accepts a terminal status when a concurrent run already errored" do
+      run = Run.create!(task_name: "Maintenance::UpdatePostsTask", status: "running")
+      # A concurrent execution of the same run finalizes it as errored, bumping
+      # the lock_version so this instance's save races.
+      Run.find(run.id).errored!
+
+      run.status = :interrupted
+      assert_nothing_raised do
+        run.persist_transition
+      end
+      assert_predicate run.reload, :errored?
+    end
+
+    test "#persist_transition accepts a terminal status when a concurrent run already succeeded" do
+      run = Run.create!(task_name: "Maintenance::UpdatePostsTask", status: "running")
+      Run.find(run.id).succeeded!
+
+      run.status = :interrupted
+      assert_nothing_raised do
+        run.persist_transition
+      end
+      assert_predicate run.reload, :succeeded?
+    end
+
     test "#persist_progress persists increments to tick count and time_running" do
       run = Run.create!(
         task_name: "Maintenance::UpdatePostsTask",


### PR DESCRIPTION
## Problem

When two executions of the **same** run overlap, `persist_transition` can raise `ActiveRecord::RecordInvalid` with an invalid status transition such as:

```
Validation failed: Status Cannot transition run from status errored to interrupted
Validation failed: Status Cannot transition run from status succeeded to interrupted
```

This happens in practice when a re-enqueued continuation (or a retry) of a run starts while the previous instance is still winding down. One instance finalizes the run to a **terminal** status (`succeeded`, `errored`, or `cancelled`) and bumps `lock_version`; the other instance's `save!` then loses the optimistic-lock race and raises `StaleObjectError`.

The `StaleObjectError` retry path in `persist_transition` is where it goes wrong:

```ruby
success = succeeded?   # computed BEFORE reload — stale
reload_status          # pulls the DB truth: another worker set a terminal status
if success
  self.status = :succeeded   # can force e.g. errored -> succeeded (invalid)
else
  job_shutdown               # forces <terminal> -> interrupted (invalid)
end
retry                        # retried save! raises RecordInvalid
```

`RunStatusValidator` only permits `errored -> enqueued`, and has no exit transitions from `succeeded`/`cancelled`, so once a sibling worker has finalized the run, forcing any further transition raises `RecordInvalid`. The error is unhandled (it isn't a `StaleObjectError`), so it escapes the job and gets reported. The stale `success` flag (captured before `reload_status`) means the `if success` branch is vulnerable too, not just `job_shutdown`.

## Fix

After `reload_status`, if the run has already reached a terminal status, accept it and return instead of forcing a further transition. The worker that actually finalized the run owns the terminal status and its lifecycle callbacks.

```ruby
reload_status
return if completed?
```

This is safe for the existing race cases (`cancelling`/`pausing` are not terminal, so those paths are unchanged) and prevents both the `errored -> interrupted` and `succeeded -> interrupted` variants.

## Tests

Added two tests to `run_test.rb` that reproduce the race (a second AR instance finalizes the run via `errored!` / `succeeded!`, bumping `lock_version` under a running in-memory copy). They fail on `main` with the exact production errors and pass with the fix. Existing `run_test.rb` (all 80) continues to pass, including the pre-existing cancelling-race tests.
