### PR TITLE
Mark interrupted Runs as errored when re-enqueuing fails

### DIFF
--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -30,6 +30,21 @@ module MaintenanceTasks
       end
     end
 
+    if ActiveJob.gem_version < Gem::Version.new("8.1")
+      # Active Job 7.2 and 8.0 retry by enqueuing a duplicate, so
+      # +successfully_enqueued?+ is set on the copy rather than this job.
+      # Enqueue self instead, keeping the +enqueue_retry+ instrumentation.
+      def retry_job(options = {})
+        return if defined?(@retried) && @retried
+
+        result = instrument(:enqueue_retry, options.slice(:error, :wait)) do
+          enqueue(options)
+        end
+        @retried = true
+        result
+      end
+    end
+
     private
 
     def serialized_cursor_position
@@ -188,8 +203,15 @@ module MaintenanceTasks
 
     def after_perform
       @run.persist_transition
-      if defined?(@reenqueue_iteration_job) && @reenqueue_iteration_job
-        reenqueue_iteration_job(should_ignore: false) unless @run.stopped?
+      if defined?(@reenqueue_iteration_job) && @reenqueue_iteration_job && !@run.stopped?
+        reenqueue_iteration_job(should_ignore: false)
+        unless successfully_enqueued?
+          error = enqueue_error || ActiveJob::EnqueueError.new(
+            "The job to perform #{@run.task_name} could not be re-enqueued. " \
+              "Enqueuing has been prevented by a callback.",
+          )
+          raise error
+        end
       end
     end
 

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -173,6 +173,40 @@ module MaintenanceTasks
       assert_enqueued_with(job: TaskJob) { TaskJob.perform_now(@run) }
     end
 
+    if ActiveJob.gem_version < Gem::Version.new("8.1")
+      test ".perform_now instruments enqueue_retry when the job is interrupted" do
+        JobIteration.stubs(interruption_adapter: -> { true })
+        Maintenance::TestTask.any_instance.expects(:process).once
+
+        events = []
+        callback = ->(*args) { events << ActiveSupport::Notifications::Event.new(*args) }
+        ActiveSupport::Notifications.subscribed(callback, "enqueue_retry.active_job") do
+          TaskJob.perform_now(@run)
+        end
+
+        assert_equal 1, events.size
+        assert_kind_of TaskJob, events.first.payload[:job]
+      end
+    end
+
+    test ".perform_now errors the Run when re-enqueuing is unsuccessful" do
+      JobIteration.stubs(interruption_adapter: -> { true })
+      Maintenance::TestTask.any_instance.expects(:process).once
+      job_class = Class.new(TaskJob) do
+        before_enqueue { throw :abort }
+      end
+
+      assert_no_enqueued_jobs { job_class.perform_now(@run) }
+
+      assert_predicate @run.reload, :errored?
+      assert_equal "ActiveJob::EnqueueError", @run.error_class
+      assert_equal(
+        "The job to perform Maintenance::TestTask could not be re-enqueued. " \
+          "Enqueuing has been prevented by a callback.",
+        @run.error_message,
+      )
+    end
+
     test ".perform_now updates Run to errored and persists ended_at when exception is raised" do
       freeze_time
       run = Run.create!(task_name: "Maintenance::ErrorTask")


### PR DESCRIPTION
### Why

An interrupted Task is expected to be re-enqueued so another job can resume it. Active Job can reject an enqueue without raising when a `before_enqueue` callback aborts or a queue adapter reports an enqueue error.

The deferred re-enqueue currently ignores that result, leaving the Run as `interrupted` even though no job was enqueued to continue it.

### What changed

Check `successfully_enqueued?` after the re-enqueue attempt. When it fails, use the adapter's `enqueue_error` if available, or raise an `ActiveJob::EnqueueError` for a callback rejection.

The existing error handling then persists the Run as `errored`, where it can be resumed. This preserves the callback's ability to reject the enqueue while preventing the Run from being stranded without a job.
