### PR TITLE
Refresh feature refactor

### DIFF
--- a/app/views/maintenance_tasks/tasks/index.html.erb
+++ b/app/views/maintenance_tasks/tasks/index.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(data: { refresh: (defined?(@auto_refresh_enabled) && @auto_refresh_enabled) || "" }) do %>
+<%= tag.div(data: { refresh: @auto_refresh_enabled || "" }) do %>
   <% if @available_tasks.empty? %>
     <div class="content is-large">
       <h3 class="title is-3"> The MaintenanceTasks gem has been successfully installed! </h3>

--- a/app/views/maintenance_tasks/tasks/index.html.erb
+++ b/app/views/maintenance_tasks/tasks/index.html.erb
@@ -8,6 +8,13 @@
       </p>
     </div>
   <% else %>
+    <div class="is-flex is-justify-content-flex-end mb-2">
+      <% if @auto_refresh_enabled %>
+        <%= link_to "Disable auto-refresh", tasks_path(refresh: false), class: "button is-small is-light" %>
+      <% else %>
+        <%= link_to "Enable auto-refresh", tasks_path, class: "button is-small is-light" %>
+      <% end %>
+    </div>
     <% if active_tasks = @available_tasks[:active] %>
       <h3 class="title is-4 has-text-weight-bold">Active Tasks</h3>
       <%= render partial: 'task', collection: active_tasks %>

--- a/app/views/maintenance_tasks/tasks/index.html.erb
+++ b/app/views/maintenance_tasks/tasks/index.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(data: { refresh: @auto_refresh_enabled || "" }) do %>
+<%= tag.div(data: { refresh: @available_tasks.any? && @auto_refresh_enabled || "" }) do %>
   <% if @available_tasks.empty? %>
     <div class="content is-large">
       <h3 class="title is-3"> The MaintenanceTasks gem has been successfully installed! </h3>

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -56,6 +56,34 @@ module MaintenanceTasks
       assert_no_selector "[data-refresh=true]"
     end
 
+    test "toggle auto-refresh on the index page" do
+      tasks_path = maintenance_tasks.tasks_path
+
+      visit tasks_path
+
+      assert_selector "[data-refresh=true]"
+      assert_link "Disable auto-refresh", href: "#{tasks_path}?refresh=false"
+
+      click_on "Disable auto-refresh"
+
+      assert_no_selector "[data-refresh=true]"
+      assert_link "Enable auto-refresh", href: tasks_path
+
+      click_on "Enable auto-refresh"
+
+      assert_selector "[data-refresh=true]"
+      assert_link "Disable auto-refresh", href: "#{tasks_path}?refresh=false"
+    end
+
+    test "hide the auto-refresh toggle when there are no tasks" do
+      TaskDataIndex.stubs(available_tasks: [])
+
+      visit maintenance_tasks_path
+
+      assert_no_link "Disable auto-refresh"
+      assert_no_link "Enable auto-refresh"
+    end
+
     test "show a Task" do
       visit maintenance_tasks_path
 

--- a/test/system/maintenance_tasks/tasks_test.rb
+++ b/test/system/maintenance_tasks/tasks_test.rb
@@ -46,6 +46,16 @@ module MaintenanceTasks
       assert_equal expected, page.all("h3").map(&:text)
     end
 
+    test "auto-refresh is not enabled when there are no tasks" do
+      TaskDataIndex.stubs(available_tasks: [])
+
+      visit maintenance_tasks_path
+
+      assert_text "The MaintenanceTasks gem has been successfully installed!"
+      assert_selector "[data-refresh='']"
+      assert_no_selector "[data-refresh=true]"
+    end
+
     test "show a Task" do
       visit maintenance_tasks_path
 


### PR DESCRIPTION
- Remove redundant `defined?` check
- Don't refresh the index page when it is empty. It makes copy pasting the task generating command annoying.
- Add a refresh disabling button to the task index