### PR TITLE
Skip task setup for non-runnable Runs

### DIFF
--- a/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
+++ b/app/jobs/concerns/maintenance_tasks/task_job_concern.rb
@@ -139,18 +139,32 @@ module MaintenanceTasks
 
     def before_perform
       @run = arguments.first
-      @task = @run.task
-      if @task.has_csv_content?
-        @task.csv_content = @run.csv_file.download
+      @run.running
+
+      if @run.running?
+        @task = @run.task
+        if @task.has_csv_content?
+          @task.csv_content = @run.csv_file.download
+        end
+        @run.reload_status
       end
 
-      @run.running
+      abort_unless_run_is_running
+      @last_status_reload = Time.now
 
       @ticker = Ticker.new(MaintenanceTasks.ticker_delay) do |ticks, duration|
         @run.persist_progress(ticks, duration)
       end
+    end
 
-      @last_status_reload = nil
+    def abort_unless_run_is_running
+      return if @run.running?
+
+      if @run.cancelling? || @run.pausing?
+        @run.job_shutdown
+        @run.persist_transition
+      end
+      throw(:abort)
     end
 
     def on_start

--- a/app/models/concerns/maintenance_tasks/run_concern.rb
+++ b/app/models/concerns/maintenance_tasks/run_concern.rb
@@ -29,6 +29,8 @@ module MaintenanceTasks
       :interrupted,
     ].freeze
 
+    RUNNABLE_STATUSES = [:enqueued, :running, :interrupted].freeze
+
     STOPPING_STATUSES = [
       :pausing,
       :cancelling,
@@ -233,6 +235,14 @@ module MaintenanceTasks
       ACTIVE_STATUSES.include?(status.to_sym)
     end
 
+    # Returns whether the Run is runnable, which is defined as
+    # having a status of enqueued, running, or interrupted.
+    #
+    # @return [Boolean] whether the Run is runnable.
+    def runnable?
+      RUNNABLE_STATUSES.include?(status.to_sym)
+    end
+
     # Returns the duration left for the Run to finish based on the number of
     # ticks left and the average time needed to process a tick. Returns nil if
     # the Run is completed, or if tick_count or tick_total is zero.
@@ -250,20 +260,21 @@ module MaintenanceTasks
 
     # Marks a Run as running.
     #
-    # If the run is stopping already, it will not transition to running.
+    # If the Run is not runnable, it will not transition to running.
     # Rescues and retries status transition if an ActiveRecord::StaleObjectError
     # is encountered.
     def running
       if locking_enabled?
         with_stale_object_retry do
-          running! unless stopping?
+          reload_status if running?
+          running! if runnable?
         end
       else
         # Preserve swap-and-replace solution for data races until users
         # run migration to upgrade to optimistic locking solution
-        return if stopping?
+        return unless runnable?
 
-        updated = self.class.where(id: id).where.not(status: STOPPING_STATUSES)
+        updated = self.class.where(id: id, status: RUNNABLE_STATUSES)
           .update_all(status: :running, updated_at: Time.now) > 0
         if updated
           self.status = :running

--- a/test/jobs/maintenance_tasks/task_job_test.rb
+++ b/test/jobs/maintenance_tasks/task_job_test.rb
@@ -33,16 +33,64 @@ module MaintenanceTasks
 
     test ".perform doesn't run a cancelled job" do
       freeze_time
-      TaskJob.perform_later(@run)
-      @run.cancel
+      run = Run.create!(task_name: "Maintenance::CallbackTestTask")
+      TaskJob.perform_later(run)
+      Maintenance::CallbackTestTask.any_instance
+        .expects(:after_cancel_callback).once
+      run.cancel
       travel MaintenanceTasks.stuck_task_duration
-      @run.cancel # force cancel the Run
-      assert_predicate @run, :cancelled?
-      Maintenance::TestTask.any_instance.expects(:process).never
+      run.cancel # force cancel the Run
+      assert_predicate run, :cancelled?
+      Maintenance::CallbackTestTask.any_instance.expects(:collection).never
+      Maintenance::CallbackTestTask.any_instance.expects(:process).never
+      Maintenance::CallbackTestTask.any_instance
+        .expects(:after_start_callback).never
 
       assert_nothing_raised do
         perform_enqueued_jobs
       end
+
+      assert_nil run.reload.started_at
+    end
+
+    test ".perform doesn't download CSV for a cancelled job" do
+      freeze_time
+      run = Run.new(task_name: "Maintenance::ImportPostsTask")
+      run.csv_file.attach(
+        io: file_fixture("sample.csv").open,
+        filename: "sample.csv",
+      )
+      run.save!
+      TaskJob.perform_later(run)
+      run.cancel
+      travel MaintenanceTasks.stuck_task_duration
+      run.cancel
+      ActiveStorage::Blob.service.expects(:download).never
+
+      perform_enqueued_jobs
+    end
+
+    test ".perform_now stops when a Run is cancelled while downloading CSV without optimistic locking" do
+      Run.stubs(:locking_enabled?).returns(false)
+      run = Run.new(task_name: "Maintenance::ImportPostsTask")
+      run.csv_file.attach(
+        io: file_fixture("sample.csv").open,
+        filename: "sample.csv",
+      )
+      run.save!
+      csv_content = file_fixture("sample.csv").binread
+      download_key = run.csv_file.blob.key
+      ActiveStorage::Blob.service.expects(:download).with do |key|
+        Run.find(run.id).cancelling!
+        key == download_key
+      end.returns(csv_content)
+      Maintenance::ImportPostsTask.any_instance.expects(:collection).never
+      Maintenance::ImportPostsTask.any_instance.expects(:process).never
+
+      TaskJob.perform_now(run)
+
+      assert_predicate(run.reload, :cancelled?)
+      assert_nil(run.started_at)
     end
 
     test ".perform_now persists ended_at when the Run is cancelled" do
@@ -70,11 +118,13 @@ module MaintenanceTasks
     test ".perform_now avoids iterating when Run is cancelled" do
       @run.cancelling!
 
+      Maintenance::TestTask.any_instance.expects(:collection).never
       Maintenance::TestTask.any_instance.expects(:process).never
 
       TaskJob.perform_now(@run)
 
       assert_predicate @run.reload, :cancelled?
+      assert_nil @run.started_at
       assert_no_enqueued_jobs
     end
 
@@ -83,12 +133,31 @@ module MaintenanceTasks
         Run.find(@run.id).update(status: :cancelling)
       end
 
+      Maintenance::TestTask.any_instance.expects(:collection).never
       Maintenance::TestTask.any_instance.expects(:process).never
 
       CustomTaskJob.perform_now(@run)
 
       assert_predicate(@run.reload, :cancelled?)
+      assert_nil(@run.started_at)
       assert_no_enqueued_jobs
+    ensure
+      CustomTaskJob.race_condition_hook = nil
+    end
+
+    test ".perform_now avoids setup when a running Run is concurrently cancelled" do
+      run = Run.create!(task_name: "Maintenance::TestTask", status: :running)
+      CustomTaskJob.race_condition_hook = -> do
+        Run.find(run.id).cancelling!
+      end
+
+      Maintenance::TestTask.any_instance.expects(:collection).never
+      Maintenance::TestTask.any_instance.expects(:process).never
+
+      CustomTaskJob.perform_now(run)
+
+      assert_predicate(run.reload, :cancelled?)
+      assert_nil(run.started_at)
     ensure
       CustomTaskJob.race_condition_hook = nil
     end

--- a/test/models/maintenance_tasks/run_test.rb
+++ b/test/models/maintenance_tasks/run_test.rb
@@ -358,6 +358,20 @@ module MaintenanceTasks
       end
     end
 
+    test "#runnable? returns true if status is among Run::RUNNABLE_STATUSES" do
+      run = Run.new(task_name: "Maintenance::UpdatePostsTask")
+
+      (Run::STATUSES - Run::RUNNABLE_STATUSES).each do |status|
+        run.status = status
+        refute_predicate run, :runnable?
+      end
+
+      Run::RUNNABLE_STATUSES.each do |status|
+        run.status = status
+        assert_predicate run, :runnable?
+      end
+    end
+
     test "#time_to_completion returns nil if the run is completed" do
       run = Run.new(
         task_name: "Maintenance::UpdatePostsTask",
@@ -427,13 +441,16 @@ module MaintenanceTasks
       end
     end
 
-    test "with optimistic locking enabled, #running doesn't set a stopping run to running" do
-      [:cancelling, :pausing].each do |status|
+    test "with optimistic locking enabled, #running doesn't set a non-runnable run to running" do
+      non_runnable_statuses = Run::STATUSES - Run::RUNNABLE_STATUSES
+      non_runnable_statuses.each do |status|
         run = Run.create!(
           task_name: "Maintenance::UpdatePostsTask",
           status: status,
         )
-        refute_predicate run, :running?
+        run.running
+
+        assert_equal status.to_s, run.status
       end
     end
 
@@ -461,12 +478,26 @@ module MaintenanceTasks
       assert_predicate run, :pausing?
     end
 
-    test "with optimistic locking disabled, #running doesn't set a stopping run to running and reloads the status" do
-      [:cancelling, :pausing].each do |status|
+    test "with optimistic locking enabled, #running reloads a stale running Run" do
+      run = Run.create!(
+        task_name: "Maintenance::UpdatePostsTask",
+        status: :running,
+      )
+      Run.find(run.id).cancelling!
+
+      run.running
+
+      assert_predicate run, :cancelling?
+    end
+
+    test "with optimistic locking disabled, #running doesn't set a non-runnable run to running and reloads the status" do
+      Run.expects(:locking_enabled?).returns(false).at_least_once
+      non_runnable_statuses = Run::STATUSES - Run::RUNNABLE_STATUSES
+      non_runnable_statuses.each do |status|
         run = Run.create!(
           task_name: "Maintenance::UpdatePostsTask",
         )
-        Run.find(run.id).update(status: status) # race condition
+        Run.find(run.id).update_column(:status, status) # race condition
         run.running
 
         assert_equal status.to_s, run.status


### PR DESCRIPTION
A job can remain queued after its Run is cancelled. When eventually worked, it currently downloads CSV data, builds the collection, sets `started_at`, and runs `after_start` before stopping.

Claim the Run before task setup and abort when it is no longer runnable. Preserve pausing and cancelling transitions, and prevent the no-locking fallback from moving paused or completed Runs back to running.

Adds regression coverage for cancelled jobs, lifecycle callbacks, races, and both locking paths.

Tests: `bundle exec rake test` and `bundle exec rubocop --no-parallel`.
