### PR TITLE
Animate progress bar updates

### DIFF
--- a/app/controllers/maintenance_tasks/application_controller.rb
+++ b/app/controllers/maintenance_tasks/application_controller.rb
@@ -19,7 +19,7 @@ module MaintenanceTasks
       ] if defined?(Capybara::Lockstep)
       policy.script_src_elem(
         # <script> tag in app/views/layouts/maintenance_tasks/application.html.erb
-        "'sha256-NiHKryHWudRC2IteTqmY9v1VkaDUA/5jhgXkMTkgo2w='",
+        "'sha256-7yJtzzaCpz6GIYkRX8ZJ28S1A9mKj4x/BMn5HIHA+Jc='",
         # <script> tag for capybara-lockstep
         *capybara_lockstep_scripts,
       )

--- a/app/helpers/maintenance_tasks/tasks_helper.rb
+++ b/app/helpers/maintenance_tasks/tasks_helper.rb
@@ -48,6 +48,7 @@ module MaintenanceTasks
         value: progress.value,
         max: progress.max,
         class: ["progress", "mt-4"] + STATUS_COLOURS.fetch(run.status),
+        data: { progress_run_id: run.id },
       )
       progress_text = tag.p(tag.i(progress.text))
       tag.div(progress_bar + progress_text, class: "block")

--- a/app/views/layouts/maintenance_tasks/application.html.erb
+++ b/app/views/layouts/maintenance_tasks/application.html.erb
@@ -94,6 +94,57 @@
     </style>
 
     <script>
+      function progressStates(target) {
+        return new Map(
+          Array.from(
+            target.querySelectorAll("progress[data-progress-run-id]"),
+            progress => [
+              progress.dataset.progressRunId,
+              progress.hasAttribute("value") ? {
+                value: Number(progress.value),
+                max: Number(progress.max),
+              } : null,
+            ],
+          ),
+        )
+      }
+
+      function animateProgressBars(target, previousStates) {
+        if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return
+
+        target
+          .querySelectorAll("progress[data-progress-run-id][value]")
+          .forEach(progress => {
+            const previousState = previousStates.get(progress.dataset.progressRunId)
+            const nextValue = Number(progress.value)
+            const startValue = previousState &&
+              (previousState.value / previousState.max) * Number(progress.max)
+
+            if (
+              !Number.isFinite(startValue) ||
+              startValue === nextValue
+            ) return
+
+            const startedAt = performance.now()
+            const duration = 450
+
+            progress.value = startValue
+
+            function drawFrame(timestamp) {
+              const elapsed = Math.min((timestamp - startedAt) / duration, 1)
+              const eased = 1 - Math.pow(1 - elapsed, 3)
+
+              progress.value = startValue + ((nextValue - startValue) * eased)
+
+              if (elapsed < 1 && progress.isConnected) {
+                window.requestAnimationFrame(drawFrame)
+              }
+            }
+
+            window.requestAnimationFrame(drawFrame)
+          })
+      }
+
       function refresh() {
         const target = document.querySelector("[data-refresh]")
         if (!target || !target.dataset.refresh) return
@@ -105,7 +156,10 @@
               const newDocument = new DOMParser().parseFromString(text, "text/html")
               const newTarget = newDocument.querySelector("[data-refresh]")
               if (newTarget) {
+                const previousStates = progressStates(target)
+
                 target.replaceWith(newTarget)
+                animateProgressBars(newTarget, previousStates)
               }
               document.body.style.cursor = ""
               refresh()

--- a/test/helpers/maintenance_tasks/tasks_helper_test.rb
+++ b/test/helpers/maintenance_tasks/tasks_helper_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 module MaintenanceTasks
   class TasksHelperTest < ActionView::TestCase
     setup do
-      @run = Run.new
+      @run = Run.new(id: 42)
     end
 
     test "#format_backtrace converts the backtrace to a formatted string" do
@@ -28,7 +28,7 @@ module MaintenanceTasks
       )
 
       expected = '<div class="block"><progress value="42" max="84" ' \
-        'class="progress mt-4 is-primary is-light"></progress>' \
+        'class="progress mt-4 is-primary is-light" data-progress-run-id="42"></progress>' \
         "<p><i>Almost there!</i></p></div>"
       assert_equal expected, progress(@run)
     end
@@ -44,7 +44,7 @@ module MaintenanceTasks
       )
 
       expected = '<div class="block"><progress max="84" ' \
-        'class="progress mt-4 is-primary is-light"></progress>' \
+        'class="progress mt-4 is-primary is-light" data-progress-run-id="42"></progress>' \
         "<p><i>Almost there!</i></p></div>"
       assert_equal expected, progress(@run)
     end


### PR DESCRIPTION
Progress bars currently jump directly to their new value whenever the task page auto-refreshes.

Identify each rendered progress bar by its Run ID and preserve its previous state before replacing the refreshed content. Determinate progress bars now animate from their previous value to the updated value over 450ms using `requestAnimationFrame` and a cubic ease-out curve.

The animation preserves relative progress when the maximum value changes and is disabled when the user prefers reduced motion.

Update the inline script CSP hash to allow the modified layout script.

## Release notes

Progress bars now animate smoothly when their values change during task-page auto-refresh.
