### PR TITLE
Add task auto-refresh toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,6 +879,11 @@ end
 
 You can run your new Task by accessing the Web UI and clicking on "Run".
 
+A Task's page auto-refreshes in the background while it has active runs, so the
+progress and run statuses stay up to date. You can turn this off with the
+"Disable auto-refresh" toggle on the Task page, which adds a `?refresh=false`
+parameter to the URL. Use "Enable auto-refresh" to turn it back on.
+
 #### Running a Task from the command line
 
 Alternatively, you can run your Task in the command line:

--- a/app/controllers/maintenance_tasks/tasks_controller.rb
+++ b/app/controllers/maintenance_tasks/tasks_controller.rb
@@ -7,7 +7,7 @@ module MaintenanceTasks
   #
   # @api private
   class TasksController < ApplicationController
-    before_action :set_refresh, only: [:index]
+    before_action :set_refresh, only: [:index, :show]
 
     # Renders the maintenance_tasks/tasks page, displaying
     # available tasks to users, grouped by category.
@@ -21,14 +21,14 @@ module MaintenanceTasks
       @task = TaskDataShow.prepare(
         params.fetch(:id),
         runs_cursor: params[:cursor],
-        arguments: params.except(:id, :controller, :action).permit!,
+        arguments: params.except(:id, :controller, :action, :refresh).permit!,
       )
     end
 
     private
 
     def set_refresh
-      @refresh = true
+      @auto_refresh_enabled = params[:refresh] != "false"
     end
   end
 end

--- a/app/views/maintenance_tasks/tasks/index.html.erb
+++ b/app/views/maintenance_tasks/tasks/index.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(data: { refresh: (defined?(@refresh) && @refresh) || "" }) do %>
+<%= tag.div(data: { refresh: (defined?(@auto_refresh_enabled) && @auto_refresh_enabled) || "" }) do %>
   <% if @available_tasks.empty? %>
     <div class="content is-large">
       <h3 class="title is-3"> The MaintenanceTasks gem has been successfully installed! </h3>

--- a/app/views/maintenance_tasks/tasks/show.html.erb
+++ b/app/views/maintenance_tasks/tasks/show.html.erb
@@ -42,7 +42,17 @@
 </details>
 <% end %>
 
-<%= tag.div(data: { refresh: @task.refresh? || "" }) do %>
+<%= tag.div(data: { refresh: (@task.refresh? && @auto_refresh_enabled) || "" }) do %>
+  <% if @task.refresh? %>
+    <div class="is-flex is-justify-content-flex-end mb-2">
+      <% if @auto_refresh_enabled %>
+        <%= link_to "Disable auto-refresh", task_path(@task, refresh: false), class: "button is-small is-light" %>
+      <% else %>
+        <%= link_to "Enable auto-refresh", task_path(@task), class: "button is-small is-light" %>
+      <% end %>
+    </div>
+  <% end %>
+
   <% if @task.active_runs.any? %>
     <hr>
 

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -72,6 +72,32 @@ module MaintenanceTasks
       assert_text(/January 01, 2020 01:00 Succeeded #\d/)
     end
 
+    test "toggle auto-refresh on a Task with active runs" do
+      task_path = maintenance_tasks.task_path("Maintenance::UpdatePostsTask")
+
+      visit task_path
+
+      assert_selector "[data-refresh=true]"
+      assert_link "Disable auto-refresh", href: "#{task_path}?refresh=false"
+
+      click_on "Disable auto-refresh"
+
+      assert_no_selector "[data-refresh=true]"
+      assert_link "Enable auto-refresh", href: task_path
+
+      click_on "Enable auto-refresh"
+
+      assert_selector "[data-refresh=true]"
+      assert_link "Disable auto-refresh", href: "#{task_path}?refresh=false"
+    end
+
+    test "hide the auto-refresh toggle when a Task has no active runs" do
+      visit maintenance_tasks.task_path("Maintenance::ImportPostsTask")
+
+      assert_no_link "Disable auto-refresh"
+      assert_no_link "Enable auto-refresh"
+    end
+
     test "show a Task with stale run" do
       travel_to(maintenance_tasks_runs(:stale_task).ended_at + 2.days) do
         MaintenanceTasks.with(task_staleness_threshold: 1.day) do
@@ -233,6 +259,15 @@ module MaintenanceTasks
       assert_equal("false", boolean_dropdown_field.value)
       boolean_dropdown_field_options = boolean_dropdown_field.find_all("option").map { |option| option[:value] }
       assert_equal(["", "true", "false"], boolean_dropdown_field_options)
+    end
+
+    test "refresh=false does not interfere with Task parameters" do
+      visit maintenance_tasks.task_path("Maintenance::ParamsTask", params: {
+        refresh: false,
+        content: "string content",
+      })
+
+      assert_field "task[content]", with: "string content"
     end
 
     test "view a Task with multiple pages of Runs" do


### PR DESCRIPTION
Closes #1490.

Continues #1489 with its review feedback applied. Adds a task-page toggle for disabling auto-refresh without passing `refresh` through as a task argument.

Original implementation by @knightq, preserved as co-author.

## Testing

- `bin/setup`
- `bundle exec rails test`
- `bundle exec rails test:system`
- `bundle exec rubocop`
- `bundle exec herb analyze`
