### PR TITLE
Preserve tick count constraints in SQLite migrations

### DIFF
--- a/db/migrate/20220706101937_change_runs_tick_columns_to_bigints.rb
+++ b/db/migrate/20220706101937_change_runs_tick_columns_to_bigints.rb
@@ -3,14 +3,15 @@
 class ChangeRunsTickColumnsToBigints < ActiveRecord::Migration[7.0]
   def up
     change_table(:maintenance_tasks_runs, bulk: true) do |t|
-      t.change(:tick_count, :bigint)
+      # SQLite drops unstated options on t.change; restate default/null.
+      t.change(:tick_count, :bigint, default: 0, null: false)
       t.change(:tick_total, :bigint)
     end
   end
 
   def down
     change_table(:maintenance_tasks_runs, bulk: true) do |t|
-      t.change(:tick_count, :integer)
+      t.change(:tick_count, :integer, default: 0, null: false)
       t.change(:tick_total, :integer)
     end
   end

--- a/db/migrate/20260819071249_restore_runs_tick_count_constraints.rb
+++ b/db/migrate/20260819071249_restore_runs_tick_count_constraints.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Repairs tick_count constraints that SQLite may drop during the historical type change.
+class RestoreRunsTickCountConstraints < ActiveRecord::Migration[7.2]
+  def up
+    column = connection.columns(:maintenance_tasks_runs).find do |candidate|
+      candidate.name == "tick_count"
+    end
+    return if [0, "0"].include?(column.default) && !column.null
+
+    execute(<<~SQL.squish) if column.null
+      UPDATE #{connection.quote_table_name(:maintenance_tasks_runs)}
+      SET #{connection.quote_column_name(:tick_count)} = 0
+      WHERE #{connection.quote_column_name(:tick_count)} IS NULL
+    SQL
+
+    change_column(
+      :maintenance_tasks_runs,
+      :tick_count,
+      :bigint,
+      default: 0,
+      null: false,
+    )
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration,
+      "NULL tick counts were normalized to zero"
+  end
+end

--- a/test/db/migrate/restore_runs_tick_count_constraints_test.rb
+++ b/test/db/migrate/restore_runs_tick_count_constraints_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../../db/migrate/20260819071249_restore_runs_tick_count_constraints"
+
+class RestoreRunsTickCountConstraintsTest < ActiveSupport::TestCase
+  class TestRecord < ActiveRecord::Base
+    self.abstract_class = true
+  end
+
+  setup do
+    TestRecord.establish_connection(adapter: "sqlite3", database: ":memory:")
+    @connection = TestRecord.connection
+  end
+
+  teardown do
+    TestRecord.remove_connection
+  end
+
+  test "repairs an affected SQLite database" do
+    create_runs_table
+    @connection.execute(<<~SQL.squish)
+      INSERT INTO maintenance_tasks_runs (tick_count, tick_total)
+      VALUES (NULL, NULL), (5, 10)
+    SQL
+
+    run_migration_up
+
+    column = @connection.columns(:maintenance_tasks_runs).find do |candidate|
+      candidate.name == "tick_count"
+    end
+    assert_equal "bigint", column.sql_type
+    assert_includes [0, "0"], column.default
+    refute column.null
+    assert_equal(
+      [[0, nil], [5, 10]],
+      @connection.select_rows(<<~SQL.squish),
+        SELECT tick_count, tick_total
+        FROM maintenance_tasks_runs
+        ORDER BY id
+      SQL
+    )
+
+    assert_empty(capture_writes { run_migration_up })
+  end
+
+  test "does not change an already healthy SQLite database" do
+    create_runs_table(default: 0, null: false)
+
+    assert_empty(capture_writes { run_migration_up })
+  end
+
+  test "is irreversible" do
+    error = assert_raises(ActiveRecord::IrreversibleMigration) do
+      migration.down
+    end
+    assert_match(/NULL tick counts were normalized to zero/, error.message)
+  end
+
+  private
+
+  def create_runs_table(default: nil, null: true)
+    options = { null: null }
+    options[:default] = default unless default.nil?
+
+    @connection.create_table(:maintenance_tasks_runs) do |table|
+      table.bigint(:tick_count, **options)
+      table.bigint(:tick_total)
+    end
+  end
+
+  def migration
+    connection = @connection
+    RestoreRunsTickCountConstraints.new.tap do |instance|
+      instance.define_singleton_method(:connection) { connection }
+    end
+  end
+
+  def run_migration_up
+    migration.suppress_messages { migration.up }
+  end
+
+  def capture_writes(&block)
+    writes = []
+    callback = lambda do |*arguments|
+      sql = arguments.last[:sql]
+      writes << sql if sql.match?(/\A(?:ALTER|CREATE|DROP|INSERT|UPDATE)/i)
+    end
+
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record", &block)
+    writes
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_19_151430) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_19_071249) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false

--- a/test/lib/generators/maintenance_tasks/install_generator_test.rb
+++ b/test/lib/generators/maintenance_tasks/install_generator_test.rb
@@ -36,6 +36,10 @@ module MaintenanceTasks
         assert_migration(mig)
         assert_file("db/schema.rb") do |contents|
           assert_match(/create_table "maintenance_tasks_runs"/, contents)
+          assert_match(
+            /t\.bigint "tick_count", default: 0, null: false/,
+            contents,
+          )
         end
       end
     end


### PR DESCRIPTION
Running the full migration history on a Rails 8.1 SQLite database drops
`DEFAULT 0` and `NOT NULL` from `maintenance_tasks_runs.tick_count` when
the 2022 migration changes it to `bigint`. Runs can then persist
`tick_count = NULL` and render indeterminate progress after succeeding.

Preserve the constraints explicitly in the historical migration for new
installations. Add a corrective migration for affected databases that
normalizes existing `NULL` values to zero and restores `bigint`,
`DEFAULT 0`, and `NOT NULL`. Databases with the expected schema are
skipped to avoid an unnecessary SQLite table rebuild.

The corrective migration is intentionally irreversible because the
`NULL`-to-zero normalization cannot be undone reliably.

## Testing

- Rails 7.2, 8.0, and 8.1 with SQLite
- Fresh installation migration history
- Legacy affected database migration
